### PR TITLE
sync gravity cycle

### DIFF
--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -39,6 +39,7 @@ namespace RainMeadow
             On.RoomSpecificScript.AddRoomSpecificScript += RoomSpecificScript_AddRoomSpecificScript;
 
             IL.RoomSpecificScript.SS_E08GradientGravity.Update += RoomSpecificScript_SS_E08GradientGravity_Update;
+            On.AntiGravity.BrokenAntiGravity.Update += AntiGravity_BrokenAntiGravity_Update;
 
             On.FliesWorldAI.AddFlyToSwarmRoom += FliesWorldAI_AddFlyToSwarmRoom;
 
@@ -256,6 +257,18 @@ namespace RainMeadow
             {
                 Logger.LogError(e);
             }
+        }
+
+        private void AntiGravity_BrokenAntiGravity_Update(On.AntiGravity.BrokenAntiGravity.orig_Update orig, AntiGravity.BrokenAntiGravity self)
+        {
+            if (OnlineManager.lobby != null && self.game.world.GetResource() is WorldSession ws && !ws.isOwner)
+            {
+                if (ws.state != null)
+                {
+                    self.counter = (self.on == (ws.state as WorldSession.WorldState).rainCycleData.antiGravity) ? self.cycleMin * 40 : 0;
+                }
+            }
+            orig(self);
         }
 
         private void StoryGameSession_ctor(On.StoryGameSession.orig_ctor orig, StoryGameSession self, SlugcatStats.Name saveStateNumber, RainWorldGame game)

--- a/Online/Resource/OnlineResource.State.cs
+++ b/Online/Resource/OnlineResource.State.cs
@@ -10,6 +10,8 @@ namespace RainMeadow
     {
         protected ResourceState latestState;
 
+        public ResourceState? state { get => isAvailable ? latestState : null; }
+
         public ResourceState GetState(uint ts)
         {
             if (!isOwner) { throw new InvalidProgrammerException("not owner"); }

--- a/Online/Resource/WorldSession.RainCycle.cs
+++ b/Online/Resource/WorldSession.RainCycle.cs
@@ -13,6 +13,8 @@
             public int timer = 0;
             [OnlineField]
             public int preTimer = 0;
+            [OnlineField]
+            public bool antiGravity = false;
 
             public RainCycleData() { 
             
@@ -21,13 +23,14 @@
                 this.cycleLength = rainCycle.cycleLength;
                 this.timer = rainCycle.timer;
                 this.preTimer = rainCycle.preTimer;
+                this.antiGravity = rainCycle.brokenAntiGrav?.on ?? false;
             }
 
             public override bool Equals(object obj)
             {
                 if (obj is RainCycleData) {
                     var rainCycle = (RainCycleData)obj;
-                    return (this.cycleLength == rainCycle.cycleLength && this.timer == rainCycle.timer && this.preTimer == rainCycle.preTimer);
+                    return (this.cycleLength == rainCycle.cycleLength && this.timer == rainCycle.timer && this.preTimer == rainCycle.preTimer && this.antiGravity == rainCycle.antiGravity);
                 }
                 return false;
             }

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -88,6 +88,13 @@ namespace RainMeadow
             {
                 if (resource.world != null) {
                     RainCycle rainCycle = resource.world.rainCycle;
+                    if (rainCycle.brokenAntiGrav == null)
+                    {
+                        rainCycle.brokenAntiGrav = new AntiGravity.BrokenAntiGravity(
+                            resource.world.game.setupValues.gravityFlickerCycleMin,
+                            resource.world.game.setupValues.gravityFlickerCycleMax,
+                            resource.world.game);
+                    }
                     rainCycleData = new RainCycleData(rainCycle);
                     realizedRooms = new(resource.world.abstractRooms.Where(s => s.firstTimeRealized == false).Select(r => (ushort)r.index).ToList());
                 }


### PR DESCRIPTION
fixes gravity cycle desync in 5P unfortunate development (SS_S03 is a good shelter for testing)

on worldsession ownership transfer, counter before next change will be initialized to minimum value (320 by default). we could handle this more correctly i.e. randomize the duration, but imo it's not too important

tested:
- [x] story
- [x] meadow