### PR TITLE
don't set abscreature destination if unrealized

### DIFF
--- a/Online/State/AbstractCreatureState.cs
+++ b/Online/State/AbstractCreatureState.cs
@@ -38,9 +38,9 @@ namespace RainMeadow
             base.ReadTo(onlineEntity);
             var abstractCreature = (AbstractCreature)((OnlineCreature)onlineEntity).apo;
             creatureStateState.ReadTo(abstractCreature);
-            if (abstractCreature.abstractAI is AbstractCreatureAI absAi)
+            if (abstractCreature.Room?.realizedRoom != null && abstractCreature.abstractAI is AbstractCreatureAI absAi)
             {
-                if(destination.room != absAi.destination.room || destination.abstractNode != absAi.destination.abstractNode)
+                if (destination.room != absAi.destination.room || destination.abstractNode != absAi.destination.abstractNode)
                 {
                     absAi.SetDestination(destination);
                 }


### PR DESCRIPTION
only set destination if creature is realized

minimizes creatures trying (and failing) to pathfind to rooms that are not loaded on the client