### PR TITLE
handle player stomach items

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -14,6 +14,8 @@ public partial class RainMeadow
         On.Player.ctor += Player_ctor;
         On.Player.Die += PlayerOnDie;
         On.Player.Grabability += PlayerOnGrabability;
+        On.Player.SwallowObject += Player_SwallowObject;
+        On.Player.Regurgitate += Player_Regurgitate;
         On.Player.AddFood += Player_AddFood;
         On.Player.AddQuarterFood += Player_AddQuarterFood;
         On.Player.FoodInRoom_bool += Player_FoodInRoom;
@@ -217,6 +219,32 @@ public partial class RainMeadow
             }
         }
         return orig(self, obj);
+    }
+
+    private void Player_SwallowObject(On.Player.orig_SwallowObject orig, Player self, int grasp)
+    {
+        if (OnlineManager.lobby != null)
+        {
+            if (OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var oe)
+                && !oe.isMine)
+            {
+                return;
+            }
+        }
+        orig(self, grasp);
+    }
+
+    private void Player_Regurgitate(On.Player.orig_Regurgitate orig, Player self)
+    {
+        if (OnlineManager.lobby != null)
+        {
+            if (OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var oe)
+                && !oe.isMine)
+            {
+                return;
+            }
+        }
+        orig(self);
     }
 
     private void SlugcatStats_ctor(On.SlugcatStats.orig_ctor orig, SlugcatStats self, SlugcatStats.Name slugcat, bool malnourished)

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -48,7 +48,7 @@ namespace RainMeadow
 
         public OnlinePlayer owner;
         public readonly EntityId id;
-        public readonly bool isTransferable;
+        public bool isTransferable;
 
         internal ushort version;
         internal bool everRegistered;

--- a/Online/State/PlayerStateState.cs
+++ b/Online/State/PlayerStateState.cs
@@ -10,7 +10,7 @@ namespace RainMeadow
         [OnlineField]
         public int quarterFoodPoints;
         [OnlineField(nullable:true)]
-        public string swallowedItem;
+        public OnlineEntity.EntityId? objectInStomach;
 
         public PlayerStateState() { }
 
@@ -21,7 +21,24 @@ namespace RainMeadow
 
             foodInStomach = playerState.foodInStomach;
             quarterFoodPoints = playerState.quarterFoodPoints;
-            swallowedItem = playerState.swallowedItem;
+
+            if ((abstractCreature.realizedCreature as Player)?.objectInStomach is AbstractPhysicalObject apo)
+            {
+                apo.Move(abstractCreature.pos);
+                RainMeadow.Debug($"objectInStomach is {apo}");
+                if (!OnlinePhysicalObject.map.TryGetValue(apo, out var oe))
+                {
+                    apo.world.GetResource().ApoEnteringWorld(apo);
+                    if (!OnlinePhysicalObject.map.TryGetValue(apo, out oe)) throw new System.InvalidOperationException("Stomach item doesn't exist in online space!");
+                }
+                RainMeadow.Debug($"onlineEntity is {oe}");
+                objectInStomach = oe.id;
+            }
+            else
+            {
+                RainMeadow.Debug("objectInStomach is null");
+                objectInStomach = null;
+            }
         }
 
         public override void ReadTo(AbstractCreature abstractCreature)
@@ -31,8 +48,11 @@ namespace RainMeadow
 
             playerState.foodInStomach = this.foodInStomach;
             playerState.quarterFoodPoints = this.quarterFoodPoints;
-            playerState.swallowedItem = this.swallowedItem;
-        }
 
+            if (abstractCreature.realizedCreature is Player player)
+            {
+                player.objectInStomach = (this.objectInStomach?.FindEntity() as OnlinePhysicalObject)?.apo;
+            }
+        }
     }
 }


### PR DESCRIPTION
needs more testing

- [ ] when player swallows item, swallow seems to fail for a moment before swallowed state is synced
  - can handle by faking the swallow clientside (~~too much hassle imo~~ EDIT: actually pretty noticeable, might be worth fixing)
- [ ] no swallow sound
  - play sound manually (ugly)
  - IL hook swallow function to skip item stuff and play sound (worth the hassle?)
- [ ] sheltering? dying?
  - should respawn in shelter then players can "claim" them while spawning in
- [ ] remix item tracking