### PR TITLE
preserve non-gameplay remix settings

### DIFF
--- a/Story/StoryMenu.cs
+++ b/Story/StoryMenu.cs
@@ -40,6 +40,8 @@ namespace RainMeadow
 
         public static List<string> nonCampaignSlugcats = new List<string> { "Night", "Inv", "Slugpup", "MeadowOnline", "MeadowOnlineRemote" };
 
+        public static List<string> nonGameplayRemixSettings = new List<string> { "cfgSpeedrunTimer", "cfgHideRainMeterNoThreat", "cfgLoadingScreenTips", "cfgExtraTutorials", "cfgClearerDeathGradients", "cfgShowUnderwaterShortcuts", "cfgBreathTimeVisualIndicator", "cfgCreatureSense", "cfgTickTock", "cfgFastMapReveal", "cfgThreatMusicPulse", "cfgExtraLizardSounds", "cfgQuieterGates", "cfgDisableScreenShake", "cfgHunterBatflyAutograb", "cfgNoMoreTinnitus" };
+
         private SlugcatStats.Name customSelectedSlugcat = SlugcatStats.Name.White;
 
         public override MenuScene.SceneID GetScene => null;
@@ -515,9 +517,9 @@ namespace RainMeadow
                 FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Static);
                 var sortedFields = fields.OrderBy(f => f.Name);
 
-
                 foreach (FieldInfo field in sortedFields)
                 {
+                    if (nonGameplayRemixSettings.Contains(field.Name)) continue;
                     var reflectedValue = field.GetValue(null);
                     if (reflectedValue is Configurable<bool> boolOption)
                     {


### PR DESCRIPTION
list of preserved remix options:
- Speedrun timer 
- Hide rain timer in safe areas 
- Loading screen tips 
- Extra tutorials 
- Stronger bottomless pit indicators 
- Show underwater shortcuts 
- Visual breath meter 
- Slug Senses
- Rain timer tick-tock 
- Fast map reveal 
- Threat music visual pulse
- Additional lizard voices
- Quieter gates/shelters 
- Reduce screen shaking 
- No Hunter batfly auto-grabbing 
- No more tinnitus