### PR TITLE
adds access for clients to access pause menu while dead.

### DIFF
--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -71,15 +71,15 @@ namespace RainMeadow
 
         private void TextPrompt_UpdateGameOverString(On.HUD.TextPrompt.orig_UpdateGameOverString orig, TextPrompt self, Options.ControlSetup.Preset controllerType)
         {
-            if (isStoryMode(out var storyGameMode))
+            if (isStoryMode(out var _))
             {
                 if (OnlineManager.lobby.isOwner)
                 {
-                    self.gameOverString = "A slugcat has fallen. Perform a rescue, shelter, or press PAUSE BUTTON to restart";
+                    self.gameOverString = $"A slugcat has fallen. Perform a rescue, shelter, press  {RainMeadow.rainMeadowOptions.SpectatorKey.Value} to spectate, or press PAUSE BUTTON to restart";
                 }
                 else
                 {
-                    self.gameOverString = $"A slugcat has fallen. Perform a rescue, shelter, or press";
+                    self.gameOverString = $"A slugcat has fallen. Perform a rescue, shelter, or press {RainMeadow.rainMeadowOptions.SpectatorKey.Value} to spectate";
                 }
             }
 
@@ -92,7 +92,7 @@ namespace RainMeadow
         private void TextPrompt_Update(On.HUD.TextPrompt.orig_Update orig, TextPrompt self)
         {
             orig(self);
-            if (isStoryMode(out var storyGameMode))
+            if (isStoryMode(out var _))
             {
                 if (!OnlineManager.lobby.isOwner && self.currentlyShowing == TextPrompt.InfoID.GameOver)
                 {
@@ -102,7 +102,7 @@ namespace RainMeadow
                     // let clients still have access to pause menu
                     for (int j = 0; j < self.hud.rainWorld.options.controls.Length; j++)
                     {
-                        touchedInput = ((self.hud.rainWorld.options.controls[j].gamePad || !self.defaultMapControls[j]) ? (touchedInput || self.hud.rainWorld.options.controls[j].GetButton(5) || RWInput.CheckPauseButton(0, inMenu: false)) : (touchedInput || self.hud.rainWorld.options.controls[j].GetButton(11)));
+                        touchedInput = (self.hud.rainWorld.options.controls[j].gamePad || !self.defaultMapControls[j]) ? (touchedInput || self.hud.rainWorld.options.controls[j].GetButton(5) || RWInput.CheckPauseButton(0, inMenu: false)) : (touchedInput || self.hud.rainWorld.options.controls[j].GetButton(11));
                     }
                     if (touchedInput)
                     {

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -88,7 +88,17 @@ namespace RainMeadow
                 if (!OnlineManager.lobby.isOwner && self.currentlyShowing == TextPrompt.InfoID.GameOver)
                 {
                     self.restartNotAllowed = 1; // block clients from GoToDeathScreen
-                }
+                    bool touchedInput = false;
+
+                    // let clients still have access to pause menu
+                    for (int j = 0; j < self.hud.rainWorld.options.controls.Length; j++)
+                    {
+                        touchedInput = ((self.hud.rainWorld.options.controls[j].gamePad || !self.defaultMapControls[j]) ? (touchedInput || self.hud.rainWorld.options.controls[j].GetButton(5) || RWInput.CheckPauseButton(0, inMenu: false)) : (touchedInput || self.hud.rainWorld.options.controls[j].GetButton(11)));
+                    }
+                    if (touchedInput)
+                    {
+                        self.gameOverMode = false;
+                    }
             }
         }
 

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -79,9 +79,10 @@ namespace RainMeadow
                 }
                 else
                 {
-                    self.gameOverString = "A slugcat has fallen. Perform a rescue, or wait for host to shelter or die";
+                    self.gameOverString = $"A slugcat has fallen. Perform a rescue, shelter, or press";
                 }
             }
+
             else
             {
                 orig(self, controllerType);
@@ -107,246 +108,247 @@ namespace RainMeadow
                     {
                         self.gameOverMode = false;
                     }
-            }
-        }
-
-        private void SSOracleSwarmer_NewRoom(On.SSOracleSwarmer.orig_NewRoom orig, SSOracleSwarmer self, Room newRoom)
-        {
-            if (OnlineManager.lobby == null)
-            {
-                orig(self, newRoom);
-                return;
-            }
-
-            if (!ModManager.MSC)
-            {
-                newRoom.abstractRoom.AddEntity(self.abstractPhysicalObject);
-            }
-        }
-
-        //Only spawn if we own the room
-        private void OnCoralNeuronSystem_PlaceSwarmers(On.CoralBrain.CoralNeuronSystem.orig_PlaceSwarmers orig, CoralBrain.CoralNeuronSystem self)
-        {
-            if (OnlineManager.lobby == null)
-            {
-                orig(self);
-                return;
-            }
-            RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
-            if (room.isOwner)
-            {
-                orig(self);
-            }
-        }
-
-
-        private void SLOracleSwarmer_BitByPlayer(On.SLOracleSwarmer.orig_BitByPlayer orig, SLOracleSwarmer self, Creature.Grasp grasp, bool eu)
-        {
-            orig(self, grasp, eu);
-            if (self.slatedForDeletetion == true)
-            {
-                SwarmerEaten();
-            }
-        }
-
-        private void OracleSwarmer_BitByPlayer(On.OracleSwarmer.orig_BitByPlayer orig, OracleSwarmer self, Creature.Grasp grasp, bool eu)
-        {
-            orig(self, grasp, eu);
-            if (self.slatedForDeletetion == true)
-            {
-                SwarmerEaten();
-            }
-        }
-
-        private void SwarmerEaten()
-        {
-            if (OnlineManager.lobby == null) return;
-            if (!OnlineManager.lobby.isOwner && OnlineManager.lobby.gameMode is StoryGameMode)
-            {
-                if (!OnlineManager.lobby.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(ConsumableRPCs.enableTheGlow)))
-                {
-                    OnlineManager.lobby.owner.InvokeRPC(ConsumableRPCs.enableTheGlow);
                 }
             }
         }
 
-        private void Oracle_SetUpSwarmers(On.Oracle.orig_SetUpSwarmers orig, Oracle self)
-        {
-            if (OnlineManager.lobby == null)
+            private void SSOracleSwarmer_NewRoom(On.SSOracleSwarmer.orig_NewRoom orig, SSOracleSwarmer self, Room newRoom)
             {
-                orig(self);
-                return;
-            }
-
-            RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
-            if (room.isOwner)
-            {
-                orig(self); //Only setup the room if we are the room owner.
-                foreach (var swamer in self.mySwarmers)
+                if (OnlineManager.lobby == null)
                 {
-                    var apo = swamer.abstractPhysicalObject;
-                    self.room.world.GetResource().ApoEnteringWorld(apo);
-                    self.room.abstractRoom.GetResource().ApoEnteringRoom(apo, apo.pos);
+                    orig(self, newRoom);
+                    return;
+                }
+
+                if (!ModManager.MSC)
+                {
+                    newRoom.abstractRoom.AddEntity(self.abstractPhysicalObject);
                 }
             }
-        }
 
-        private void PuffBall_Explode(On.PuffBall.orig_Explode orig, PuffBall self)
-        {
-            if (OnlineManager.lobby == null)
+            //Only spawn if we own the room
+            private void OnCoralNeuronSystem_PlaceSwarmers(On.CoralBrain.CoralNeuronSystem.orig_PlaceSwarmers orig, CoralBrain.CoralNeuronSystem self)
             {
-                orig(self);
-                return;
+                if (OnlineManager.lobby == null)
+                {
+                    orig(self);
+                    return;
+                }
+                RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
+                if (room.isOwner)
+                {
+                    orig(self);
+                }
             }
 
-            RoomSession.map.TryGetValue(self.room.abstractRoom, out var onlineRoom);
-            OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var onlineSporePlant);
 
-            if (onlineSporePlant.isMine)
+            private void SLOracleSwarmer_BitByPlayer(On.SLOracleSwarmer.orig_BitByPlayer orig, SLOracleSwarmer self, Creature.Grasp grasp, bool eu)
             {
-                foreach (var kv in OnlineManager.lobby.playerAvatars)
+                orig(self, grasp, eu);
+                if (self.slatedForDeletetion == true)
                 {
-                    var playerAvatar = kv.Value;
-                    if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none || kv.Key.isMe) continue; // not in game or is me
-                    if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
+                    SwarmerEaten();
+                }
+            }
+
+            private void OracleSwarmer_BitByPlayer(On.OracleSwarmer.orig_BitByPlayer orig, OracleSwarmer self, Creature.Grasp grasp, bool eu)
+            {
+                orig(self, grasp, eu);
+                if (self.slatedForDeletetion == true)
+                {
+                    SwarmerEaten();
+                }
+            }
+
+            private void SwarmerEaten()
+            {
+                if (OnlineManager.lobby == null) return;
+                if (!OnlineManager.lobby.isOwner && OnlineManager.lobby.gameMode is StoryGameMode)
+                {
+                    if (!OnlineManager.lobby.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(ConsumableRPCs.enableTheGlow)))
                     {
-                        if (ac.Room == self.room.abstractRoom)
+                        OnlineManager.lobby.owner.InvokeRPC(ConsumableRPCs.enableTheGlow);
+                    }
+                }
+            }
+
+            private void Oracle_SetUpSwarmers(On.Oracle.orig_SetUpSwarmers orig, Oracle self)
+            {
+                if (OnlineManager.lobby == null)
+                {
+                    orig(self);
+                    return;
+                }
+
+                RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
+                if (room.isOwner)
+                {
+                    orig(self); //Only setup the room if we are the room owner.
+                    foreach (var swamer in self.mySwarmers)
+                    {
+                        var apo = swamer.abstractPhysicalObject;
+                        self.room.world.GetResource().ApoEnteringWorld(apo);
+                        self.room.abstractRoom.GetResource().ApoEnteringRoom(apo, apo.pos);
+                    }
+                }
+            }
+
+            private void PuffBall_Explode(On.PuffBall.orig_Explode orig, PuffBall self)
+            {
+                if (OnlineManager.lobby == null)
+                {
+                    orig(self);
+                    return;
+                }
+
+                RoomSession.map.TryGetValue(self.room.abstractRoom, out var onlineRoom);
+                OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var onlineSporePlant);
+
+                if (onlineSporePlant.isMine)
+                {
+                    foreach (var kv in OnlineManager.lobby.playerAvatars)
+                    {
+                        var playerAvatar = kv.Value;
+                        if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none || kv.Key.isMe) continue; // not in game or is me
+                        if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
                         {
-                            if (!opo.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(ConsumableRPCs.explodePuffBall, onlineSporePlant, self.bodyChunks[0].pos)))
+                            if (ac.Room == self.room.abstractRoom)
                             {
-                                opo.owner.InvokeRPC(ConsumableRPCs.explodePuffBall, onlineRoom, self.bodyChunks[0].pos, self.sporeColor, self.color);
+                                if (!opo.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(ConsumableRPCs.explodePuffBall, onlineSporePlant, self.bodyChunks[0].pos)))
+                                {
+                                    opo.owner.InvokeRPC(ConsumableRPCs.explodePuffBall, onlineRoom, self.bodyChunks[0].pos, self.sporeColor, self.color);
+                                }
                             }
                         }
                     }
+                    orig(self);
+                    return;
                 }
-                orig(self);
-                return;
-            }
-        }
-
-        private void Oracle_SetUpMarbles(On.Oracle.orig_SetUpMarbles orig, Oracle self)
-        {
-            if (OnlineManager.lobby == null)
-            {
-                orig(self);
-                return;
             }
 
-            RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
-            if (room.isOwner)
+            private void Oracle_SetUpMarbles(On.Oracle.orig_SetUpMarbles orig, Oracle self)
             {
-                orig(self); //Only setup the room if we are the room owner.
-            }
-        }
-
-        private void Oracle_CreateMarble(On.Oracle.orig_CreateMarble orig, Oracle self, PhysicalObject orbitObj, Vector2 ps, int circle, float dist, int color)
-        {
-            if (OnlineManager.lobby == null)
-            {
-                orig(self, orbitObj, ps, circle, dist, color);
-                return;
-            }
-
-            RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
-            if (room.isOwner)
-            {
-                AbstractPhysicalObject abstractPhysicalObject = new PebblesPearl.AbstractPebblesPearl(self.room.world, null, self.room.GetWorldCoordinate(ps), self.room.game.GetNewID(), -1, -1, null, color, self.pearlCounter * ((ModManager.MSC && self.room.world.name == "DM") ? -1 : 1));
-                self.pearlCounter++;
-                self.room.abstractRoom.AddEntity(abstractPhysicalObject);
-
-                abstractPhysicalObject.RealizeInRoom();
-
-                PebblesPearl pebblesPearl = abstractPhysicalObject.realizedObject as PebblesPearl;
-                pebblesPearl.oracle = self;
-                pebblesPearl.firstChunk.HardSetPosition(ps);
-                pebblesPearl.orbitObj = orbitObj;
-                if (orbitObj == null)
+                if (OnlineManager.lobby == null)
                 {
-                    pebblesPearl.hoverPos = new Vector2?(ps);
+                    orig(self);
+                    return;
                 }
-                pebblesPearl.orbitCircle = circle;
-                pebblesPearl.orbitDistance = dist;
-                pebblesPearl.marbleColor = (abstractPhysicalObject as PebblesPearl.AbstractPebblesPearl).color;
-                self.marbles.Add(pebblesPearl);
-            }
-            else
-            {
-                return;
-            }
-        }
 
-        private void SporePlant_Pacify(On.SporePlant.orig_Pacify orig, SporePlant self)
-        {
-            if (OnlineManager.lobby == null)
-            {
-                orig(self);
-                return;
-            }
-
-            RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
-            if (!room.isOwner && OnlineManager.lobby.gameMode is StoryGameMode)
-            {
-                OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var onlineSporePlant);
-                room.owner.InvokeRPC(ConsumableRPCs.pacifySporePlant, onlineSporePlant);
-            }
-            else
-            {
-                orig(self);
-            }
-        }
-
-        private void WaterNut_Swell(On.WaterNut.orig_Swell orig, WaterNut self)
-        {
-            if (OnlineManager.lobby == null)
-            {
-                orig(self);
-                return;
-            }
-            self.room.PlaySound(SoundID.Water_Nut_Swell, self.firstChunk.pos);
-
-            var abstractWaterNut = self.abstractPhysicalObject as WaterNut.AbstractWaterNut;
-            OnlinePhysicalObject.map.TryGetValue(abstractWaterNut, out var onlineWaterNut);
-
-            if (onlineWaterNut.isMine && OnlineManager.lobby.gameMode is StoryGameMode)
-            {
-                if (self.grabbedBy.Count > 0)
+                RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
+                if (room.isOwner)
                 {
-                    self.grabbedBy[0].Release();
+                    orig(self); //Only setup the room if we are the room owner.
+                }
+            }
+
+            private void Oracle_CreateMarble(On.Oracle.orig_CreateMarble orig, Oracle self, PhysicalObject orbitObj, Vector2 ps, int circle, float dist, int color)
+            {
+                if (OnlineManager.lobby == null)
+                {
+                    orig(self, orbitObj, ps, circle, dist, color);
+                    return;
                 }
 
-                EntityID id = self.room.world.game.GetNewID();
-                var abstractSwollenWaterNut = new WaterNut.AbstractWaterNut(abstractWaterNut.world, null, abstractWaterNut.pos, id, abstractWaterNut.originRoom, abstractWaterNut.placedObjectIndex, null, true);
-                self.room.abstractRoom.AddEntity(abstractSwollenWaterNut);
-                OnlinePhysicalObject.map.TryGetValue(abstractSwollenWaterNut, out var onlineSwollenWaterNut);
+                RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
+                if (room.isOwner)
+                {
+                    AbstractPhysicalObject abstractPhysicalObject = new PebblesPearl.AbstractPebblesPearl(self.room.world, null, self.room.GetWorldCoordinate(ps), self.room.game.GetNewID(), -1, -1, null, color, self.pearlCounter * ((ModManager.MSC && self.room.world.name == "DM") ? -1 : 1));
+                    self.pearlCounter++;
+                    self.room.abstractRoom.AddEntity(abstractPhysicalObject);
 
-                abstractSwollenWaterNut.RealizeInRoom();
+                    abstractPhysicalObject.RealizeInRoom();
 
-                SwollenWaterNut swollenWaterNut = abstractSwollenWaterNut.realizedObject as SwollenWaterNut;
-                //self.room.AddObject(swollenWaterNut);
-                swollenWaterNut.firstChunk.HardSetPosition(self.firstChunk.pos);
-                swollenWaterNut.AbstrConsumable.isFresh = abstractSwollenWaterNut.isFresh;
-                onlineSwollenWaterNut.realized = true;
-                self.Destroy();
+                    PebblesPearl pebblesPearl = abstractPhysicalObject.realizedObject as PebblesPearl;
+                    pebblesPearl.oracle = self;
+                    pebblesPearl.firstChunk.HardSetPosition(ps);
+                    pebblesPearl.orbitObj = orbitObj;
+                    if (orbitObj == null)
+                    {
+                        pebblesPearl.hoverPos = new Vector2?(ps);
+                    }
+                    pebblesPearl.orbitCircle = circle;
+                    pebblesPearl.orbitDistance = dist;
+                    pebblesPearl.marbleColor = (abstractPhysicalObject as PebblesPearl.AbstractPebblesPearl).color;
+                    self.marbles.Add(pebblesPearl);
+                }
+                else
+                {
+                    return;
+                }
             }
-        }
 
-        private void Player_GetInitialSlugcatClass(On.Player.orig_GetInitialSlugcatClass orig, Player self)
-        {
-            orig(self);
-            if (isStoryMode(out var storyGameMode))
+            private void SporePlant_Pacify(On.SporePlant.orig_Pacify orig, SporePlant self)
             {
-                self.SlugCatClass = (storyGameMode.clientSettings as StoryClientSettings).playingAs;
-            }
-        }
+                if (OnlineManager.lobby == null)
+                {
+                    orig(self);
+                    return;
+                }
 
-        private RWCustom.IntVector2 SlugcatStats_SlugcatFoodMeter(On.SlugcatStats.orig_SlugcatFoodMeter orig, SlugcatStats.Name slugcat)
-        {
-            if (isStoryMode(out var storyGameMode))
-            {
-                return orig(storyGameMode.currentCampaign);
+                RoomSession.map.TryGetValue(self.room.abstractRoom, out var room);
+                if (!room.isOwner && OnlineManager.lobby.gameMode is StoryGameMode)
+                {
+                    OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var onlineSporePlant);
+                    room.owner.InvokeRPC(ConsumableRPCs.pacifySporePlant, onlineSporePlant);
+                }
+                else
+                {
+                    orig(self);
+                }
             }
-            return orig(slugcat);
-        }
+
+            private void WaterNut_Swell(On.WaterNut.orig_Swell orig, WaterNut self)
+            {
+                if (OnlineManager.lobby == null)
+                {
+                    orig(self);
+                    return;
+                }
+                self.room.PlaySound(SoundID.Water_Nut_Swell, self.firstChunk.pos);
+
+                var abstractWaterNut = self.abstractPhysicalObject as WaterNut.AbstractWaterNut;
+                OnlinePhysicalObject.map.TryGetValue(abstractWaterNut, out var onlineWaterNut);
+
+                if (onlineWaterNut.isMine && OnlineManager.lobby.gameMode is StoryGameMode)
+                {
+                    if (self.grabbedBy.Count > 0)
+                    {
+                        self.grabbedBy[0].Release();
+                    }
+
+                    EntityID id = self.room.world.game.GetNewID();
+                    var abstractSwollenWaterNut = new WaterNut.AbstractWaterNut(abstractWaterNut.world, null, abstractWaterNut.pos, id, abstractWaterNut.originRoom, abstractWaterNut.placedObjectIndex, null, true);
+                    self.room.abstractRoom.AddEntity(abstractSwollenWaterNut);
+                    OnlinePhysicalObject.map.TryGetValue(abstractSwollenWaterNut, out var onlineSwollenWaterNut);
+
+                    abstractSwollenWaterNut.RealizeInRoom();
+
+                    SwollenWaterNut swollenWaterNut = abstractSwollenWaterNut.realizedObject as SwollenWaterNut;
+                    //self.room.AddObject(swollenWaterNut);
+                    swollenWaterNut.firstChunk.HardSetPosition(self.firstChunk.pos);
+                    swollenWaterNut.AbstrConsumable.isFresh = abstractSwollenWaterNut.isFresh;
+                    onlineSwollenWaterNut.realized = true;
+                    self.Destroy();
+                }
+            }
+
+            private void Player_GetInitialSlugcatClass(On.Player.orig_GetInitialSlugcatClass orig, Player self)
+            {
+                orig(self);
+                if (isStoryMode(out var storyGameMode))
+                {
+                    self.SlugCatClass = (storyGameMode.clientSettings as StoryClientSettings).playingAs;
+                }
+            }
+
+            private RWCustom.IntVector2 SlugcatStats_SlugcatFoodMeter(On.SlugcatStats.orig_SlugcatFoodMeter orig, SlugcatStats.Name slugcat)
+            {
+                if (isStoryMode(out var storyGameMode))
+                {
+                    return orig(storyGameMode.currentCampaign);
+                }
+                return orig(slugcat);
+            }
 
         private void HUD_InitSinglePlayerHud(On.HUD.HUD.orig_InitSinglePlayerHud orig, HUD.HUD self, RoomCamera cam)
         {
@@ -542,201 +544,201 @@ namespace RainMeadow
             }
         }
 
-        private void KarmaLadderScreen_Singal(On.Menu.KarmaLadderScreen.orig_Singal orig, Menu.KarmaLadderScreen self, Menu.MenuObject sender, string message)
-        {
-            if (isStoryMode(out var gameMode))
+            private void KarmaLadderScreen_Singal(On.Menu.KarmaLadderScreen.orig_Singal orig, Menu.KarmaLadderScreen self, Menu.MenuObject sender, string message)
             {
-                if (message == "CONTINUE")
+                if (isStoryMode(out var gameMode))
                 {
-                    if (OnlineManager.lobby.isOwner)
+                    if (message == "CONTINUE")
                     {
-                        RainMeadow.Debug("Continue - host");
-                        gameMode.didStartCycle = true;
-                    }
-                    else if (!gameMode.didStartCycle)
-                    {
-                        sender.toggled = !sender.toggled;
-                        isPlayerReady = sender.toggled;
-                        RainMeadow.Debug(sender.toggled ? "Ready!" : "Cancelled!");
-                        return;
-                    }
-                    RainMeadow.Debug("Continue - client");
-                }
-            }
-            orig(self, sender, message);
-        }
-
-        private void Player_Update(On.Player.orig_Update orig, Player self, bool eu)
-        {
-            orig(self, eu);
-            if (isStoryMode(out var gameMode))
-            {
-
-                //fetch the online entity and check if it is mine. 
-                //If it is mine run the below code
-                //If not, update from the lobby state
-                //self.readyForWin = OnlineMAnager.lobby.playerid === fetch if this is ours. 
-
-                if (OnlinePhysicalObject.map.TryGetValue(self.abstractCreature, out var oe))
-                {
-                    if (!oe.isMine)
-                    {
-                        self.readyForWin = gameMode.readyForWinPlayers.Contains(oe.owner.inLobbyId);
-                        return;
-                    }
-                }
-
-                if (self.readyForWin
-                    && self.touchedNoInputCounter > (ModManager.MMF ? 40 : 20)
-                    && RWCustom.Custom.ManhattanDistance(self.abstractCreature.pos.Tile, self.room.shortcuts[0].StartTile) > 3)
-                {
-                    gameMode.storyClientSettings.readyForWin = true;
-                }
-                else
-                {
-                    gameMode.storyClientSettings.readyForWin = false;
-                }
-            }
-        }
-
-        private void SleepAndDeathScreen_Update(On.Menu.SleepAndDeathScreen.orig_Update orig, Menu.SleepAndDeathScreen self)
-        {
-            orig(self);
-
-            if (isStoryMode(out var gameMode))
-            {
-                if (OnlineManager.lobby.isOwner)
-                {
-                    self.continueButton.buttonBehav.greyedOut = OnlineManager.lobby.clientSettings.Values.Any(cs => cs.inGame);
-                }
-                else
-                {
-                    if (gameMode.didStartCycle)
-                    {
-                        if (isPlayerReady)
+                        if (OnlineManager.lobby.isOwner)
                         {
-                            self.Singal(self.continueButton, "CONTINUE");
+                            RainMeadow.Debug("Continue - host");
+                            gameMode.didStartCycle = true;
                         }
-                        else if (self.continueButton != null)
+                        else if (!gameMode.didStartCycle)
                         {
-                            self.continueButton.menuLabel.text = self.Translate("CONTINUE");
+                            sender.toggled = !sender.toggled;
+                            isPlayerReady = sender.toggled;
+                            RainMeadow.Debug(sender.toggled ? "Ready!" : "Cancelled!");
+                            return;
+                        }
+                        RainMeadow.Debug("Continue - client");
+                    }
+                }
+                orig(self, sender, message);
+            }
+
+            private void Player_Update(On.Player.orig_Update orig, Player self, bool eu)
+            {
+                orig(self, eu);
+                if (isStoryMode(out var gameMode))
+                {
+
+                    //fetch the online entity and check if it is mine. 
+                    //If it is mine run the below code
+                    //If not, update from the lobby state
+                    //self.readyForWin = OnlineMAnager.lobby.playerid === fetch if this is ours. 
+
+                    if (OnlinePhysicalObject.map.TryGetValue(self.abstractCreature, out var oe))
+                    {
+                        if (!oe.isMine)
+                        {
+                            self.readyForWin = gameMode.readyForWinPlayers.Contains(oe.owner.inLobbyId);
+                            return;
                         }
                     }
-                    else if (self.continueButton != null)
+
+                    if (self.readyForWin
+                        && self.touchedNoInputCounter > (ModManager.MMF ? 40 : 20)
+                        && RWCustom.Custom.ManhattanDistance(self.abstractCreature.pos.Tile, self.room.shortcuts[0].StartTile) > 3)
                     {
-                        self.continueButton.menuLabel.text = self.Translate("READY");
-                    }
-                }
-            }
-        }
-
-        private void SleepAndDeathScreen_ctor(On.Menu.SleepAndDeathScreen.orig_ctor orig, Menu.SleepAndDeathScreen self, ProcessManager manager, ProcessManager.ProcessID ID)
-        {
-            RainMeadow.Debug("In SleepAndDeath Screen");
-            orig(self, manager, ID);
-
-            if (isStoryMode(out var gameMode))
-            {
-                isPlayerReady = false;
-                gameMode.didStartCycle = false;
-            }
-        }
-
-        private bool RegionGate_AllPlayersThroughToOtherSide(On.RegionGate.orig_AllPlayersThroughToOtherSide orig, RegionGate self)
-        {
-
-            if (isStoryMode(out var storyGameMode))
-            {
-                foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Values)
-                {
-                    if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
-                    if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
-                    {
-                        if (ac.pos.room == self.room.abstractRoom.index && (!self.letThroughDir || ac.pos.x < self.room.TileWidth / 2 + 3)
-                            && (self.letThroughDir || ac.pos.x > self.room.TileWidth / 2 - 4))
-                        {
-                            return false;
-                        }
+                        gameMode.storyClientSettings.readyForWin = true;
                     }
                     else
                     {
-                        return false; // not loaded
+                        gameMode.storyClientSettings.readyForWin = false;
                     }
-
                 }
+            }
+
+            private void SleepAndDeathScreen_Update(On.Menu.SleepAndDeathScreen.orig_Update orig, Menu.SleepAndDeathScreen self)
+            {
+                orig(self);
+
+                if (isStoryMode(out var gameMode))
+                {
+                    if (OnlineManager.lobby.isOwner)
+                    {
+                        self.continueButton.buttonBehav.greyedOut = OnlineManager.lobby.clientSettings.Values.Any(cs => cs.inGame);
+                    }
+                    else
+                    {
+                        if (gameMode.didStartCycle)
+                        {
+                            if (isPlayerReady)
+                            {
+                                self.Singal(self.continueButton, "CONTINUE");
+                            }
+                            else if (self.continueButton != null)
+                            {
+                                self.continueButton.menuLabel.text = self.Translate("CONTINUE");
+                            }
+                        }
+                        else if (self.continueButton != null)
+                        {
+                            self.continueButton.menuLabel.text = self.Translate("READY");
+                        }
+                    }
+                }
+            }
+
+            private void SleepAndDeathScreen_ctor(On.Menu.SleepAndDeathScreen.orig_ctor orig, Menu.SleepAndDeathScreen self, ProcessManager manager, ProcessManager.ProcessID ID)
+            {
+                RainMeadow.Debug("In SleepAndDeath Screen");
+                orig(self, manager, ID);
+
+                if (isStoryMode(out var gameMode))
+                {
+                    isPlayerReady = false;
+                    gameMode.didStartCycle = false;
+                }
+            }
+
+            private bool RegionGate_AllPlayersThroughToOtherSide(On.RegionGate.orig_AllPlayersThroughToOtherSide orig, RegionGate self)
+            {
+
+                if (isStoryMode(out var storyGameMode))
+                {
+                    foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Values)
+                    {
+                        if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
+                        if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
+                        {
+                            if (ac.pos.room == self.room.abstractRoom.index && (!self.letThroughDir || ac.pos.x < self.room.TileWidth / 2 + 3)
+                                && (self.letThroughDir || ac.pos.x > self.room.TileWidth / 2 - 4))
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            return false; // not loaded
+                        }
+
+                    }
 
                 self.room.game.cameras[0].hud.parts.Add(new OnlineHUD(self.room.game.cameras[0].hud, self.room.game.cameras[0], storyGameMode));
                 self.room.game.cameras[0].hud.parts.Add(new SpectatorHud(self.room.game.cameras[0].hud, self.room.game.cameras[0], storyGameMode));
 
-                return true;
+                    return true;
+                }
+                return orig(self);
+
             }
-            return orig(self);
-
-        }
 
 
-        private int RegionGate_PlayersInZone(On.RegionGate.orig_PlayersInZone orig, RegionGate self)
-        {
-            if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is StoryGameMode)
+            private int RegionGate_PlayersInZone(On.RegionGate.orig_PlayersInZone orig, RegionGate self)
             {
-                int regionGateZone = -1;
-                foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Values)
+                if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is StoryGameMode)
                 {
-                    if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
-                    if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
+                    int regionGateZone = -1;
+                    foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Values)
                     {
-                        if (ac.Room == self.room.abstractRoom)
+                        if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
+                        if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
                         {
-                            int zone = self.DetectZone(ac);
-                            if (zone != regionGateZone && regionGateZone != -1)
+                            if (ac.Room == self.room.abstractRoom)
                             {
-                                return -1;
+                                int zone = self.DetectZone(ac);
+                                if (zone != regionGateZone && regionGateZone != -1)
+                                {
+                                    return -1;
+                                }
+                                regionGateZone = zone;
                             }
-                            regionGateZone = zone;
                         }
-                    }
-                    else
-                    {
-                        return -1; // not loaded
-                    }
-                }
-
-                return regionGateZone;
-            }
-            return orig(self);
-        }
-
-        private bool PlayersStandingStill(On.RegionGate.orig_PlayersStandingStill orig, RegionGate self)
-        {
-            if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is StoryGameMode)
-            {
-                foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Values)
-                {
-                    if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
-                    if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
-                    {
-                        if (ac.Room != self.room.abstractRoom
-                        || ((ac.realizedCreature as Player)?.touchedNoInputCounter ?? 0) < (ModManager.MMF ? 40 : 20))
+                        else
                         {
-                            return false;
+                            return -1; // not loaded
                         }
                     }
-                    else
-                    {
-                        return false; // not loaded
-                    }
+
+                    return regionGateZone;
                 }
+                return orig(self);
+            }
 
-                List<HudPart> partsToRemove = new List<HudPart>();
-
-                foreach (HudPart part in self.room.game.cameras[0].hud.parts)
+            private bool PlayersStandingStill(On.RegionGate.orig_PlayersStandingStill orig, RegionGate self)
+            {
+                if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is StoryGameMode)
                 {
-                    if (part is OnlineHUD || part is PlayerSpecificOnlineHud)
+                    foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Values)
                     {
-
-                        partsToRemove.Add(part);
+                        if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
+                        if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
+                        {
+                            if (ac.Room != self.room.abstractRoom
+                            || ((ac.realizedCreature as Player)?.touchedNoInputCounter ?? 0) < (ModManager.MMF ? 40 : 20))
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            return false; // not loaded
+                        }
                     }
-                }
+
+                    List<HudPart> partsToRemove = new List<HudPart>();
+
+                    foreach (HudPart part in self.room.game.cameras[0].hud.parts)
+                    {
+                        if (part is OnlineHUD || part is PlayerSpecificOnlineHud)
+                        {
+
+                            partsToRemove.Add(part);
+                        }
+                    }
 
                 foreach (HudPart part in partsToRemove)
                 {


### PR DESCRIPTION
- [x] Test exit logic on den sleeping requirements if a client wants to quit the game while dead

In the event a client is dead but owns a room, need to test resource ownership reassignment after they quit and leave. Henpe's engine resource transfer rework should improve this experience.