### PR TITLE
Lobby Player Limit

### DIFF
--- a/Menu/LobbyInfo.cs
+++ b/Menu/LobbyInfo.cs
@@ -16,17 +16,17 @@ namespace RainMeadow
 
         public IPEndPoint? ipEndpoint;
 
-        public LobbyInfo(CSteamID id, string name, string mode, int playerCount, bool hasPassword, int maxPlayerCount)
+        public LobbyInfo(CSteamID id, string name, string mode, int playerCount, bool hasPassword, int? maxPlayerCount)
         {
             this.id = id;
             this.name = name;
             this.mode = mode;
             this.playerCount = playerCount;
             this.hasPassword = hasPassword;
-            this.maxPlayerCount = maxPlayerCount;
+            this.maxPlayerCount = (int)maxPlayerCount;
         }
 
-        public LobbyInfo(IPEndPoint ipEndpoint, string name, string mode, int playerCount, bool hasPassword, int maxPlayerCount)
+        public LobbyInfo(IPEndPoint ipEndpoint, string name, string mode, int playerCount, bool hasPassword, int? maxPlayerCount)
         {
             this.ipEndpoint = ipEndpoint;
 
@@ -35,7 +35,7 @@ namespace RainMeadow
             this.mode = mode;
             this.playerCount = playerCount;
             this.hasPassword = hasPassword;
-            this.maxPlayerCount = maxPlayerCount;
+            this.maxPlayerCount = (int)maxPlayerCount;
         }
     }
 }

--- a/Menu/LobbyInfo.cs
+++ b/Menu/LobbyInfo.cs
@@ -12,19 +12,21 @@ namespace RainMeadow
         public string mode;
         public int playerCount;
         public bool hasPassword;
+        public int maxPlayerCount;
 
         public IPEndPoint? ipEndpoint;
 
-        public LobbyInfo(CSteamID id, string name, string mode, int playerCount, bool hasPassword)
+        public LobbyInfo(CSteamID id, string name, string mode, int playerCount, bool hasPassword, int maxPlayerCount)
         {
             this.id = id;
             this.name = name;
             this.mode = mode;
             this.playerCount = playerCount;
             this.hasPassword = hasPassword;
+            this.maxPlayerCount = maxPlayerCount;
         }
 
-        public LobbyInfo(IPEndPoint ipEndpoint, string name, string mode, int playerCount, bool hasPassword)
+        public LobbyInfo(IPEndPoint ipEndpoint, string name, string mode, int playerCount, bool hasPassword, int maxPlayerCount)
         {
             this.ipEndpoint = ipEndpoint;
 
@@ -33,6 +35,7 @@ namespace RainMeadow
             this.mode = mode;
             this.playerCount = playerCount;
             this.hasPassword = hasPassword;
+            this.maxPlayerCount = maxPlayerCount;
         }
     }
 }

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -169,6 +169,8 @@ namespace RainMeadow
         public override void Update()
         {
             base.Update();
+            if (maxPlayerCount > 32) maxPlayerCount = 32;
+            if (maxPlayerCount < 1) maxPlayerCount = 1;
             int extraItems = Mathf.Max(lobbies.Length - 4, 0);
             scrollTo = Mathf.Clamp(scrollTo, -0.5f, extraItems + 0.5f);
             if (scrollTo < 0) scrollTo = RWCustom.Custom.LerpAndTick(scrollTo, 0, 0.1f, 0.1f);

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -184,7 +184,7 @@ namespace RainMeadow
             {
                 maxPlayerCount = lobbyLimitNumberTextBox.valueInt;
                 if (lobbyLimitNumberTextBox.valueInt > 32) lobbyLimitNumberTextBox.valueInt = 32;
-                if (lobbyLimitNumberTextBox.valueInt < 1) lobbyLimitNumberTextBox.valueInt = 1;
+                if (lobbyLimitNumberTextBox.valueInt < 2) lobbyLimitNumberTextBox.valueInt = 2;
             }
         }
 
@@ -240,6 +240,7 @@ namespace RainMeadow
                     this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, "Private", new(260, 20), new(10, 50), false));
                 }
                 this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, $"{lobbyInfo.maxPlayerCount} max", new(260, 5), new(10, 50), false));
+                RainMeadow.Debug($"This card has {lobbyInfo.maxPlayerCount} max");
                 this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, lobbyInfo.mode, new(5, 20), new(10, 50), false));
                 this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, lobbyInfo.playerCount + " player" + (lobbyInfo.playerCount == 1 ? "" : "s"), new(5, 5), new(10, 50), false));
             }
@@ -269,7 +270,7 @@ namespace RainMeadow
             else
             {
                 var lobbyInfo = (lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo;
-                RainMeadow.Debug($"{lobbyInfo.playerCount} test test test {lobbyInfo.maxPlayerCount}");
+                MatchmakingManager.MAX_LOBBY = lobbyInfo.maxPlayerCount;
                 if (lobbyInfo.playerCount > lobbyInfo.maxPlayerCount)
                 {
                     ShowErrorDialog("Failed to join lobby.<LINE> Lobby is full");

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -184,7 +184,7 @@ namespace RainMeadow
             {
                 maxPlayerCount = lobbyLimitNumberTextBox.valueInt;
                 if (lobbyLimitNumberTextBox.valueInt > 32) lobbyLimitNumberTextBox.valueInt = 32;
-                if (lobbyLimitNumberTextBox.valueInt < 2) lobbyLimitNumberTextBox.valueInt = 2;
+                if (lobbyLimitNumberTextBox.valueInt < 1) lobbyLimitNumberTextBox.valueInt = 1;
             }
         }
 
@@ -271,7 +271,7 @@ namespace RainMeadow
             {
                 var lobbyInfo = (lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo;
                 MatchmakingManager.MAX_LOBBY = lobbyInfo.maxPlayerCount;
-                if (lobbyInfo.playerCount > lobbyInfo.maxPlayerCount)
+                if (lobbyInfo.playerCount >= lobbyInfo.maxPlayerCount)
                 {
                     ShowErrorDialog("Failed to join lobby.<LINE> Lobby is full");
                 }

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -30,6 +30,7 @@ namespace RainMeadow
         private bool setpassword;
         private OpTextBox passwordInputBox;
         private CheckBox enablePasswordCheckbox;
+        private int maxPlayerLimit = 4;
         
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)
@@ -102,7 +103,6 @@ namespace RainMeadow
             passwordInputBox.label.text = "Password";
             new UIelementWrapper(this.tabWrapper, passwordInputBox);
             
-            <<<<<<< story-lobby-limit
             // textbox lobby limit option
             where.y -= 45;
             var limitNumberLabel = new ProperlyAlignedMenuLabel(this, mainPage, Translate("Player max:"), where, new Vector2(400, 20f), false, null);

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -303,7 +303,7 @@ namespace RainMeadow
             RainMeadow.Debug($"Creating a lobby with a max player limit of {maxPlayerCount}");
         }
 
-        private void RequestLobbyJoin(LobbyInfo lobby, string? password = null, int? maxPlayerCount = 4)
+        private void RequestLobbyJoin(LobbyInfo lobby, string? password = null)
         {
             var lobbyInfo = (lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo;
             RainMeadow.DebugMe();
@@ -395,7 +395,7 @@ namespace RainMeadow
                 case "HIDE_PASSWORD":
                     var password = (popupDialog as CustomInputDialogueBox).textBox.value;
                     ShowLoadingDialog("Joining lobby...");
-                    RequestLobbyJoin((lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo, password, maxPlayerCount);
+                    RequestLobbyJoin((lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo, password);
                     break;
             }
         }

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -30,8 +30,8 @@ namespace RainMeadow
         private bool setpassword;
         private OpTextBox passwordInputBox;
         private CheckBox enablePasswordCheckbox;
-        private int maxPlayerCount = 4;
-        
+        private int maxPlayerCount;
+
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)
         {
@@ -59,7 +59,7 @@ namespace RainMeadow
             // misc buttons on topright
             Vector2 where = new Vector2(1056f, 552f);
             var aboutButton = new SimplerButton(this, mainPage, Translate("ABOUT"), where, new Vector2(110f, 30f));
-           
+
             mainPage.subObjects.Add(aboutButton);
             where.y -= 35;
             var statsButton = new SimplerButton(this, mainPage, Translate("STATS"), where, new Vector2(110f, 30f));
@@ -93,7 +93,7 @@ namespace RainMeadow
             where.x -= 80;
 
             where.y -= 45;
-            enablePasswordCheckbox = new CheckBox(this,mainPage,this,where,60f, Translate("Enable Password:"),"SETPASSWORD",true);
+            enablePasswordCheckbox = new CheckBox(this, mainPage, this, where, 60f, Translate("Enable Password:"), "SETPASSWORD", true);
             mainPage.subObjects.Add(enablePasswordCheckbox);
             // password setting
             where.x += 160;
@@ -110,10 +110,10 @@ namespace RainMeadow
             mainPage.subObjects.Add(limitNumberLabel);
             where.x += 80;
             where.y -= 5;
-            lobbyLimitNumberTextBox = new OpTextBox(new Configurable<int>(maxPlayerCount), where, 160f);
+            lobbyLimitNumberTextBox = new OpTextBox(new Configurable<int>(maxPlayerCount = 4), where, 160f);
             lobbyLimitNumberTextBox.accept = OpTextBox.Accept.Int;
             new UIelementWrapper(this.tabWrapper, lobbyLimitNumberTextBox);
-            where.y += 5; 
+            where.y += 5;
 
             // display version
             var versionPos = new Vector2(5f, 0f);
@@ -169,8 +169,6 @@ namespace RainMeadow
         public override void Update()
         {
             base.Update();
-            if (maxPlayerCount > 32) maxPlayerCount = 32;
-            if (maxPlayerCount < 1) maxPlayerCount = 1;
             int extraItems = Mathf.Max(lobbies.Length - 4, 0);
             scrollTo = Mathf.Clamp(scrollTo, -0.5f, extraItems + 0.5f);
             if (scrollTo < 0) scrollTo = RWCustom.Custom.LerpAndTick(scrollTo, 0, 0.1f, 0.1f);
@@ -182,6 +180,12 @@ namespace RainMeadow
             passwordInputBox.greyedOut = !setpassword || this.currentlySelectedCard != 0;
             enablePasswordCheckbox.buttonBehav.greyedOut = this.currentlySelectedCard != 0;
             lobbyLimitNumberTextBox.greyedOut = this.currentlySelectedCard != 0;
+            if (lobbyLimitNumberTextBox.value != "")
+            {
+                maxPlayerCount = lobbyLimitNumberTextBox.valueInt;
+                if (lobbyLimitNumberTextBox.valueInt > 32) lobbyLimitNumberTextBox.valueInt = 32;
+                if (lobbyLimitNumberTextBox.valueInt < 1) lobbyLimitNumberTextBox.valueInt = 1;
+            }
         }
 
         private void BumpPlayButton(EventfulSelectOneButton obj)
@@ -235,6 +239,7 @@ namespace RainMeadow
                 {
                     this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, "Private", new(260, 20), new(10, 50), false));
                 }
+                this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, $"{lobbyInfo.maxPlayerCount} max", new(260, 0), new(10, 50), false));
                 this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, lobbyInfo.mode, new(5, 20), new(10, 50), false));
                 this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, lobbyInfo.playerCount + " player" + (lobbyInfo.playerCount == 1 ? "" : "s"), new(5, 5), new(10, 50), false));
             }
@@ -288,7 +293,7 @@ namespace RainMeadow
             MatchmakingManager.instance.CreateLobby(value, modeDropDown.value, setpassword ? passwordInputBox.value : null, maxPlayerCount);
         }
 
-        private void RequestLobbyJoin(LobbyInfo lobby, string? password = null)
+        private void RequestLobbyJoin(LobbyInfo lobby, string? password = null, int maxPlayerCount = 4)
         {
             RainMeadow.DebugMe();
             MatchmakingManager.instance.RequestJoinLobby(lobby, password, maxPlayerCount);

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -21,11 +21,13 @@ namespace RainMeadow
         private float scrollTo;
         private int currentlySelectedCard;
         private OpComboBox visibilityDropDown;
+        private OpTextBox lobbyLimitNumberTextBox;
         private SimplerButton playButton;
         private SimplerButton refreshButton;
         private OpComboBox2 modeDropDown;
         private ProperlyAlignedMenuLabel modeDescriptionLabel;
         private MenuDialogBox popupDialog;
+        private int maxPlayerLimit = 4;
 
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)
@@ -77,11 +79,6 @@ namespace RainMeadow
             mainPage.subObjects.Add(modeDescriptionLabel);
             UpdateModeDescription();
 
-            // display version
-            where = new Vector2(0f, 0f);
-            var meadowVer = new ProperlyAlignedMenuLabel(this, mainPage, Translate($"Rain Meadow Version {RainMeadow.MeadowVersionStr}"), where, new Vector2(0f, 20f), false, null);
-            mainPage.subObjects.Add(meadowVer);
-
             // center-low settings
             where.y -= 45;
             var visibilityLabel = new ProperlyAlignedMenuLabel(this, mainPage, Translate("Visibility:"), where, new Vector2(200, 20f), false, null);
@@ -89,6 +86,20 @@ namespace RainMeadow
             where.x += 80;
             visibilityDropDown = new OpComboBox(new Configurable<MatchmakingManager.LobbyVisibility>(MatchmakingManager.LobbyVisibility.Public), where, 160, OpResourceSelector.GetEnumNames(null, typeof(MatchmakingManager.LobbyVisibility)).Select(li => { li.displayName = Translate(li.displayName); return li; }).ToList()) { colorEdge = MenuColorEffect.rgbWhite };
             new UIelementWrapper(this.tabWrapper, visibilityDropDown);
+
+            // textbox lobby limit option
+            where.y -= 45;
+            var limitNumberLabel = new ProperlyAlignedMenuLabel(this, mainPage, Translate("Player max:"), where, new Vector2(400, 20f), false, null);
+            mainPage.subObjects.Add(limitNumberLabel);
+            where.y -= 5;
+            lobbyLimitNumberTextBox = new OpTextBox(new Configurable<int>(maxPlayerLimit), where, 160f);
+            new UIelementWrapper(this.tabWrapper, lobbyLimitNumberTextBox);
+            where.y += 5; 
+
+            // display version
+            where = new Vector2(0f, 0f);
+            var meadowVer = new ProperlyAlignedMenuLabel(this, mainPage, Translate($"Rain Meadow Version {RainMeadow.MeadowVersionStr}"), where, new Vector2(0f, 20f), false, null);
+            mainPage.subObjects.Add(meadowVer);
 
             // left lobby selector
             // bg
@@ -254,9 +265,10 @@ namespace RainMeadow
         {
             RainMeadow.DebugMe();
             MatchmakingManager.instance.JoinLobby(lobby);
-            if (SteamMatchmakingManager.isStoryLobbyFull)
+            if (SteamMatchmakingManager.isLobbyFull)
             {
                 ShowErrorDialog($"Failed to join lobby.<LINE>Lobby is full");
+                SteamMatchmakingManager.isLobbyFull = false; // so the player can try again
                 return;
             }
         }

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -308,7 +308,7 @@ namespace RainMeadow
             var lobbyInfo = (lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo;
             RainMeadow.DebugMe();
             maxPlayerCount = lobbyInfo.maxPlayerCount;
-            MatchmakingManager.instance.RequestJoinLobby(lobby, password, maxPlayerCount);
+            MatchmakingManager.instance.RequestJoinLobby(lobby, password);
         }
 
         private void OnlineManager_OnLobbyListReceived(bool ok, LobbyInfo[] lobbies)

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -184,7 +184,7 @@ namespace RainMeadow
             {
                 maxPlayerCount = lobbyLimitNumberTextBox.valueInt;
                 if (lobbyLimitNumberTextBox.valueInt > 32) lobbyLimitNumberTextBox.valueInt = 32;
-                if (lobbyLimitNumberTextBox.valueInt < 1) lobbyLimitNumberTextBox.valueInt = 1;
+                if (lobbyLimitNumberTextBox.valueInt < 2) lobbyLimitNumberTextBox.valueInt = 2;
             }
         }
 

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -30,7 +30,7 @@ namespace RainMeadow
         private bool setpassword;
         private OpTextBox passwordInputBox;
         private CheckBox enablePasswordCheckbox;
-        private int maxPlayerLimit = 4;
+        private int maxPlayerCount = 4;
         
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)
@@ -102,13 +102,16 @@ namespace RainMeadow
             passwordInputBox.description = "Lobby Password";
             passwordInputBox.label.text = "Password";
             new UIelementWrapper(this.tabWrapper, passwordInputBox);
-            
+
             // textbox lobby limit option
+            where.x -= 160;
             where.y -= 45;
             var limitNumberLabel = new ProperlyAlignedMenuLabel(this, mainPage, Translate("Player max:"), where, new Vector2(400, 20f), false, null);
             mainPage.subObjects.Add(limitNumberLabel);
+            where.x += 80;
             where.y -= 5;
-            lobbyLimitNumberTextBox = new OpTextBox(new Configurable<int>(maxPlayerLimit), where, 160f);
+            lobbyLimitNumberTextBox = new OpTextBox(new Configurable<int>(maxPlayerCount), where, 160f);
+            lobbyLimitNumberTextBox.accept = OpTextBox.Accept.Int;
             new UIelementWrapper(this.tabWrapper, lobbyLimitNumberTextBox);
             where.y += 5; 
 
@@ -116,6 +119,7 @@ namespace RainMeadow
             var versionPos = new Vector2(5f, 0f);
             var meadowVer = new ProperlyAlignedMenuLabel(this, mainPage, Translate($"Rain Meadow Version {RainMeadow.MeadowVersionStr}"), versionPos, new Vector2(0f, 20f), false, null);
             mainPage.subObjects.Add(meadowVer);
+
             // left lobby selector
             // bg
             sprites = new();
@@ -175,6 +179,7 @@ namespace RainMeadow
             visibilityDropDown.greyedOut = this.currentlySelectedCard != 0;
             passwordInputBox.greyedOut = !setpassword || this.currentlySelectedCard != 0;
             enablePasswordCheckbox.buttonBehav.greyedOut = this.currentlySelectedCard != 0;
+            lobbyLimitNumberTextBox.greyedOut = this.currentlySelectedCard != 0;
         }
 
         private void BumpPlayButton(EventfulSelectOneButton obj)
@@ -278,13 +283,13 @@ namespace RainMeadow
         {
             RainMeadow.DebugMe();
             Enum.TryParse<MatchmakingManager.LobbyVisibility>(visibilityDropDown.value, out var value);
-            MatchmakingManager.instance.CreateLobby(value, modeDropDown.value, setpassword ? passwordInputBox.value : null);
+            MatchmakingManager.instance.CreateLobby(value, modeDropDown.value, setpassword ? passwordInputBox.value : null, maxPlayerCount);
         }
 
         private void RequestLobbyJoin(LobbyInfo lobby, string? password = null)
         {
             RainMeadow.DebugMe();
-            MatchmakingManager.instance.RequestJoinLobby(lobby, password);
+            MatchmakingManager.instance.RequestJoinLobby(lobby, password, maxPlayerCount);
         }
 
         private void OnlineManager_OnLobbyListReceived(bool ok, LobbyInfo[] lobbies)

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -26,8 +26,6 @@ namespace RainMeadow
         private OpComboBox2 modeDropDown;
         private ProperlyAlignedMenuLabel modeDescriptionLabel;
         private MenuDialogBox popupDialog;
-        private int maxStoryPlayers = 4;
-        private LobbyInfo lobbyInfo;
 
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)
@@ -256,6 +254,11 @@ namespace RainMeadow
         {
             RainMeadow.DebugMe();
             MatchmakingManager.instance.JoinLobby(lobby);
+            if (SteamMatchmakingManager.isStoryLobbyFull)
+            {
+                ShowErrorDialog($"Failed to join lobby.<LINE>Lobby is full");
+                return;
+            }
         }
 
         private void OnlineManager_OnLobbyListReceived(bool ok, LobbyInfo[] lobbies)
@@ -270,16 +273,6 @@ namespace RainMeadow
         
         private void OnlineManager_OnLobbyJoined(bool ok, string error)
         {
-            if (OnlineManager.lobby.gameMode is StoryGameMode)
-            {
-                if (lobbyInfo.playerCount >= maxStoryPlayers)
-                {
-                    RainMeadow.Debug("Player attempted to join, but the lobby was full");
-                    ok = false;
-                    error = "The lobby is full";
-                    return;
-                }
-            }
             RainMeadow.Debug(ok);
             if (!ok)
             {

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -97,8 +97,8 @@ namespace RainMeadow
             where.y += 5; 
 
             // display version
-            where = new Vector2(0f, 0f);
-            var meadowVer = new ProperlyAlignedMenuLabel(this, mainPage, Translate($"Rain Meadow Version {RainMeadow.MeadowVersionStr}"), where, new Vector2(0f, 20f), false, null);
+            var versionPos = new Vector2(0f, 0f);
+            var meadowVer = new ProperlyAlignedMenuLabel(this, mainPage, Translate($"Rain Meadow Version {RainMeadow.MeadowVersionStr}"), versionPos, new Vector2(0f, 20f), false, null);
             mainPage.subObjects.Add(meadowVer);
 
             // left lobby selector

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -1,7 +1,6 @@
 ﻿using Menu;
 using Menu.Remix;
 using Menu.Remix.MixedUI;
-using Rewired.UI.ControlMapper;
 
 #if !LOCAL_P2P
 using Steamworks;

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -97,7 +97,7 @@ namespace RainMeadow
             where.y += 5; 
 
             // display version
-            var versionPos = new Vector2(0f, 0f);
+            var versionPos = new Vector2(5f, 0f);
             var meadowVer = new ProperlyAlignedMenuLabel(this, mainPage, Translate($"Rain Meadow Version {RainMeadow.MeadowVersionStr}"), versionPos, new Vector2(0f, 20f), false, null);
             mainPage.subObjects.Add(meadowVer);
 

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -270,7 +270,6 @@ namespace RainMeadow
         
         private void OnlineManager_OnLobbyJoined(bool ok, string error)
         {
-            RainMeadow.Debug(ok);
             if (OnlineManager.lobby.gameMode is StoryGameMode)
             {
                 if (lobbyInfo.playerCount >= maxStoryPlayers)
@@ -281,6 +280,7 @@ namespace RainMeadow
                     return;
                 }
             }
+            RainMeadow.Debug(ok);
             if (!ok)
             {
                 ShowErrorDialog($"Failed to join lobby.<LINE>{error}");

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -1,6 +1,8 @@
 ﻿using Menu;
 using Menu.Remix;
 using Menu.Remix.MixedUI;
+using Rewired.UI.ControlMapper;
+
 #if !LOCAL_P2P
 using Steamworks;
 #endif
@@ -25,6 +27,8 @@ namespace RainMeadow
         private OpComboBox2 modeDropDown;
         private ProperlyAlignedMenuLabel modeDescriptionLabel;
         private MenuDialogBox popupDialog;
+        private int maxStoryPlayers = 4;
+        private LobbyInfo lobbyInfo;
 
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)
@@ -234,7 +238,7 @@ namespace RainMeadow
                 ShowLoadingDialog("Joining lobby...");
                 RequestLobbyJoin((lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo);
             }
-            
+
         }
 
         private void RefreshLobbyList(SimplerButton obj)
@@ -268,6 +272,16 @@ namespace RainMeadow
         private void OnlineManager_OnLobbyJoined(bool ok, string error)
         {
             RainMeadow.Debug(ok);
+            if (OnlineManager.lobby.gameMode is StoryGameMode)
+            {
+                if (lobbyInfo.playerCount >= maxStoryPlayers)
+                {
+                    RainMeadow.Debug("Player attempted to join, but the lobby was full");
+                    ok = false;
+                    error = "The lobby is full";
+                    return;
+                }
+            }
             if (!ok)
             {
                 ShowErrorDialog($"Failed to join lobby.<LINE>{error}");

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -30,7 +30,7 @@ namespace RainMeadow
         private bool setpassword;
         private OpTextBox passwordInputBox;
         private CheckBox enablePasswordCheckbox;
-        private int maxPlayerCount;
+        public static int maxPlayerCount;
 
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)
@@ -239,7 +239,7 @@ namespace RainMeadow
                 {
                     this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, "Private", new(260, 20), new(10, 50), false));
                 }
-                this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, $"{lobbyInfo.maxPlayerCount} max", new(260, 0), new(10, 50), false));
+                this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, $"{lobbyInfo.maxPlayerCount} max", new(260, 5), new(10, 50), false));
                 this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, lobbyInfo.mode, new(5, 20), new(10, 50), false));
                 this.subObjects.Add(new ProperlyAlignedMenuLabel(menu, this, lobbyInfo.playerCount + " player" + (lobbyInfo.playerCount == 1 ? "" : "s"), new(5, 5), new(10, 50), false));
             }
@@ -269,16 +269,24 @@ namespace RainMeadow
             else
             {
                 var lobbyInfo = (lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo;
-                if (lobbyInfo.hasPassword) {
-                    ShowPasswordRequestDialog();
+                RainMeadow.Debug($"{lobbyInfo.playerCount} test test test {lobbyInfo.maxPlayerCount}");
+                if (lobbyInfo.playerCount > lobbyInfo.maxPlayerCount)
+                {
+                    ShowErrorDialog("Failed to join lobby.<LINE> Lobby is full");
                 }
                 else
                 {
-                    ShowLoadingDialog("Joining lobby...");
-                    RequestLobbyJoin(lobbyInfo);
+                    if (lobbyInfo.hasPassword)
+                    {
+                        ShowPasswordRequestDialog();
+                    }
+                    else
+                    {
+                        ShowLoadingDialog("Joining lobby...");
+                        RequestLobbyJoin(lobbyInfo);
+                    }
                 }
             }
-
         }
 
         private void RefreshLobbyList(SimplerButton obj)
@@ -291,11 +299,14 @@ namespace RainMeadow
             RainMeadow.DebugMe();
             Enum.TryParse<MatchmakingManager.LobbyVisibility>(visibilityDropDown.value, out var value);
             MatchmakingManager.instance.CreateLobby(value, modeDropDown.value, setpassword ? passwordInputBox.value : null, maxPlayerCount);
+            RainMeadow.Debug($"Creating a lobby with a max player limit of {maxPlayerCount}");
         }
 
-        private void RequestLobbyJoin(LobbyInfo lobby, string? password = null, int maxPlayerCount = 4)
+        private void RequestLobbyJoin(LobbyInfo lobby, string? password = null, int? maxPlayerCount = 4)
         {
+            var lobbyInfo = (lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo;
             RainMeadow.DebugMe();
+            maxPlayerCount = lobbyInfo.maxPlayerCount;
             MatchmakingManager.instance.RequestJoinLobby(lobby, password, maxPlayerCount);
         }
 
@@ -383,7 +394,7 @@ namespace RainMeadow
                 case "HIDE_PASSWORD":
                     var password = (popupDialog as CustomInputDialogueBox).textBox.value;
                     ShowLoadingDialog("Joining lobby...");
-                    RequestLobbyJoin((lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo, password);
+                    RequestLobbyJoin((lobbyButtons[currentlySelectedCard] as LobbyInfoCard).lobbyInfo, password, maxPlayerCount);
                     break;
             }
         }

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -30,7 +30,7 @@ namespace RainMeadow
         private bool setpassword;
         private OpTextBox passwordInputBox;
         private CheckBox enablePasswordCheckbox;
-        public static int maxPlayerCount;
+        private int maxPlayerCount;
 
         public override MenuScene.SceneID GetScene => MenuScene.SceneID.Landscape_CC;
         public LobbySelectMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.LobbySelectMenu)

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -276,7 +276,7 @@ namespace RainMeadow
                         if (args.Length > i + 1 && ulong.TryParse(args[i + 1], out var id))
                         {
                             Debug($"joining lobby with id {id} from the command line");
-                            MatchmakingManager.instance.RequestJoinLobby(new LobbyInfo(new CSteamID(id), "", "", 0, false, 4), null, 4);
+                            MatchmakingManager.instance.RequestJoinLobby(new LobbyInfo(new CSteamID(id), "", "", 0, false, 4), null);
                         }
                         else
                         {

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -196,7 +196,7 @@ namespace RainMeadow
                         if (args.Length > i + 1 && ulong.TryParse(args[i + 1], out var id))
                         {
                             Debug($"joining lobby with id {id} from the command line");
-                            MatchmakingManager.instance.RequestJoinLobby(new LobbyInfo(new CSteamID(id), "", "", 0, false),null);
+                            MatchmakingManager.instance.RequestJoinLobby(new LobbyInfo(new CSteamID(id), "", "", 0, false, 4), null, 4);
                         }
                         else
                         {

--- a/Online/Matchmaking/LocalMatchmakingManager.cs
+++ b/Online/Matchmaking/LocalMatchmakingManager.cs
@@ -59,7 +59,7 @@ namespace RainMeadow
             return new LocalPlayerId();
         }
 
-        public int? maxLobbyCount = 4;
+        public int maxLobbyCount = 4;
         public string? lobbyPassword;
         public LobbyInfo lobbyInfo;
 
@@ -130,7 +130,7 @@ namespace RainMeadow
                 return;
             } 
             lobbyPassword = password;
-            maxLobbyCount = maxPlayerCount;
+            maxLobbyCount = (int)maxPlayerCount;
             var memory = new MemoryStream(16);
             var writer = new BinaryWriter(memory);
             Packet.Encode(new RequestJoinPacket(), writer, null);

--- a/Online/Matchmaking/LocalMatchmakingManager.cs
+++ b/Online/Matchmaking/LocalMatchmakingManager.cs
@@ -112,7 +112,7 @@ namespace RainMeadow
                 return;
             }
 
-            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), OnlineManager.mePlayer, password, maxPlayerCount);
+            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), OnlineManager.mePlayer, password);
             OnLobbyJoined?.Invoke(true);
         }
 
@@ -138,7 +138,7 @@ namespace RainMeadow
         }
         public void LobbyJoined()
         {
-            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), GetLobbyOwner(), lobbyPassword, maxLobbyCount);
+            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), GetLobbyOwner(), lobbyPassword);
             var lobbyOwner = (LocalPlayerId)OnlineManager.lobby.owner.id;
             currentLobbyHost = lobbyOwner.endPoint;
         }

--- a/Online/Matchmaking/LocalMatchmakingManager.cs
+++ b/Online/Matchmaking/LocalMatchmakingManager.cs
@@ -59,7 +59,7 @@ namespace RainMeadow
             return new LocalPlayerId();
         }
 
-        public int maxLobbyCount = 4;
+        public int maxPlayerCount;
         public string? lobbyPassword;
         public LobbyInfo lobbyInfo;
 
@@ -112,7 +112,7 @@ namespace RainMeadow
                 return;
             }
 
-            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), OnlineManager.mePlayer, password, maxLobbyCount);
+            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), OnlineManager.mePlayer, password, maxPlayerCount);
             OnLobbyJoined?.Invoke(true);
         }
 
@@ -130,7 +130,7 @@ namespace RainMeadow
                 return;
             } 
             lobbyPassword = password;
-            maxLobbyCount = (int)maxPlayerCount;
+            this.maxPlayerCount = (int)maxPlayerCount;
             var memory = new MemoryStream(16);
             var writer = new BinaryWriter(memory);
             Packet.Encode(new RequestJoinPacket(), writer, null);
@@ -138,7 +138,7 @@ namespace RainMeadow
         }
         public void LobbyJoined()
         {
-            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), GetLobbyOwner(), lobbyPassword, maxLobbyCount);
+            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), GetLobbyOwner(), lobbyPassword, maxPlayerCount);
             var lobbyOwner = (LocalPlayerId)OnlineManager.lobby.owner.id;
             currentLobbyHost = lobbyOwner.endPoint;
         }
@@ -146,16 +146,7 @@ namespace RainMeadow
         {
             if (success)
             {
-                if (OnlineManager.players.Count > maxLobbyCount)
-                {
-                    LeaveLobby();
-                    RainMeadow.Debug("Failed to join local game. Lobby is full");
-                    OnLobbyJoined?.Invoke(false, "Lobby is full");
-                }
-                else 
-                {
-                    OnLobbyJoined?.Invoke(true); 
-                }
+                OnLobbyJoined?.Invoke(true);
             }
             else
             {

--- a/Online/Matchmaking/LocalMatchmakingManager.cs
+++ b/Online/Matchmaking/LocalMatchmakingManager.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Net;
 using System.Collections.Generic;
 using static RainMeadow.NetIO;
-using System.Diagnostics.Eventing.Reader;
 
 namespace RainMeadow
 {

--- a/Online/Matchmaking/LocalMatchmakingManager.cs
+++ b/Online/Matchmaking/LocalMatchmakingManager.cs
@@ -116,7 +116,7 @@ namespace RainMeadow
             OnLobbyJoined?.Invoke(true);
         }
 
-        public override void RequestJoinLobby(LobbyInfo lobby, string? password, int? maxPlayerCount)
+        public override void RequestJoinLobby(LobbyInfo lobby, string? password)
         {
             sessionSetup(false);
             if (((LocalPlayerId)OnlineManager.mePlayer.id).isHost)
@@ -130,7 +130,6 @@ namespace RainMeadow
                 return;
             } 
             lobbyPassword = password;
-            maxLobbyCount = (int)maxPlayerCount;
             var memory = new MemoryStream(16);
             var writer = new BinaryWriter(memory);
             Packet.Encode(new RequestJoinPacket(), writer, null);

--- a/Online/Matchmaking/LocalMatchmakingManager.cs
+++ b/Online/Matchmaking/LocalMatchmakingManager.cs
@@ -59,7 +59,6 @@ namespace RainMeadow
             return new LocalPlayerId();
         }
 
-        public int maxLobbyCount;
         public string? lobbyPassword;
         public LobbyInfo lobbyInfo;
 

--- a/Online/Matchmaking/LocalMatchmakingManager.cs
+++ b/Online/Matchmaking/LocalMatchmakingManager.cs
@@ -59,7 +59,7 @@ namespace RainMeadow
             return new LocalPlayerId();
         }
 
-        public int maxPlayerCount;
+        public int maxLobbyCount;
         public string? lobbyPassword;
         public LobbyInfo lobbyInfo;
 
@@ -130,7 +130,7 @@ namespace RainMeadow
                 return;
             } 
             lobbyPassword = password;
-            this.maxPlayerCount = (int)maxPlayerCount;
+            maxLobbyCount = (int)maxPlayerCount;
             var memory = new MemoryStream(16);
             var writer = new BinaryWriter(memory);
             Packet.Encode(new RequestJoinPacket(), writer, null);
@@ -138,7 +138,7 @@ namespace RainMeadow
         }
         public void LobbyJoined()
         {
-            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), GetLobbyOwner(), lobbyPassword, maxPlayerCount);
+            OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(localGameMode), GetLobbyOwner(), lobbyPassword, maxLobbyCount);
             var lobbyOwner = (LocalPlayerId)OnlineManager.lobby.owner.id;
             currentLobbyHost = lobbyOwner.endPoint;
         }

--- a/Online/Matchmaking/MatchmakingManager.cs
+++ b/Online/Matchmaking/MatchmakingManager.cs
@@ -13,6 +13,7 @@ namespace RainMeadow
         public static string NAME_KEY = "name";
         public static string MODE_KEY = "mode";
         public static string PASSWORD_KEY = "password";
+        public static int MAX_LOBBY = 4;
 
         public static void InitLobbyManager()
         {
@@ -43,9 +44,9 @@ namespace RainMeadow
 
         public abstract void RequestLobbyList();
 
-        public abstract void CreateLobby(LobbyVisibility visibility, string gameMode, string? password);
+        public abstract void CreateLobby(LobbyVisibility visibility, string gameMode, string? password, int? maxPlayerCount);
 
-        public abstract void RequestJoinLobby(LobbyInfo lobby, string? password);
+        public abstract void RequestJoinLobby(LobbyInfo lobby, string? password, int? maxPlayerCount);
         public abstract void JoinLobby(bool success);
 
         public abstract void LeaveLobby();

--- a/Online/Matchmaking/MatchmakingManager.cs
+++ b/Online/Matchmaking/MatchmakingManager.cs
@@ -32,7 +32,6 @@ namespace RainMeadow
             FriendsOnly,
             [Description("Private")]
             Private
-
         }
 
         public abstract event LobbyListReceived_t OnLobbyListReceived;

--- a/Online/Matchmaking/MatchmakingManager.cs
+++ b/Online/Matchmaking/MatchmakingManager.cs
@@ -45,7 +45,7 @@ namespace RainMeadow
 
         public abstract void CreateLobby(LobbyVisibility visibility, string gameMode, string? password, int? maxPlayerCount);
 
-        public abstract void RequestJoinLobby(LobbyInfo lobby, string? password, int? maxPlayerCount);
+        public abstract void RequestJoinLobby(LobbyInfo lobby, string? password);
         public abstract void JoinLobby(bool success);
 
         public abstract void LeaveLobby();

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -123,7 +123,7 @@ namespace RainMeadow
             m_CreateLobbyCall.Set(SteamMatchmaking.CreateLobby(eLobbyTypeeLobbyType, 16));
         }
 
-        public override void RequestJoinLobby(LobbyInfo lobby, string? password, int? maxPlayerCount)
+        public override void RequestJoinLobby(LobbyInfo lobby, string? password)
         {
             lobbyPassword = password;
             m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(lobby.id));

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -8,6 +8,7 @@ namespace RainMeadow
 {
     public class SteamMatchmakingManager : MatchmakingManager
     {
+        public static bool isStoryLobbyFull;
         public class SteamPlayerId : MeadowPlayerId
         {
             public CSteamID steamID;
@@ -120,7 +121,24 @@ namespace RainMeadow
 
         public override void JoinLobby(LobbyInfo lobby)
         {
-            m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(lobby.id));
+            if (lobby.mode == "Story")
+            {
+                if (lobby.playerCount > 1)
+                {
+                    RainMeadow.Debug("Maximum players for the lobby have been reached");
+                    isStoryLobbyFull = true;
+                    return;
+                }
+                else
+                {
+                    m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(lobby.id));
+                }
+
+            }
+            else
+            {
+                m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(lobby.id));
+            }
         }
 
         private static string creatingWithMode;

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -8,8 +8,8 @@ namespace RainMeadow
 {
     public class SteamMatchmakingManager : MatchmakingManager
     {
-        public static bool isLobbyFull;
-        public static int maxLobbyLimit = 1;
+        public static bool isLobbyFull; // might not need it
+        private static int maxLobbyCount = 4;
         public class SteamPlayerId : MeadowPlayerId
         {
             public CSteamID steamID;
@@ -94,7 +94,7 @@ namespace RainMeadow
                     for (int i = 0; i < pCallback.m_nLobbiesMatching; i++)
                     {
                         CSteamID id = SteamMatchmaking.GetLobbyByIndex(i);
-                        lobbies[i] = new LobbyInfo(id, SteamMatchmaking.GetLobbyData(id, NAME_KEY), SteamMatchmaking.GetLobbyData(id, MODE_KEY), SteamMatchmaking.GetNumLobbyMembers(id), bool.Parse(SteamMatchmaking.GetLobbyData(id, PASSWORD_KEY)));
+                        lobbies[i] = new LobbyInfo(id, SteamMatchmaking.GetLobbyData(id, NAME_KEY), SteamMatchmaking.GetLobbyData(id, MODE_KEY), SteamMatchmaking.GetNumLobbyMembers(id), bool.Parse(SteamMatchmaking.GetLobbyData(id, PASSWORD_KEY)), SteamMatchmaking.GetLobbyMemberLimit(id));
                     }
                 }
 
@@ -107,10 +107,11 @@ namespace RainMeadow
             }
         }
 
-        public override void CreateLobby(LobbyVisibility visibility, string gameMode, string? password)
+        public override void CreateLobby(LobbyVisibility visibility, string gameMode, string? password, int? maxPlayerCount)
         {
             creatingWithMode = gameMode;
             lobbyPassword = password;
+            maxLobbyCount = (int)maxPlayerCount;
             ELobbyType eLobbyTypeeLobbyType = visibility switch
             {
                 LobbyVisibility.Private => ELobbyType.k_ELobbyTypePrivate,
@@ -121,7 +122,7 @@ namespace RainMeadow
             m_CreateLobbyCall.Set(SteamMatchmaking.CreateLobby(eLobbyTypeeLobbyType, 16));
         }
 
-        public override void RequestJoinLobby(LobbyInfo lobby, string? password)
+        public override void RequestJoinLobby(LobbyInfo lobby, string? password, int? maxPlayerCount)
         {
             lobbyPassword = password;
             m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(lobby.id));
@@ -131,7 +132,16 @@ namespace RainMeadow
         {
             if (success)
             {
-                OnLobbyJoined?.Invoke(true);
+                if (OnlineManager.players.Count >= maxLobbyCount)
+                {
+                    LeaveLobby();
+                    RainMeadow.Debug("Failed to join local game. Lobby is full");
+                    OnLobbyJoined?.Invoke(false, "Lobby is full");
+                }
+                else
+                {
+                    OnLobbyJoined?.Invoke(true);
+                }
             }
             else
             {
@@ -159,7 +169,7 @@ namespace RainMeadow
                     {
                         SteamMatchmaking.SetLobbyData(lobbyID, PASSWORD_KEY, "true");
                     }
-                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(creatingWithMode), OnlineManager.mePlayer, lobbyPassword);
+                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(creatingWithMode), OnlineManager.mePlayer, lobbyPassword, maxLobbyCount);
                     SteamFriends.SetRichPresence("connect", lobbyID.ToString());
                     OnLobbyJoined?.Invoke(true);
                 }
@@ -196,7 +206,7 @@ namespace RainMeadow
                     }
                     SteamFriends.SetRichPresence("connect", lobbyID.ToString());
 
-                    OnlineManager.lobby = new Lobby(mode, owner, lobbyPassword);
+                    OnlineManager.lobby = new Lobby(mode, owner, lobbyPassword, maxLobbyCount);
                 }
                 else
                 {
@@ -370,7 +380,7 @@ namespace RainMeadow
                     LeaveLobby();
                 }
 
-                OnlineManager.currentlyJoiningLobby = new LobbyInfo(param.m_steamIDLobby, "", "", 0,false);
+                OnlineManager.currentlyJoiningLobby = new LobbyInfo(param.m_steamIDLobby, "", "", 0,false, maxLobbyCount);
                 Custom.rainWorld.processManager.RequestMainProcessSwitch(RainMeadow.Ext_ProcessID.LobbySelectMenu);
 
                 m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(param.m_steamIDLobby));

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -8,7 +8,7 @@ namespace RainMeadow
 {
     public class SteamMatchmakingManager : MatchmakingManager
     {
-        private static int maxLobbyCount;
+        public static int maxLobbyCount;
         public class SteamPlayerId : MeadowPlayerId
         {
             public CSteamID steamID;
@@ -112,6 +112,7 @@ namespace RainMeadow
             creatingWithMode = gameMode;
             lobbyPassword = password;
             maxLobbyCount = (int)maxPlayerCount;
+            MAX_LOBBY = (int)maxPlayerCount;
             ELobbyType eLobbyTypeeLobbyType = visibility switch
             {
                 LobbyVisibility.Private => ELobbyType.k_ELobbyTypePrivate,
@@ -132,16 +133,7 @@ namespace RainMeadow
         {
             if (success)
             {
-                if (OnlineManager.currentlyJoiningLobby.playerCount > LobbySelectMenu.maxPlayerCount)
-                {
-                    LeaveLobby();
-                    RainMeadow.Debug("Failed to join local game. Lobby is full");
-                    OnLobbyJoined?.Invoke(false, "Lobby is full");
-                }
-                else
-                {
-                    OnLobbyJoined?.Invoke(true);
-                }
+                OnLobbyJoined?.Invoke(true);
             }
             else
             {

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -8,8 +8,7 @@ namespace RainMeadow
 {
     public class SteamMatchmakingManager : MatchmakingManager
     {
-        public static bool isLobbyFull; // might not need it
-        private static int maxLobbyCount = 4;
+        private static int maxLobbyCount;
         public class SteamPlayerId : MeadowPlayerId
         {
             public CSteamID steamID;
@@ -132,7 +131,7 @@ namespace RainMeadow
         {
             if (success)
             {
-                if (OnlineManager.players.Count >= maxLobbyCount)
+                if (OnlineManager.currentlyJoiningLobby.playerCount > LobbySelectMenu.maxPlayerCount)
                 {
                     LeaveLobby();
                     RainMeadow.Debug("Failed to join local game. Lobby is full");
@@ -169,6 +168,7 @@ namespace RainMeadow
                     {
                         SteamMatchmaking.SetLobbyData(lobbyID, PASSWORD_KEY, "true");
                     }
+                    SteamMatchmaking.SetLobbyMemberLimit(lobbyID, MAX_LOBBY);
                     OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(creatingWithMode), OnlineManager.mePlayer, lobbyPassword, maxLobbyCount);
                     SteamFriends.SetRichPresence("connect", lobbyID.ToString());
                     OnLobbyJoined?.Invoke(true);

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -165,7 +165,7 @@ namespace RainMeadow
                         SteamMatchmaking.SetLobbyData(lobbyID, PASSWORD_KEY, "false");
                     }
                     SteamMatchmaking.SetLobbyMemberLimit(lobbyID, MAX_LOBBY);
-                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(creatingWithMode), OnlineManager.mePlayer, lobbyPassword, maxLobbyCount);
+                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(creatingWithMode), OnlineManager.mePlayer, lobbyPassword);
                     SteamFriends.SetRichPresence("connect", lobbyID.ToString());
                     OnLobbyJoined?.Invoke(true);
                 }
@@ -202,7 +202,7 @@ namespace RainMeadow
                     }
                     SteamFriends.SetRichPresence("connect", lobbyID.ToString());
 
-                    OnlineManager.lobby = new Lobby(mode, owner, lobbyPassword, maxLobbyCount);
+                    OnlineManager.lobby = new Lobby(mode, owner, lobbyPassword);
                 }
                 else
                 {

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -8,7 +8,8 @@ namespace RainMeadow
 {
     public class SteamMatchmakingManager : MatchmakingManager
     {
-        public static bool isStoryLobbyFull;
+        public static bool isLobbyFull;
+        public static int maxLobbyLimit = 1;
         public class SteamPlayerId : MeadowPlayerId
         {
             public CSteamID steamID;
@@ -121,19 +122,12 @@ namespace RainMeadow
 
         public override void JoinLobby(LobbyInfo lobby)
         {
-            if (lobby.mode == "Story")
+            if (lobby.playerCount >= maxLobbyLimit)
             {
-                if (lobby.playerCount > 1)
-                {
-                    RainMeadow.Debug("Maximum players for the lobby have been reached");
-                    isStoryLobbyFull = true;
-                    return;
-                }
-                else
-                {
-                    m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(lobby.id));
-                }
-
+                RainMeadow.Debug("Maximum players for the lobby have been reached");
+                isLobbyFull = true;
+                LeaveLobby();
+                return;
             }
             else
             {

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -8,7 +8,6 @@ namespace RainMeadow
 {
     public class SteamMatchmakingManager : MatchmakingManager
     {
-        public static int maxLobbyCount;
         public class SteamPlayerId : MeadowPlayerId
         {
             public CSteamID steamID;
@@ -111,7 +110,6 @@ namespace RainMeadow
         {
             creatingWithMode = gameMode;
             lobbyPassword = password;
-            maxLobbyCount = (int)maxPlayerCount;
             MAX_LOBBY = (int)maxPlayerCount;
             ELobbyType eLobbyTypeeLobbyType = visibility switch
             {
@@ -376,7 +374,7 @@ namespace RainMeadow
                     LeaveLobby();
                 }
 
-                OnlineManager.currentlyJoiningLobby = new LobbyInfo(param.m_steamIDLobby, "", "", 0,false, maxLobbyCount);
+                OnlineManager.currentlyJoiningLobby = new LobbyInfo(param.m_steamIDLobby, "", "", 0,false, MAX_LOBBY);
                 Custom.rainWorld.processManager.RequestMainProcessSwitch(RainMeadow.Ext_ProcessID.LobbySelectMenu);
 
                 m_JoinLobbyCall.Set(SteamMatchmaking.JoinLobby(param.m_steamIDLobby));

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -15,10 +15,10 @@ namespace RainMeadow
 
         public string[] mods = RainMeadowModManager.GetActiveMods();
         public static bool modsChecked;
-
+        public int? maxPlayerCount;
         public string? password;
         public bool hasPassword => password != null;
-        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password)
+        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password, int? maxPlayerCount)
         {
             this.super = this;
             OnlineManager.lobby = this; // needed for early entity processing
@@ -40,6 +40,8 @@ namespace RainMeadow
             {
                 RequestLobby(password);
             }
+
+            this.maxPlayerCount = maxPlayerCount;
         }
 
         public void RequestLobby(string? key)

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -15,10 +15,9 @@ namespace RainMeadow
 
         public string[] mods = RainMeadowModManager.GetActiveMods();
         public static bool modsChecked;
-        public int maxPlayerCount;
         public string? password;
         public bool hasPassword => password != null;
-        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password, int? maxPlayerCount)
+        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password)
         {
             this.super = this;
             OnlineManager.lobby = this; // needed for early entity processing
@@ -40,8 +39,6 @@ namespace RainMeadow
             {
                 RequestLobby(password);
             }
-
-            this.maxPlayerCount = (int)maxPlayerCount;
         }
 
         public void RequestLobby(string? key)

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -18,7 +18,7 @@ namespace RainMeadow
         public int maxPlayerCount;
         public string? password;
         public bool hasPassword => password != null;
-        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password, int maxPlayerCount)
+        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password, int? maxPlayerCount)
         {
             this.super = this;
             OnlineManager.lobby = this; // needed for early entity processing
@@ -41,7 +41,7 @@ namespace RainMeadow
                 RequestLobby(password);
             }
 
-            this.maxPlayerCount = maxPlayerCount;
+            this.maxPlayerCount = (int)maxPlayerCount;
         }
 
         public void RequestLobby(string? key)

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -15,10 +15,10 @@ namespace RainMeadow
 
         public string[] mods = RainMeadowModManager.GetActiveMods();
         public static bool modsChecked;
-        public int? maxPlayerCount;
+        public int maxPlayerCount;
         public string? password;
         public bool hasPassword => password != null;
-        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password, int? maxPlayerCount)
+        public Lobby(OnlineGameMode.OnlineGameModeType mode, OnlinePlayer owner, string? password, int maxPlayerCount)
         {
             this.super = this;
             OnlineManager.lobby = this; // needed for early entity processing

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -176,7 +176,7 @@ namespace RainMeadow
 #if LOCAL_P2P
                 if (!self.setup.startScreen)
                 {
-                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(LocalMatchmakingManager.localGameMode), OnlineManager.mePlayer,null);
+                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(LocalMatchmakingManager.localGameMode), OnlineManager.mePlayer, null, 4);
                 }
 #endif
             }

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -176,7 +176,7 @@ namespace RainMeadow
 #if LOCAL_P2P
                 if (!self.setup.startScreen)
                 {
-                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(LocalMatchmakingManager.localGameMode), OnlineManager.mePlayer, null, 4);
+                    OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(LocalMatchmakingManager.localGameMode), OnlineManager.mePlayer, null);
                 }
 #endif
             }


### PR DESCRIPTION
This adds a lobby limit as an option that is configurable in the Lobby select screen
- Within a minimum of 2 and a maximum of 32 players
- Adds a little text where it also tells the max of the lobby in the bottom right of lobby cards