### PR TITLE
draft: Modlist sync

### DIFF
--- a/Online/OnlineManager.cs
+++ b/Online/OnlineManager.cs
@@ -41,6 +41,12 @@ namespace RainMeadow
             currentlyJoiningLobby = default;
             if (ok)
             {
+                if (OnlineManager.lobby.isOwner)
+                {
+                    manager.RequestMainProcessSwitch(lobby.gameMode.MenuProcessId());
+                }
+
+
                 if (!OnlineManager.lobby.isOwner) // clients must check mods at the door
                 {
                     var theirMods = OnlineManager.lobby.mods;
@@ -57,10 +63,7 @@ namespace RainMeadow
                         MatchmakingManager.instance.LeaveLobby();
                     }
                 }
-                if (OnlineManager.lobby.isOwner)
-                {
-                    manager.RequestMainProcessSwitch(lobby.gameMode.MenuProcessId());
-                }
+
             }
             else
             {

--- a/Online/RainMeadowModManager.cs
+++ b/Online/RainMeadowModManager.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using UnityEngine;
 
 namespace RainMeadow
 {
@@ -8,20 +10,35 @@ namespace RainMeadow
     {
         public static string[] GetActiveMods()
         {
-            var suffer = ModManager.ActiveMods.Select(mod => mod.id.ToString()).ToArray();
-            foreach (string mod in suffer)
+
+            var highImpactMods = ModManager.ActiveMods.Where(mod => Directory.Exists(Path.Combine(mod.path, "modify", "world"))).ToList().Select(mod => mod.id.ToString()).ToArray();
+
+            string remixModId = "rwremix"; // Add remix to high impact mods to manage game setting sync. 
+
+            var remixMod = ModManager.ActiveMods.Find(mod => mod.id == remixModId);
+
+            if (remixMod != null)
             {
-                RainMeadow.Debug("MY MODS:" + mod);
+
+                var highImpactModsList = highImpactMods.ToList();
+                highImpactModsList.Add(remixMod.id);
+                highImpactMods = highImpactModsList.ToArray();
+
+            } else
+            {
+                RainMeadow.Debug("Couldn't find rwremix");
             }
 
-            return ModManager.ActiveMods.Select(mod => mod.id.ToString()).ToArray();
+            return highImpactMods;
         }
 
-        internal static void CheckMods(string[] lobbyMods, string[] localMods)
+        internal static bool CheckMods(string[] lobbyMods, string[] localMods)
         {
-            if (Enumerable.SequenceEqual(localMods, lobbyMods))
+
+            if (!Enumerable.SequenceEqual(localMods, lobbyMods)) //change !
             {
                 RainMeadow.Debug("Same mod set !");
+                return true;
             }
             else
             {
@@ -36,6 +53,8 @@ namespace RainMeadow
                 List<string> unknownMods = new();
                 List<ModManager.Mod> modsToEnable = new();
                 List<ModManager.Mod> modsToDisable = new();
+                modsToDisable.Add(ModManager.ActiveMods.Find(mod => mod.id == "rwremix"));
+
 
                 foreach (var id in MissingMods)
                 {
@@ -64,12 +83,15 @@ namespace RainMeadow
 
                 ModApplier modApplyer = new(RWCustom.Custom.rainWorld.processManager, mods.ToList(), loadOrder);
 
-                modApplyer.ShowConfirmation(modsToEnable, modsToDisable, unknownMods);
-
-                modApplyer.OnFinish += (ModApplier modApplyer) =>
+                modApplyer.OnFinish += (ModApplier modApplyer) => // currently does not reconnect users to the lobby
                 {
                     Utils.Restart($"+connect_lobby {MatchmakingManager.instance.GetLobbyID()}");
+
                 };
+
+                return modApplyer.ShowConfirmation(modsToEnable, modsToDisable, unknownMods);
+
+
             }
         }
 

--- a/Online/RainMeadowModManager.cs
+++ b/Online/RainMeadowModManager.cs
@@ -35,7 +35,7 @@ namespace RainMeadow
         internal static bool CheckMods(string[] lobbyMods, string[] localMods)
         {
 
-            if (!Enumerable.SequenceEqual(localMods, lobbyMods)) //change !
+            if (Enumerable.SequenceEqual(localMods, lobbyMods)) //change !
             {
                 RainMeadow.Debug("Same mod set !");
                 return true;
@@ -53,7 +53,6 @@ namespace RainMeadow
                 List<string> unknownMods = new();
                 List<ModManager.Mod> modsToEnable = new();
                 List<ModManager.Mod> modsToDisable = new();
-                modsToDisable.Add(ModManager.ActiveMods.Find(mod => mod.id == "rwremix"));
 
 
                 foreach (var id in MissingMods)

--- a/Online/RainMeadowModManager.cs
+++ b/Online/RainMeadowModManager.cs
@@ -8,7 +8,13 @@ namespace RainMeadow
     {
         public static string[] GetActiveMods()
         {
-            return ModManager.ActiveMods.Where(mod => Directory.Exists(Path.Combine(mod.path, "modify", "world"))).ToList().Select(mod => mod.id.ToString()).ToArray();
+            var suffer = ModManager.ActiveMods.Select(mod => mod.id.ToString()).ToArray();
+            foreach (string mod in suffer)
+            {
+                RainMeadow.Debug("MY MODS:" + mod);
+            }
+
+            return ModManager.ActiveMods.Select(mod => mod.id.ToString()).ToArray();
         }
 
         internal static void CheckMods(string[] lobbyMods, string[] localMods)

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -14,7 +14,6 @@ namespace RainMeadow
         public Dictionary<OnlinePlayer, OnlineEntity.EntityId> playerAvatars = new(); // should maybe be in GameMode
 
         public string[] mods = RainMeadowModManager.GetActiveMods();
-        public static bool modsChecked;
 
         public string? password;
         public bool hasPassword => password != null;
@@ -162,14 +161,12 @@ namespace RainMeadow
             [OnlineField(nullable = true)]
             public Generics.AddRemoveSortedUshorts inLobbyIds;
             [OnlineField]
-            public string[] mods;
             public LobbyState() : base() { }
             public LobbyState(Lobby lobby, uint ts) : base(lobby, ts)
             {
                 nextId = lobby.nextId;
                 players = new(lobby.participants.Keys.Select(p => p.id).ToList());
                 inLobbyIds = new(lobby.participants.Keys.Select(p => p.inLobbyId).ToList());
-                mods = lobby.mods;
             }
 
             public override void ReadTo(OnlineResource resource)
@@ -190,13 +187,6 @@ namespace RainMeadow
                     }
                 }
                 lobby.UpdateParticipants(players.list.Select(MatchmakingManager.instance.GetPlayer).Where(p => p != null).ToList());
-
-                if (!modsChecked)
-                {
-                    modsChecked = true;
-                    RainMeadowModManager.CheckMods(this.mods, lobby.mods);
-                }
-
                 base.ReadTo(resource);
             }
         }

--- a/Utils/ModApplier.cs
+++ b/Utils/ModApplier.cs
@@ -50,17 +50,20 @@ namespace RainMeadow
             }
         }
 
-        public void ShowConfirmation(List<ModManager.Mod> modsToEnable, List<ModManager.Mod> modsToDisable, List<string> unknownMods)
+        public bool ShowConfirmation(List<ModManager.Mod> modsToEnable, List<ModManager.Mod> modsToDisable, List<string> unknownMods)
         {
-            string text = "Mod mismatch detected" + Environment.NewLine;
+            string text = "Mod mismatch detected." + Environment.NewLine;
 
             if (modsToEnable.Count > 0) text += Environment.NewLine + "Mods that will be enabled: " + string.Join(", ", modsToEnable.ConvertAll(mod => mod.LocalizedName));
             if (modsToDisable.Count > 0) text += Environment.NewLine + "Mods that will be disabled: " + string.Join(", ", modsToDisable.ConvertAll(mod => mod.LocalizedName));
             if (unknownMods.Count > 0) text += Environment.NewLine + "Unable to find those mods, please install them: " + string.Join(", ", unknownMods);
 
+            text += Environment.NewLine + Environment.NewLine + "Rain World will be restarted for these changes to take effect";
+
             requiresRestartDialog = new DialogNotify(text, new Vector2(480f, 320f), manager, () => { Start(false); });
             
             manager.ShowDialog(requiresRestartDialog);
+            return false;
         }
 
         public new void Start(bool filesInBadState)
@@ -71,10 +74,6 @@ namespace RainMeadow
                 manager.ShowNextDialog();
                 requiresRestartDialog = null;
             }
-
-            dialogBox = new DialogAsyncWait(menu, "Applying mods...", new Vector2(480f, 320f));
-
-            manager.ShowDialog(dialogBox);
 
             base.Start(filesInBadState);
         }

--- a/Utils/ModApplier.cs
+++ b/Utils/ModApplier.cs
@@ -10,6 +10,8 @@ namespace RainMeadow
         public DialogAsyncWait dialogBox;
         public DialogNotify requiresRestartDialog;
         private readonly Menu.Menu menu;
+        private List<ModManager.Mod> modsToEnable;
+        private List<ModManager.Mod> modsToDisable;
 
         public event Action<ModApplier> OnFinish;
 
@@ -54,14 +56,27 @@ namespace RainMeadow
         {
             string text = "Mod mismatch detected." + Environment.NewLine;
 
-            if (modsToEnable.Count > 0) text += Environment.NewLine + "Mods that will be enabled: " + string.Join(", ", modsToEnable.ConvertAll(mod => mod.LocalizedName));
-            if (modsToDisable.Count > 0) text += Environment.NewLine + "Mods that will be disabled: " + string.Join(", ", modsToDisable.ConvertAll(mod => mod.LocalizedName));
-            if (unknownMods.Count > 0) text += Environment.NewLine + "Unable to find those mods, please install them: " + string.Join(", ", unknownMods);
+            if (modsToEnable.Count > 0)
+            {
+                text += Environment.NewLine + "Mods that will be enabled: " + string.Join(", ", modsToEnable.ConvertAll(mod => mod.LocalizedName));
+                this.modsToEnable = modsToEnable;
+            }
+            if (modsToDisable.Count > 0)
+            {
+                text += Environment.NewLine + "Mods that will be disabled: " + string.Join(", ", modsToDisable.ConvertAll(mod => mod.LocalizedName));
+            }   this.modsToDisable = modsToDisable;
+            if (unknownMods.Count > 0)
+            {
+                text += Environment.NewLine + "Unable to find those mods, please install them: " + string.Join(", ", unknownMods);
+            }
 
             text += Environment.NewLine + Environment.NewLine + "Rain World will be restarted for these changes to take effect";
 
-            requiresRestartDialog = new DialogNotify(text, new Vector2(480f, 320f), manager, () => { Start(false); });
-            
+            requiresRestartDialog = new DialogNotify(text, new Vector2(480f, 320f), manager, () =>
+            {
+                Start(false);
+            });
+
             manager.ShowDialog(requiresRestartDialog);
             return false;
         }
@@ -73,6 +88,17 @@ namespace RainMeadow
                 manager.dialog = null;
                 manager.ShowNextDialog();
                 requiresRestartDialog = null;
+            }
+
+            foreach(ModManager.Mod mod in this.modsToDisable)
+            {
+                ModManager.ActiveMods.Remove(mod);
+                RainMeadow.Debug($"Disabled mod: {mod.name}");
+            }
+            foreach(ModManager.Mod mod in this.modsToEnable)
+            {
+                ModManager.ActiveMods.Add(mod);
+                RainMeadow.Debug($"Enabled mod: {mod.name}");
             }
 
             base.Start(filesInBadState);


### PR DESCRIPTION
For syncing mods so we can sync settings so we can sync gameplay  *wipes away sweat*

Currently still need to test with a real person:
1. Are mods disabled from this logic
2. Are mods enabled

LobbyState used to pass the lobby.mods data down into its ReadTo which is where the mod check initially occurred.

This, however, was kind of funky and didn't allow the user to interact with the dialog box since the process manager had moved on. 

I removed the mod data from LobbyState and just passed the check into OnlineManager on a lobby request join so if "OK" then as a client we do a mod check. 

This was to:
1. Make it scalable across game modes (assuming @henpemaz wanted mod support in Meadow)
2. Keep the user journey consistent. The user sees an attempt to join a lobby and then the return to the lobby select on mod mismatch failure, which is exactly what I'd expect to occur as a user (versus behaviors like hitting the storymenu and then getting booted). 

Optimization opportunites:
- I think we could support users inputting more 'required mods' as a config option in the meadow remix selection menu semi-colon separated or some other parsing mechanism to enable mod req scalability. However, I also think that the current implementation is sufficient because the required mods are the ones that we have deemed to be game-breaking so if a user wanted to require mods, I would think they would also be game-breaking and thus be caught by our catch-all. 


Below is the current user-flow behavior (though I faked the mod mismatch for localhost reasons). 

https://github.com/henpemaz/Rain-Meadow/assets/57415489/ad60872b-2abe-4628-93db-860609a9f583

