### PR TITLE
vulture mask sync

### DIFF
--- a/GameModes/OnlineGameModeHelpers.cs
+++ b/GameModes/OnlineGameModeHelpers.cs
@@ -94,7 +94,7 @@ namespace RainMeadow
             PlacedObject.Type.BubbleGrass,
             PlacedObject.Type.Hazer,
             PlacedObject.Type.DeadHazer,
-            PlacedObject.Type.VultureMask,        //AbstractPhysicalObject Child MEDIUM
+            PlacedObject.Type.VultureMask,
             //PlacedObject.Type.HangingPearls,      //MSC?
             PlacedObject.Type.Lantern,
         };

--- a/GameModes/OnlineGameModeHelpers.cs
+++ b/GameModes/OnlineGameModeHelpers.cs
@@ -94,7 +94,7 @@ namespace RainMeadow
             PlacedObject.Type.BubbleGrass,
             PlacedObject.Type.Hazer,
             PlacedObject.Type.DeadHazer,
-            //PlacedObject.Type.VultureMask,        //AbstractPhysicalObject Child MEDIUM
+            PlacedObject.Type.VultureMask,        //AbstractPhysicalObject Child MEDIUM
             //PlacedObject.Type.HangingPearls,      //MSC?
             PlacedObject.Type.Lantern,
         };


### PR DESCRIPTION
Tested and checked, I think this item falls into the same category as a "rock" in terms of its properties requiring syncing. 

Two player in-game: P1 could grab the mask and wear it, P2 could pull the mask off P1 and wear it. Mask could be dropped. 

As this is my first item to sync I'm not sure if there's usually a 'tell' when it's not working but unless creature in-game behavior has to be synced (which I would think it wouldn't even be handled here), then this is working as I expect, hence my lack of changes.