### PR TITLE
Sync spear lifetimes

### DIFF
--- a/Online/State/RealizedSpearState.cs
+++ b/Online/State/RealizedSpearState.cs
@@ -17,12 +17,15 @@ namespace RainMeadow
         private sbyte stuckBodyPart;
         [OnlineField(group = "spear")]
         private float stuckRotation;
+        [OnlineField(group = "spear")]
+        private int stuckInWallCycles;
 
         public RealizedSpearState() { }
         public RealizedSpearState(OnlinePhysicalObject onlineEntity) : base(onlineEntity)
         {
             var spear = (Spear)onlineEntity.apo.realizedObject;
             stuckInWall = spear.stuckInWall;
+            stuckInWallCycles = spear.abstractSpear.stuckInWallCycles;
 
             if (spear.stuckInObject != null)
             {
@@ -52,6 +55,7 @@ namespace RainMeadow
             if (!onlineEntity.owner.isMe && onlineEntity.isPending) return; // Don't sync if pending, reduces visibility and effect of lag
             var spear = (Spear)((OnlinePhysicalObject)onlineEntity).apo.realizedObject;
             spear.stuckInWall = stuckInWall;
+            spear.abstractSpear.stuckInWallCycles = stuckInWallCycles;
             if (!stuckInWall.HasValue)
                 spear.addPoles = false;
 


### PR DESCRIPTION
track spear lifetime in `RealizedSpearState`

bugs (needs testing):
- spear sprites can sometimes appear behind player (does this happen with jolly co-op?)
- plays the wrong sound when downspearing (might not be due to this change, could be a separate issue?)

closes #199 