### PR TITLE
Small fix for properly releasing a resource

### DIFF
--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -307,7 +307,7 @@ namespace RainMeadow
                 }
             }
             participants.Remove(participant);
-            if(isSupervisor && participant == owner && participants.Count > 0)
+            if(isSupervisor && participant == owner)
             {
                 PickNewOwner();
             }


### PR DESCRIPTION
After a lot of testing, I found a solution for the problem of being stuck in pipes sometimes when traversing between rooms. It seemed like after one player left the room with no other participants the other players just couldn't load it. It's because the owner of said room points to the former owner even after he already left. This one little commit simply allows the PickNewOwner() function to set the owner of the resource to null so that the other players know they can claim the resource for themselves. It also seems like it fixes the issue of the red room after hibernating.