### PR TITLE
remove all players dead check

### DIFF
--- a/Story/RainMeadow.StoryHooks.cs
+++ b/Story/RainMeadow.StoryHooks.cs
@@ -65,14 +65,6 @@ namespace RainMeadow
         {
             if (isStoryMode(out var gameMode))
             {
-                foreach (var playerAvatar in OnlineManager.lobby.playerAvatars)
-                {
-                    if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
-                    if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
-                    {
-                        if (ac.state.alive) return;
-                    }
-                }
                 //INITIATE DEATH
                 foreach (OnlinePlayer player in OnlineManager.players)
                 {


### PR DESCRIPTION
Show the restart button when any player dies, instead of checking if all players are dead. 