### PR TITLE
exit to gamemode menu

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -34,7 +34,6 @@ namespace RainMeadow
 
             On.ArenaGameSession.SpawnPlayers += ArenaGameSession_SpawnPlayers;
             On.ArenaGameSession.Update += ArenaGameSession_Update;
-            On.ArenaGameSession.ctor += ArenaGameSession_ctor;
 
             On.ArenaGameSession.AddHUD += ArenaGameSession_AddHUD;
             On.ArenaGameSession.SpawnCreatures += ArenaGameSession_SpawnCreatures;
@@ -114,36 +113,6 @@ namespace RainMeadow
             }
             return orig(playerNumber);
 
-        }
-
-
-        private void ArenaGameSession_ctor(On.ArenaGameSession.orig_ctor orig, ArenaGameSession self, RainWorldGame game)
-        {
-            orig(self, game);
-            if (isArenaMode(out var arena))
-
-            {
-                On.ProcessManager.RequestMainProcessSwitch_ProcessID += ProcessManager_RequestMainProcessSwitch_ProcessID;
-            }
-
-
-        }
-        private void ProcessManager_RequestMainProcessSwitch_ProcessID(On.ProcessManager.orig_RequestMainProcessSwitch_ProcessID orig, ProcessManager self, ProcessManager.ProcessID ID)
-        {
-
-            if (isArenaMode(out var _))
-            {
-                if (ID == ProcessManager.ProcessID.MultiplayerMenu && self.currentMainLoop.ID == ProcessManager.ProcessID.Game)
-                {
-                    ID = Ext_ProcessID.ArenaLobbyMenu;
-                }
-                orig(self, ID);
-            }
-            else
-            {
-
-                orig(self, ID);
-            }
         }
 
         private void OverwriteArenaPlayerMax(ILContext il) => OverwriteArenaPlayerMax(il, false);

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -75,7 +75,6 @@ namespace RainMeadow
             if (lobby.isOwner)
             {
                 RainMeadow.Debug("Host LobbyReadyCheck - started game");
-                currentCampaign = storyClientSettings.playingAs;
             }
         }
 

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -18,6 +18,7 @@ namespace RainMeadow
             On.Menu.MainMenu.ctor += MainMenu_ctor;
             //On.Menu.InputOptionsMenu.ctor += InputOptionsMenu_ctor;
 
+            On.ProcessManager.RequestMainProcessSwitch_ProcessID += ProcessManager_RequestMainProcessSwitch_ProcessID;
             On.ProcessManager.PostSwitchMainProcess += ProcessManager_PostSwitchMainProcess;
 
             IL.Menu.SlugcatSelectMenu.SlugcatPage.AddImage += SlugcatPage_AddImage;
@@ -25,7 +26,6 @@ namespace RainMeadow
             On.Menu.MenuScene.BuildScene += MenuScene_BuildScene;
 
             On.Menu.SlugcatSelectMenu.SlugcatUnlocked += SlugcatSelectMenu_SlugcatUnlocked;
-
         }
 
         private bool SlugcatSelectMenu_SlugcatUnlocked(On.Menu.SlugcatSelectMenu.orig_SlugcatUnlocked orig, SlugcatSelectMenu self, SlugcatStats.Name i)
@@ -353,6 +353,19 @@ namespace RainMeadow
                 }
 
             });
+        }
+
+        private void ProcessManager_RequestMainProcessSwitch_ProcessID(On.ProcessManager.orig_RequestMainProcessSwitch_ProcessID orig, ProcessManager self, ProcessManager.ProcessID ID)
+        {
+            if (OnlineManager.lobby?.gameMode is OnlineGameMode gameMode && RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame)
+            {
+                if (ID == ProcessManager.ProcessID.MainMenu || ID == ProcessManager.ProcessID.MultiplayerMenu)
+                {
+                    ID = gameMode.MenuProcessId();
+                }
+            }
+
+            orig(self, ID);
         }
 
         private void ProcessManager_PostSwitchMainProcess(On.ProcessManager.orig_PostSwitchMainProcess orig, ProcessManager self, ProcessManager.ProcessID ID)

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -362,6 +362,12 @@ namespace RainMeadow
                 if (ID == ProcessManager.ProcessID.MainMenu || ID == ProcessManager.ProcessID.MultiplayerMenu)
                 {
                     ID = gameMode.MenuProcessId();
+
+                    if (OnlineManager.lobby.isOwner)
+                    {
+                        foreach (OnlinePlayer player in OnlineManager.players)
+                            if (!player.isMe) player.InvokeOnceRPC(RPCs.ExitToGameModeMenu);
+                    }
                 }
             }
 

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -417,6 +417,15 @@ namespace RainMeadow
         }
 
         [RPCMethod]
+        public static void ExitToGameModeMenu()
+        {
+            var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
+            if (game is null || game.manager.upcomingProcess != null) return;
+
+            game.manager.RequestMainProcessSwitch(OnlineManager.lobby.gameMode.MenuProcessId());
+        }
+
+        [RPCMethod]
         public static void TriggerGhostHunch(string ghostID)
         {
             var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);

--- a/Story/StoryMenu.cs
+++ b/Story/StoryMenu.cs
@@ -48,6 +48,7 @@ namespace RainMeadow
         public StoryMenu(ProcessManager manager) : base(manager, RainMeadow.Ext_ProcessID.StoryMenu)
         {
             RainMeadow.DebugMe();
+            this.backTarget = RainMeadow.Ext_ProcessID.LobbySelectMenu;
 
             this.rainEffect = new RainEffect(this, this.pages[0]);
             this.pages[0].subObjects.Add(this.rainEffect);

--- a/Story/StoryMenu.cs
+++ b/Story/StoryMenu.cs
@@ -268,7 +268,11 @@ namespace RainMeadow
                 this.UpdateCharacterUI();
             }
 
-            if (!OnlineManager.lobby.isOwner)
+            if (OnlineManager.lobby.isOwner)
+            {
+                hostStartButton.buttonBehav.greyedOut = OnlineManager.lobby.clientSettings.Values.Any(cs => cs.inGame);
+            }
+            else
             {
                 campaignContainer.text = $"Current Campaign: The {GetCurrentCampaignName()}";
                 clientWaitingButton.buttonBehav.greyedOut = !(gameMode.isInGame && !gameMode.changedRegions);

--- a/Story/StoryMenu.cs
+++ b/Story/StoryMenu.cs
@@ -108,7 +108,28 @@ namespace RainMeadow
             }
 
             BindSettings();
+            SanitizeStoryClientSettings(personaSettings);
+            SanitizeStoryGameMode(gameMode);
+
             MatchmakingManager.instance.OnPlayerListReceived += OnlineManager_OnPlayerListReceived;
+        }
+
+        private void SanitizeStoryClientSettings(StoryClientSettings clientSettings)
+        {
+            clientSettings.readyForWin = false;
+            clientSettings.isDead = false;
+            clientSettings.myLastDenPos = null;
+            clientSettings.hasSheltered = false;
+        }
+
+        private void SanitizeStoryGameMode(StoryGameMode gameMode)
+        {
+            gameMode.isInGame = false;
+            gameMode.changedRegions = false;
+            gameMode.didStartCycle = false;
+            gameMode.defaultDenPos = null;
+            gameMode.ghostsTalkedTo = new();
+            gameMode.consumedItems = new();
         }
 
         private void SetupHostMenu()


### PR DESCRIPTION
STORY SPECIFIC STUFF (or at least shouldn't apply to meadow)
- [x] reset storylobbydata/storyclientsettings when switching campaigns
- [x] kick players to slugcat selection menu when host exits out of game session
  - don't think we should allow host to leave temporarily
- [ ] kick players to lobby when host quits