### PR TITLE
draft: Settings sync

### DIFF
--- a/Online/RainMeadowModManager.cs
+++ b/Online/RainMeadowModManager.cs
@@ -48,15 +48,11 @@ namespace RainMeadow
 
         internal static void CheckSettings(List<FieldInfo> lobbySettings, List<FieldInfo> localSettings)
         {
-
-            foreach(FieldInfo field in localSettings)
+            if (Enumerable.SequenceEqual(lobbySettings, localSettings)) // null ref on lobby settings, data is not transferred
             {
-                RainMeadow.Debug("LOCAL SETTTINGS: " + field.Name);
+                RainMeadow.Debug("Game settings match!");
             }
-            foreach (FieldInfo field2 in lobbySettings) // Null ref, data is not coming through
-            {
-                RainMeadow.Debug("LOBBY SETTTINGS: " + field2.Name);
-            }
+            RainMeadow.Debug("Game settings DO NOT match!");
 
         }
 

--- a/Online/RainMeadowModManager.cs
+++ b/Online/RainMeadowModManager.cs
@@ -1,6 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using IL.MoreSlugcats;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using MoreSlugcats;
+using System.Reflection;
+using Mono.Cecil;
+using static RainMeadow.Lobby;
+using static RainMeadow.OnlineResource;
+using UnityEngine.UI;
+using UnityEngine;
 
 namespace RainMeadow
 {
@@ -10,6 +18,54 @@ namespace RainMeadow
         {
             return ModManager.ActiveMods.Where(mod => Directory.Exists(Path.Combine(mod.path, "modify", "world"))).ToList().Select(mod => mod.id.ToString()).ToArray();
         }
+
+        internal static List<FieldInfo> GetSettings()
+        {
+            List<FieldInfo> configurables = new List<FieldInfo>();
+
+            if (ModManager.MMF)
+            {
+                System.Type type = typeof(MoreSlugcats.MMF);
+
+                // Get all static fields of the type
+                FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Static);
+
+                // Filter and add fields of type Configurable<bool> to the list
+                foreach (FieldInfo field in fields)
+                {
+                    if (field.Name == "MOD_ID") continue;
+
+                    {
+                        RainMeadow.Debug("FIELD Name: " + field.Name);
+                        configurables.Add(field);
+                    }
+                }
+                return configurables;
+
+            }
+            return configurables;
+        }
+
+        internal static void CheckSettings(List<FieldInfo> lobbySettings, List<FieldInfo> localSettings)
+        {
+
+            foreach(FieldInfo field in localSettings)
+            {
+                RainMeadow.Debug("LOCAL SETTTINGS: " + field.Name);
+            }
+/*
+            [Error: RainMeadow] 23:30:59 | 11364 | OnlineManager.ProcessIncomingState:System.NullReferenceException: Object reference not set to an instance of an object
+  at RainMeadow.RainMeadowModManager.CheckSettings(System.Collections.Generic.List`1[T] lobbySettings, System.Collections.Generic.List`1[T] localSettings)[0x00050] in C: \Users\lol\source\repos\Rain - Meadow\Online\RainMeadowModManager.cs:52
+  at RainMeadow.Lobby + LobbyState.ReadTo(RainMeadow.OnlineResource resource)[0x00180] in C: \Users\lol\source\repos\Rain - Meadow\Online\Resource\Lobby.cs:204
+  at RainMeadow.OnlineResource.ReadState(RainMeadow.OnlineResource + ResourceState newState)[0x002eb] in C: \Users\lol\source\repos\Rain - Meadow\Online\Resource\OnlineResource.State.cs:64
+  at RainMeadow.OnlineManager.ProcessIncomingState(RainMeadow.OnlineState state)[0x00069] in C: \Users\lol\source\repos\Rain - Meadow\Online\OnlineManager.cs:233*/
+            foreach (FieldInfo field2 in lobbySettings)
+            {
+                RainMeadow.Debug("LOBBY SETTTINGS: " + field2.Name);
+            }
+
+        }
+
 
         internal static void CheckMods(string[] lobbyMods, string[] localMods)
         {

--- a/Online/RainMeadowModManager.cs
+++ b/Online/RainMeadowModManager.cs
@@ -53,13 +53,7 @@ namespace RainMeadow
             {
                 RainMeadow.Debug("LOCAL SETTTINGS: " + field.Name);
             }
-/*
-            [Error: RainMeadow] 23:30:59 | 11364 | OnlineManager.ProcessIncomingState:System.NullReferenceException: Object reference not set to an instance of an object
-  at RainMeadow.RainMeadowModManager.CheckSettings(System.Collections.Generic.List`1[T] lobbySettings, System.Collections.Generic.List`1[T] localSettings)[0x00050] in C: \Users\lol\source\repos\Rain - Meadow\Online\RainMeadowModManager.cs:52
-  at RainMeadow.Lobby + LobbyState.ReadTo(RainMeadow.OnlineResource resource)[0x00180] in C: \Users\lol\source\repos\Rain - Meadow\Online\Resource\Lobby.cs:204
-  at RainMeadow.OnlineResource.ReadState(RainMeadow.OnlineResource + ResourceState newState)[0x002eb] in C: \Users\lol\source\repos\Rain - Meadow\Online\Resource\OnlineResource.State.cs:64
-  at RainMeadow.OnlineManager.ProcessIncomingState(RainMeadow.OnlineState state)[0x00069] in C: \Users\lol\source\repos\Rain - Meadow\Online\OnlineManager.cs:233*/
-            foreach (FieldInfo field2 in lobbySettings)
+            foreach (FieldInfo field2 in lobbySettings) // Null ref, data is not coming through
             {
                 RainMeadow.Debug("LOBBY SETTTINGS: " + field2.Name);
             }

--- a/Online/RainMeadowModManager.cs
+++ b/Online/RainMeadowModManager.cs
@@ -27,10 +27,8 @@ namespace RainMeadow
             {
                 System.Type type = typeof(MoreSlugcats.MMF);
 
-                // Get all static fields of the type
                 FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Static);
 
-                // Filter and add fields of type Configurable<bool> to the list
                 foreach (FieldInfo field in fields)
                 {
                     if (field.Name == "MOD_ID") continue;

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using RainMeadow.Properties;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace RainMeadow
 {
@@ -14,6 +16,7 @@ namespace RainMeadow
         public Dictionary<OnlinePlayer, OnlineEntity.EntityId> playerAvatars = new(); // should maybe be in GameMode
 
         public string[] mods = RainMeadowModManager.GetActiveMods();
+        public List<FieldInfo> settings = RainMeadowModManager.GetSettings();
         public static bool modsChecked;
 
         public string? password;
@@ -163,6 +166,7 @@ namespace RainMeadow
             public Generics.AddRemoveSortedUshorts inLobbyIds;
             [OnlineField]
             public string[] mods;
+            public List<FieldInfo> settings;
             public LobbyState() : base() { }
             public LobbyState(Lobby lobby, uint ts) : base(lobby, ts)
             {
@@ -170,6 +174,8 @@ namespace RainMeadow
                 players = new(lobby.participants.Keys.Select(p => p.id).ToList());
                 inLobbyIds = new(lobby.participants.Keys.Select(p => p.inLobbyId).ToList());
                 mods = lobby.mods;
+                settings = lobby.settings;
+                
             }
 
             public override void ReadTo(OnlineResource resource)
@@ -195,7 +201,10 @@ namespace RainMeadow
                 {
                     modsChecked = true;
                     RainMeadowModManager.CheckMods(this.mods, lobby.mods);
+                    RainMeadowModManager.CheckSettings(this.settings, lobby.settings);
                 }
+
+
 
                 base.ReadTo(resource);
             }


### PR DESCRIPTION
Init for settings sync. Currently retrieves the remix settings and their values via reflection. 
![image](https://github.com/henpemaz/Rain-Meadow/assets/57415489/561858dd-88ed-4527-b1f3-5b19f88bef4c)


Issues however with sending that data over the wire 

![image](https://github.com/henpemaz/Rain-Meadow/assets/57415489/cc76b105-3bfc-4579-bf29-dda1e57a85f7)


```

            [Error: RainMeadow] 23:30:59 | 11364 | OnlineManager.ProcessIncomingState:System.NullReferenceException: Object reference not set to an instance of an object
  at RainMeadow.RainMeadowModManager.CheckSettings(System.Collections.Generic.List`1[T] lobbySettings, System.Collections.Generic.List`1[T] localSettings)[0x00050] in Rain - Meadow\Online\RainMeadowModManager.cs:52
  at RainMeadow.Lobby + LobbyState.ReadTo(RainMeadow.OnlineResource resource)[0x00180] in Rain - Meadow\Online\Resource\Lobby.cs:204
  at RainMeadow.OnlineResource.ReadState(RainMeadow.OnlineResource + ResourceState newState)[0x002eb] in Rain - Meadow\Online\Resource\OnlineResource.State.cs:64
  at RainMeadow.OnlineManager.ProcessIncomingState(RainMeadow.OnlineState state)[0x00069] in \Rain - Meadow\Online\OnlineManager.cs:233
```

need to investigate more. 

Also, it seems like the remix story data is technically accessed under MoreSlugcats hence the check for ModManager.MMF, kinda funky on how we should handle that one.