### PR TITLE
Draft: bare minimum for generic hud between modes

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1,0 +1,25 @@
+﻿using RainMeadow;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace RainMeadow
+{
+    public partial class RainMeadow
+    {
+        public static bool isArenaMode(out ArenaCompetitiveGameMode gameMode)
+        {
+            gameMode = null;
+            if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is ArenaCompetitiveGameMode arena)
+            {
+                gameMode = arena;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -184,7 +184,7 @@ namespace RainMeadow
                 saveStateNumber = OnlineManager.lobby.gameMode.GetStorySessionPlayer(game);
                 if (isStoryMode(out var story))
                 {
-                    story.storyClientSettings.inGame = true;
+                    story.clientSettings.inGame = true;
                     story.storyClientSettings.isDead = false;
                 }
             }

--- a/GameModes/ArenaClientSettings.cs
+++ b/GameModes/ArenaClientSettings.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace RainMeadow
 {
-    public class StoryClientSettings : ClientSettings
+    public class ArenaClientSettings : ClientSettings
     {
         public class Definition : ClientSettings.Definition
         {
@@ -13,27 +13,25 @@ namespace RainMeadow
 
             public override OnlineEntity MakeEntity(OnlineResource inResource)
             {
-                return new StoryClientSettings(this);
+                return new ArenaClientSettings(this);
             }
         }
 
         public Color bodyColor;
-        public Color eyeColor; // unused
-        public SlugcatStats.Name? playingAs;
-        public bool readyForWin;
-        public string? myLastDenPos = null;
-        public bool isDead;
+        public Color eyeColor;
 
-        public StoryClientSettings(Definition entityDefinition) : base(entityDefinition)
+
+        public ArenaClientSettings(Definition entityDefinition) : base(entityDefinition)
         {
             RainMeadow.Debug(this);
-            bodyColor = entityDefinition.owner == 2 ? Color.cyan : PlayerGraphics.DefaultSlugcatColor(playingAs);
+            bodyColor = entityDefinition.owner == 2 ? Color.cyan : PlayerGraphics.DefaultSlugcatColor(SlugcatStats.Name.Yellow);
             eyeColor = Color.black;
+
         }
 
         internal override AvatarCustomization MakeCustomization()
         {
-            return new SlugcatCustomization(this);
+            return new ArenaAvatarCustomization(this);
         }
 
         protected override EntityState MakeState(uint tick, OnlineResource inResource)
@@ -52,43 +50,29 @@ namespace RainMeadow
             public Color bodyColor;
             [OnlineFieldColorRgb]
             public Color eyeColor;
-            [OnlineField(nullable = true)]
-            public string? playingAs;
-            [OnlineField(group = "game")]
-            public bool readyForWin;
-
-            [OnlineField(group = "game")]
-            public bool isDead;
 
             public State() { }
-            public State(StoryClientSettings onlineEntity, OnlineResource inResource, uint ts) : base(onlineEntity, inResource, ts)
+            public State(ArenaClientSettings onlineEntity, OnlineResource inResource, uint ts) : base(onlineEntity, inResource, ts)
             {
                 bodyColor = onlineEntity.bodyColor;
                 eyeColor = onlineEntity.eyeColor;
-                playingAs = onlineEntity.playingAs?.value;
-                readyForWin = onlineEntity.readyForWin;
-                isDead = onlineEntity.isDead;
+
             }
 
             public override void ReadTo(OnlineEntity onlineEntity)
             {
                 base.ReadTo(onlineEntity);
-                var avatarSettings = (StoryClientSettings)onlineEntity;
+                var avatarSettings = (ArenaClientSettings)onlineEntity;
                 avatarSettings.bodyColor = bodyColor;
                 avatarSettings.eyeColor = eyeColor;
-                if (playingAs != null) {
-                    ExtEnumBase.TryParse(typeof(SlugcatStats.Name), playingAs, false, out var rawEnumBase);
-                    avatarSettings.playingAs = rawEnumBase as SlugcatStats.Name;
-                }
-                avatarSettings.readyForWin = readyForWin;
-                avatarSettings.isDead = isDead;
+
             }
         }
-        public class SlugcatCustomization : AvatarCustomization
+        public class ArenaAvatarCustomization : AvatarCustomization
         {
-            public readonly StoryClientSettings settings;
+            public readonly ArenaClientSettings settings;
 
-            public SlugcatCustomization(StoryClientSettings slugcatAvatarSettings)
+            public ArenaAvatarCustomization(ArenaClientSettings slugcatAvatarSettings)
             {
                 this.settings = slugcatAvatarSettings;
             }

--- a/GameModes/ClientSettings.cs
+++ b/GameModes/ClientSettings.cs
@@ -2,6 +2,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using UnityEngine;
+using static RainMeadow.OnlineState;
 
 namespace RainMeadow
 {
@@ -17,7 +18,7 @@ namespace RainMeadow
         /// the real avatar of the player
         /// </summary>
         public OnlineEntity.EntityId avatarId;
-
+        public bool inGame;
         public ClientSettings(EntityDefinition entityDefinition) : base(entityDefinition)
         {
             avatarId = new OnlineEntity.EntityId(entityDefinition.owner, OnlineEntity.EntityId.IdType.none, 0);
@@ -36,18 +37,24 @@ namespace RainMeadow
         {
             [OnlineField(nullable:true)]
             private EntityId avatarId;
+            [OnlineField(group = "game")]
+            private bool inGame;
 
             protected State() { }
 
             protected State(ClientSettings clientSettings, OnlineResource inResource, uint ts) : base(clientSettings, inResource, ts)
             {
                 this.avatarId = clientSettings.avatarId;
+                this.inGame = clientSettings.inGame;
+
             }
 
             public override void ReadTo(OnlineEntity onlineEntity)
             {
                 base.ReadTo(onlineEntity);
                 (onlineEntity as ClientSettings).avatarId = avatarId;
+                (onlineEntity as ClientSettings).inGame = inGame;
+
             }
         }
     }

--- a/Story/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/Story/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -17,6 +17,7 @@ namespace RainMeadow
         public float lastBlink;
         public bool switchedToDeathIcon;
         private bool isButtonToggled;
+        public Color drawColor;
 
 
         public OnlinePlayerDisplay(PlayerSpecificOnlineHud owner) : base(owner)
@@ -31,18 +32,67 @@ namespace RainMeadow
             this.gradient.alpha = 0f;
             this.gradient.x = -1000f;
             this.label = new FLabel(Custom.GetFont(), owner.clientSettings.owner.id.name);
-            this.label.color = owner.clientSettings.SlugcatColor();
+            if (RainMeadow.isArenaMode(out var _))
+            {
+
+                this.label.color = (owner.clientSettings as ArenaClientSettings).SlugcatColor();
+
+            }
+            else if (RainMeadow.isStoryMode(out var _))
+            {
+
+                this.label.color = (owner.clientSettings as StoryClientSettings).SlugcatColor();
+
+            }
+            else
+            {
+                this.label.color = Color.white;
+
+            }
             owner.hud.fContainers[0].AddChild(this.label);
             this.label.alpha = 0f;
             this.label.x = -1000f;
             this.arrowSprite = new FSprite("Multiplayer_Arrow", true);
-            this.arrowSprite.color = owner.clientSettings.SlugcatColor();
+            if (RainMeadow.isArenaMode(out var _))
+            {
+
+                this.arrowSprite.color = (owner.clientSettings as ArenaClientSettings).SlugcatColor();
+
+            }
+            else if (RainMeadow.isStoryMode(out var _))
+            {
+
+                this.arrowSprite.color = (owner.clientSettings as StoryClientSettings).SlugcatColor();
+
+            }
+            else
+            {
+                this.arrowSprite.color = Color.white;
+
+            }
             owner.hud.fContainers[0].AddChild(this.arrowSprite);
             this.arrowSprite.alpha = 0f;
             this.arrowSprite.x = -1000f;
 
             this.slugIcon = new FSprite("Kill_Slugcat", true);
-            this.slugIcon.color = owner.clientSettings.SlugcatColor();
+            if (RainMeadow.isArenaMode(out var _))
+            {
+
+                this.slugIcon.color = (owner.clientSettings as ArenaClientSettings).SlugcatColor();
+
+            }
+            else if (RainMeadow.isStoryMode(out var _))
+            {
+
+                this.slugIcon.color = (owner.clientSettings as StoryClientSettings).SlugcatColor();
+
+            }
+            else
+            {
+                this.slugIcon.color = Color.white;
+
+            }
+
             owner.hud.fContainers[0].AddChild(this.slugIcon);
             this.slugIcon.alpha = 0f;
             this.slugIcon.x = -1000f;
@@ -117,19 +167,35 @@ namespace RainMeadow
 
             this.label.x = vector.x;
             this.label.y = vector.y + 20f;
-            Color color = owner.clientSettings.SlugcatColor();
+            if (RainMeadow.isArenaMode(out var _))
+            {
+
+                this.drawColor = (owner.clientSettings as ArenaClientSettings).SlugcatColor();
+
+            }
+            else if (RainMeadow.isStoryMode(out var _))
+            {
+
+                this.drawColor = (owner.clientSettings as StoryClientSettings).SlugcatColor();
+
+            }
+            else
+            {
+                this.drawColor = Color.white;
+
+            }
             if (this.counter % 6 < 2 && this.lastBlink > 0f)
             {
-                if (((Vector3)(Vector4)color).magnitude > 1.56f)
+                if (((Vector3)(Vector4)drawColor).magnitude > 1.56f)
                 {
-                    color = Color.Lerp(color, new Color(0.9f, 0.9f, 0.9f), Mathf.InverseLerp(0f, 0.5f, Mathf.Lerp(this.lastBlink, this.blink, timeStacker)));
+                    drawColor = Color.Lerp(drawColor, new Color(0.9f, 0.9f, 0.9f), Mathf.InverseLerp(0f, 0.5f, Mathf.Lerp(this.lastBlink, this.blink, timeStacker)));
                 }
                 else
                 {
-                    color = Color.Lerp(color, new Color(1f, 1f, 1f), Mathf.InverseLerp(0f, 0.5f, Mathf.Lerp(this.lastBlink, this.blink, timeStacker)));
+                    drawColor = Color.Lerp(drawColor, new Color(1f, 1f, 1f), Mathf.InverseLerp(0f, 0.5f, Mathf.Lerp(this.lastBlink, this.blink, timeStacker)));
                 }
             }
-            var lighter_color = color * 1.7f;
+            var lighter_color = drawColor * 1.7f;
 
             this.label.color = lighter_color;
             this.arrowSprite.color = lighter_color;

--- a/Story/OnlineUIComponents/OnlineStoryHud.cs
+++ b/Story/OnlineUIComponents/OnlineStoryHud.cs
@@ -6,23 +6,23 @@ using HarmonyLib;
 
 namespace RainMeadow
 {
-    public class OnlineStoryHud : HudPart
+    public class OnlineHud : HudPart
     {
         private List<PlayerSpecificOnlineHud> indicators = new();
 
         private RoomCamera camera;
-        private readonly StoryGameMode storyGameMode;
+        private readonly OnlineGameMode onlineGameMode;
 
-        public OnlineStoryHud(HUD.HUD hud, RoomCamera camera, StoryGameMode storyGameMode) : base(hud)
+        public OnlineHud(HUD.HUD hud, RoomCamera camera, OnlineGameMode onlineGameMode) : base(hud)
         {
             this.camera = camera;
-            this.storyGameMode = storyGameMode;
+            this.onlineGameMode = onlineGameMode;
             UpdatePlayers();
         }
 
         public void UpdatePlayers()
         {
-            List<StoryClientSettings> clientSettings = OnlineManager.lobby.clientSettings.Values.OfType<StoryClientSettings>().ToList();
+            List<ClientSettings> clientSettings = OnlineManager.lobby.clientSettings.Values.OfType<ClientSettings>().ToList();
             var currentSettings = indicators.Select(i => i.clientSettings);
 
             clientSettings.Except(currentSettings).Do(PlayerAdded); 
@@ -30,15 +30,15 @@ namespace RainMeadow
 
         }
 
-        public void PlayerAdded(StoryClientSettings clientSettings)
+        public void PlayerAdded(ClientSettings clientSettings)
         {
             RainMeadow.DebugMe();
-            PlayerSpecificOnlineHud indicator = new PlayerSpecificOnlineHud(hud, camera, storyGameMode, clientSettings);
+            PlayerSpecificOnlineHud indicator = new PlayerSpecificOnlineHud(hud, camera, onlineGameMode, clientSettings);
             this.indicators.Add(indicator);
             hud.AddPart(indicator);
         }
 
-        public void PlayerRemoved(StoryClientSettings clientSettings)
+        public void PlayerRemoved(ClientSettings clientSettings)
         {
             RainMeadow.DebugMe();
             var indicator = this.indicators.First(i => i.clientSettings == clientSettings);

--- a/Story/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/Story/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -6,8 +6,8 @@ namespace RainMeadow
 {
     public class PlayerSpecificOnlineHud : HudPart
     {
-        public StoryGameMode storyGameMode;
-        public StoryClientSettings clientSettings;
+        public OnlineGameMode onlineGameMode;
+        public ClientSettings clientSettings;
 
         public AbstractCreature abstractPlayer;
         public OnlinePlayerDisplay playerDisplay;
@@ -37,12 +37,12 @@ namespace RainMeadow
             }
         }
 
-        public PlayerSpecificOnlineHud(HUD.HUD hud, RoomCamera camera, StoryGameMode storyGameMode, StoryClientSettings clientSettings) : base(hud)
+        public PlayerSpecificOnlineHud(HUD.HUD hud, RoomCamera camera, OnlineGameMode onlineGameMode, ClientSettings clientSettings) : base(hud)
         {
             RainMeadow.Debug("Adding PlayerSpecificOnlineHud for " + clientSettings.owner);
             this.camera = camera;
             camrect = new Rect(Vector2.zero, this.camera.sSize).CloneWithExpansion(-30f);
-            this.storyGameMode = storyGameMode;
+            this.onlineGameMode = onlineGameMode;
             this.clientSettings = clientSettings;
 
             this.playerDisplay = new OnlinePlayerDisplay(this);

--- a/Story/RainMeadow.StoryHooks.cs
+++ b/Story/RainMeadow.StoryHooks.cs
@@ -325,7 +325,7 @@ namespace RainMeadow
             orig(self, cam);
             if (isStoryMode(out var gameMode))
             {
-                self.AddPart(new OnlineStoryHud(self, cam, gameMode));
+                self.AddPart(new OnlineHud(self, cam, gameMode));
             }
         }
         private void RainWorldGame_GhostShutDown(On.RainWorldGame.orig_GhostShutDown orig, RainWorldGame self, GhostWorldPresence.GhostID ghostID)
@@ -538,7 +538,7 @@ namespace RainMeadow
 
                 }
 
-                self.room.game.cameras[0].hud.parts.Add(new OnlineStoryHud(self.room.game.cameras[0].hud, self.room.game.cameras[0], storyGameMode));
+                self.room.game.cameras[0].hud.parts.Add(new OnlineHud(self.room.game.cameras[0].hud, self.room.game.cameras[0], storyGameMode));
 
                 return true;
             }
@@ -603,7 +603,7 @@ namespace RainMeadow
 
                 foreach (HudPart part in self.room.game.cameras[0].hud.parts)
                 {
-                    if (part is OnlineStoryHud || part is PlayerSpecificOnlineHud)
+                    if (part is OnlineHud || part is PlayerSpecificOnlineHud)
                     {
 
                         partsToRemove.Add(part);


### PR DESCRIPTION
This adds some basic Arena files in preparation for the larger changes coming between myself and @Silvyger  have done. 

Makes the online hud generic across game modes (useful for arena as pictured):

![image](https://github.com/henpemaz/Rain-Meadow/assets/57415489/ed244343-47a0-4896-8a69-aeba8f5a46c0)


