### PR TITLE
simpler one-off RPCs with InvokeOnceRPC

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -181,10 +181,7 @@ namespace RainMeadow
                     if (!onlinePlayer.isMe)
                     {
                         //self.playersContinueButtons = null;
-                        if (!onlinePlayer.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(RPCs.Arena_Killing, absPlayerCreature, targetAbsCreature, onlinePlayer.id.name)))
-                        {
-                            onlinePlayer.InvokeRPC(RPCs.Arena_Killing, absPlayerCreature, targetAbsCreature, onlinePlayer.id.name);
-                        }
+                        onlinePlayer.InvokeOnceRPC(RPCs.Arena_Killing, absPlayerCreature, targetAbsCreature, onlinePlayer.id.name);
                     }
                     else
                     {

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -46,10 +46,7 @@ namespace RainMeadow
 
                     if (scavBombAbstract != null)
                     {
-                        if (!room.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(OnlinePhysicalObject.ScavengerBombExplode, scavBombAbstract, self.bodyChunks[0].pos)))
-                        {
-                            room.owner.InvokeRPC(OnlinePhysicalObject.ScavengerBombExplode, scavBombAbstract, self.bodyChunks[0].pos);
-                        }
+                        room.owner.InvokeOnceRPC(OnlinePhysicalObject.ScavengerBombExplode, scavBombAbstract, self.bodyChunks[0].pos);
                     }
                 }
 
@@ -187,10 +184,7 @@ namespace RainMeadow
                 OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var objectHit);
                 if (objectHit != null)
                 {
-                    if (!room.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(OnlinePhysicalObject.HitByExplosion, objectHit, hitFac)))
-                    {
-                        room.owner.InvokeRPC(OnlinePhysicalObject.HitByExplosion, objectHit, hitFac);
-                    }
+                    room.owner.InvokeOnceRPC(OnlinePhysicalObject.HitByExplosion, objectHit, hitFac);
                 }
             }
 

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -57,13 +57,13 @@ public partial class RainMeadow
             {
                 if (!OnlineManager.lobby.isOwner)
                 {
-                    OnlineManager.lobby.owner.InvokeRPC(RPCs.ReinforceKarma);
+                    OnlineManager.lobby.owner.InvokeOnceRPC(RPCs.ReinforceKarma);
                 }
                 foreach (OnlinePlayer player in OnlineManager.players)
                 {
                     if (!player.isMe)
                     {
-                        player.InvokeRPC(RPCs.PlayReinforceKarmaAnimation);
+                        player.InvokeOnceRPC(RPCs.PlayReinforceKarmaAnimation);
                     }
                 }
             }
@@ -196,7 +196,10 @@ public partial class RainMeadow
         orig(self, grasp, eu);
         if (OnlineManager.lobby != null && !OnlineManager.lobby.isOwner && OnlineManager.lobby.gameMode is StoryGameMode)
         {
-            OnlineManager.lobby.owner.InvokeRPC(RPCs.AddMushroomCounter);
+            if (!OnlinePhysicalObject.map.TryGetValue((grasp.grabber as Player).abstractPhysicalObject, out var onlineEntity)) throw new InvalidProgrammerException("Player doesn't have OnlineEntity counterpart!!");
+            if (!onlineEntity.isMine) return;
+
+            OnlineManager.lobby.owner.InvokeOnceRPC(RPCs.AddMushroomCounter);
         }
     }
 

--- a/Online/OnlinePlayer.cs
+++ b/Online/OnlinePlayer.cs
@@ -162,6 +162,21 @@ namespace RainMeadow
             return (RPCEvent)this.QueueEvent(RPCManager.BuildRPC(del, args));
         }
 
+        internal RPCEvent InvokeOnceRPC(Delegate del, params object[] args)
+        {
+            foreach (var e in OutgoingEvents)
+                if (e is RPCEvent rpc && rpc.IsIdentical(del, args))
+                    return rpc;
+
+            if (isMe)
+            {
+                del.Method.Invoke(del.Target, args);
+                return null;
+            }
+
+            return (RPCEvent)this.QueueEvent(RPCManager.BuildRPC(del, args));
+        }
+
         internal void Update()
         {
             // Update snapshot cycle for debug overlay and reset for snapshot frame

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -172,10 +172,7 @@ namespace RainMeadow
                 if (OnlineManager.lobby == null) return;
                 if (!OnlineManager.lobby.isOwner && OnlineManager.lobby.gameMode is StoryGameMode)
                 {
-                    if (!OnlineManager.lobby.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(ConsumableRPCs.enableTheGlow)))
-                    {
-                        OnlineManager.lobby.owner.InvokeRPC(ConsumableRPCs.enableTheGlow);
-                    }
+                    OnlineManager.lobby.owner.InvokeOnceRPC(ConsumableRPCs.enableTheGlow);
                 }
             }
 
@@ -221,10 +218,7 @@ namespace RainMeadow
                         {
                             if (ac.Room == self.room.abstractRoom)
                             {
-                                if (!opo.owner.OutgoingEvents.Any(e => e is RPCEvent rpc && rpc.IsIdentical(ConsumableRPCs.explodePuffBall, onlineSporePlant, self.bodyChunks[0].pos)))
-                                {
-                                    opo.owner.InvokeRPC(ConsumableRPCs.explodePuffBall, onlineRoom, self.bodyChunks[0].pos, self.sporeColor, self.color);
-                                }
+                                opo.owner.InvokeOnceRPC(ConsumableRPCs.explodePuffBall, onlineRoom, self.bodyChunks[0].pos, self.sporeColor, self.color);
                             }
                         }
                     }
@@ -446,14 +440,7 @@ namespace RainMeadow
         {
             if (isStoryMode(out var gameMode))
             {
-                if (!OnlineManager.lobby.isOwner)
-                {
-                    OnlineManager.lobby.owner.InvokeRPC(RPCs.MovePlayersToGhostScreen, ghostID.value);
-                }
-                else
-                {
-                    RPCs.MovePlayersToGhostScreen(ghostID.value);
-                }
+                OnlineManager.lobby.owner.InvokeOnceRPC(RPCs.MovePlayersToGhostScreen, ghostID.value);
             }
             else
             {
@@ -479,15 +466,7 @@ namespace RainMeadow
         {
             if (isStoryMode(out var gameMode))
             {
-                if (OnlineManager.lobby.isOwner)
-                {
-                    RPCs.MovePlayersToWinScreen(malnourished, gameMode.storyClientSettings.myLastDenPos);
-                }
-                else if (!OnlineManager.lobby.owner.OutgoingEvents.Any(e => e is RPCEvent rpc
-                    && rpc.IsIdentical(RPCs.MovePlayersToWinScreen, malnourished, gameMode.storyClientSettings.myLastDenPos)))
-                {
-                    OnlineManager.lobby.owner.InvokeRPC(RPCs.MovePlayersToWinScreen, malnourished, gameMode.storyClientSettings.myLastDenPos);
-                }
+                OnlineManager.lobby.owner.InvokeOnceRPC(RPCs.MovePlayersToWinScreen, malnourished, gameMode.storyClientSettings.myLastDenPos);
             }
             else
             {


### PR DESCRIPTION
slower than directly calling the original function but i think the simpler code is worth it

also fixed mushroom consumption multiplying per player

a note about `explodeSporePuff`: ideally we should be ignoring the colour when checking for outgoing but the original version didn't work anyway (comparison didn't provide colour params so length diff => counted as not equal) and colour shouldn't change so it should still work fine