### PR TITLE
Small fix for loadworld

### DIFF
--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using static RainMeadow.RainMeadow;
 
 namespace RainMeadow
 {
@@ -46,15 +45,15 @@ namespace RainMeadow
 
         public override SlugcatStats.Name LoadWorldAs(RainWorldGame game)
         {
-            if (currentCampaign == Ext_SlugcatStatsName.OnlineStoryYellow) 
+            if (currentCampaign == RainMeadow.Ext_SlugcatStatsName.OnlineStoryYellow) 
             {
                 return SlugcatStats.Name.Yellow;
             }
-            else if (currentCampaign == Ext_SlugcatStatsName.OnlineStoryWhite) 
+            else if (currentCampaign == RainMeadow.Ext_SlugcatStatsName.OnlineStoryWhite) 
             {
                 return SlugcatStats.Name.White;
             }
-            else if (currentCampaign == Ext_SlugcatStatsName.OnlineStoryRed) 
+            else if (currentCampaign == RainMeadow.Ext_SlugcatStatsName.OnlineStoryRed) 
             {
                 return SlugcatStats.Name.Red;
             }

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using static RainMeadow.RainMeadow;
 
 namespace RainMeadow
 {
@@ -45,7 +46,22 @@ namespace RainMeadow
 
         public override SlugcatStats.Name LoadWorldAs(RainWorldGame game)
         {
-            return storyClientSettings.playingAs;
+            if (currentCampaign == Ext_SlugcatStatsName.OnlineStoryYellow) 
+            {
+                return SlugcatStats.Name.Yellow;
+            }
+            else if (currentCampaign == Ext_SlugcatStatsName.OnlineStoryWhite) 
+            {
+                return SlugcatStats.Name.White;
+            }
+            else if (currentCampaign == Ext_SlugcatStatsName.OnlineStoryRed) 
+            {
+                return SlugcatStats.Name.Red;
+            }
+            else
+            {
+                return SlugcatStats.Name.White;
+            }
         }
 
         public override bool ShouldSpawnFly(FliesWorldAI self, int spawnRoom)


### PR DESCRIPTION
I think LoadWorldAs is only used in WorldLoader_Ctor. Doesn't seem like there are any impacts as the other hooks report back the Online counterpart of the slugcats.