### PR TITLE
story mode: client continue button to wait for host

### DIFF
--- a/Story/RainMeadow.StoryHooks.cs
+++ b/Story/RainMeadow.StoryHooks.cs
@@ -484,22 +484,29 @@ namespace RainMeadow
         {
             orig(self);
 
-            if (isStoryMode(out var gameMode) && !OnlineManager.lobby.isOwner)
+            if (isStoryMode(out var gameMode))
             {
-                if (gameMode.didStartCycle)
+                if (OnlineManager.lobby.isOwner)
                 {
-                    if (isPlayerReady)
+                    self.continueButton.buttonBehav.greyedOut = OnlineManager.lobby.clientSettings.Values.Any(cs => cs.inGame);
+                }
+                else
+                {
+                    if (gameMode.didStartCycle)
                     {
-                        self.Singal(self.continueButton, "CONTINUE");
+                        if (isPlayerReady)
+                        {
+                            self.Singal(self.continueButton, "CONTINUE");
+                        }
+                        else if (self.continueButton != null)
+                        {
+                            self.continueButton.menuLabel.text = self.Translate("CONTINUE");
+                        }
                     }
                     else if (self.continueButton != null)
                     {
-                        self.continueButton.menuLabel.text = self.Translate("CONTINUE");
+                        self.continueButton.menuLabel.text = self.Translate("READY");
                     }
-                }
-                else if (self.continueButton != null)
-                {
-                    self.continueButton.menuLabel.text = self.Translate("READY");
                 }
             }
         }

--- a/Story/RainMeadow.StoryHooks.cs
+++ b/Story/RainMeadow.StoryHooks.cs
@@ -484,13 +484,22 @@ namespace RainMeadow
         {
             orig(self);
 
-            if (isStoryMode(out var gameMode))
+            if (isStoryMode(out var gameMode) && !OnlineManager.lobby.isOwner)
             {
-                if (isPlayerReady && gameMode.didStartCycle)
+                if (gameMode.didStartCycle)
                 {
-                    // HACK: doesn't seem like sender is ever used but still
-                    // maybe we could replay the sender of the intercepted CONTINUE signal?
-                    self.Singal(null, "CONTINUE");
+                    if (isPlayerReady)
+                    {
+                        self.Singal(self.continueButton, "CONTINUE");
+                    }
+                    else if (self.continueButton != null)
+                    {
+                        self.continueButton.menuLabel.text = self.Translate("CONTINUE");
+                    }
+                }
+                else if (self.continueButton != null)
+                {
+                    self.continueButton.menuLabel.text = self.Translate("READY");
                 }
             }
         }

--- a/Story/RainMeadow.StoryHooks.cs
+++ b/Story/RainMeadow.StoryHooks.cs
@@ -436,8 +436,9 @@ namespace RainMeadow
                     }
                     else if (!gameMode.didStartCycle)
                     {
-                        RainMeadow.Debug("Ready!");
-                        isPlayerReady = true;
+                        sender.toggled = !sender.toggled;
+                        isPlayerReady = sender.toggled;
+                        RainMeadow.Debug(sender.toggled ? "Ready!" : "Cancelled!");
                         return;
                     }
                     RainMeadow.Debug("Continue - client");


### PR DESCRIPTION
allows clients to press continue before the host is ready, then auto-join once the host has continued

would like the client's continue button to be toggleable (and also renamed to ready?) but not sure how to do that ui-wise

UPDATE: implemented both

[video demo here](https://discord.com/channels/1094716194180841602/1094730322911952917/1280088742530387969)