### PR TITLE
Story: use campaign savestatenumber, intercept in save/load

### DIFF
--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -46,12 +46,11 @@ namespace RainMeadow
             return true;
         }
 
-        public override SlugcatStats.Name GetStorySessionPlayer(RainWorldGame self) 
+        public override SlugcatStats.Name GetStorySessionPlayer(RainWorldGame game)
         {
-            // Return the save slot slugcatStats name
-            // TODO: Handle client side saves. As in don't do anything savestate related, just get from host.
-            return currentSaveSlot?.save ?? RainMeadow.Ext_SlugcatStatsName.OnlineSessionPlayer;
+            return currentCampaign;
         }
+
         public override SlugcatStats.Name LoadWorldAs(RainWorldGame game)
         {
             return currentCampaign;


### PR DESCRIPTION
game uses savestatenum to check player character, so only use custom meadow onlineplayer enum when loading/saving

- [ ] make wrapping less ugly
- [ ] find a better home for GetSaveStateNumber (maybe as a new func to OnlineGameMode? or is this too story-specific)