### PR TITLE
Story: sync savestate string

### DIFF
--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -14,6 +14,7 @@ namespace RainMeadow
         public string? defaultDenPos;
         public string? region = null;
         public SlugcatStats.Name currentCampaign;
+        public string? saveStateString;
 
         // TODO: split these out for other gamemodes to reuse (see Story/StoryMenuHelpers for methods)
         public Dictionary<string, bool> storyBoolRemixSettings;
@@ -36,6 +37,7 @@ namespace RainMeadow
             defaultDenPos = null;
             myLastDenPos = null;
             region = null;
+            saveStateString = null;
             storyClientData?.Sanitize();
         }
 

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -178,8 +178,7 @@ namespace RainMeadow
         {
             var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
             ExtEnumBase.TryParse(typeof(GhostWorldPresence.GhostID), ghostID, false, out var rawEnumBase);
-            var ghostNumber = rawEnumBase as GhostWorldPresence.GhostID;
-            if (ghostNumber == null) return;
+            if (rawEnumBase is not GhostWorldPresence.GhostID ghostNumber) return;
             var ghostsTalkedTo = (game.session as StoryGameSession).saveState.deathPersistentSaveData.ghostsTalkedTo;
             if (!ghostsTalkedTo.ContainsKey(ghostNumber) || ghostsTalkedTo[ghostNumber] < 1)
                 ghostsTalkedTo[ghostNumber] = 1;

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -637,14 +637,6 @@ namespace RainMeadow
                 var currentSaveState = orig(self, saveStateNumber, game, setup, saveAsDeathOrQuit);
                 self.loadInProgress = origLoadInProgress;
 
-                if (!OnlineManager.lobby.isOwner)
-                {
-                    currentSaveState.deathPersistentSaveData.ghostsTalkedTo.Clear();
-                    foreach (var kvp in storyGameMode.ghostsTalkedTo)
-                        if (ExtEnumBase.TryParse(typeof(GhostWorldPresence.GhostID), kvp.Key, ignoreCase: false, out var rawEnumBase))
-                            currentSaveState.deathPersistentSaveData.ghostsTalkedTo[(GhostWorldPresence.GhostID)rawEnumBase] = kvp.Value;
-                }
-
                 if (storyGameMode.myLastDenPos != null)
                 {
                     currentSaveState.denPosition = storyGameMode.myLastDenPos;
@@ -878,7 +870,7 @@ namespace RainMeadow
             orig(self, eu);
             if (isStoryMode(out _) && !OnlineManager.lobby.isOwner)
             {
-                if (self.ghostNumber != null && (self.room.game.session as StoryGameSession).saveState.deathPersistentSaveData.ghostsTalkedTo[self.ghostNumber] > 0)
+                if (self.ghostNumber != null)
                     OnlineManager.lobby.owner.InvokeOnceRPC(RPCs.TriggerGhostHunch, self.ghostNumber.value);
             }
         }

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -47,10 +47,6 @@ namespace RainMeadow
             [OnlineField]
             public int mushroomCounter;
             [OnlineField]
-            public Dictionary<string, int> ghostsTalkedTo;
-            [OnlineField]
-            public Dictionary<ushort, ushort[]> consumedItems;
-            [OnlineField]
             public Dictionary<string, bool> storyBoolRemixSettings;
             [OnlineField]
             public Dictionary<string, float> storyFloatRemixSettings;
@@ -67,11 +63,9 @@ namespace RainMeadow
 
                 defaultDenPos = storyGameMode.defaultDenPos;
                 currentCampaign = storyGameMode.currentCampaign;
-                consumedItems = storyGameMode.consumedItems;
+                storyBoolRemixSettings = storyGameMode.storyBoolRemixSettings;
                 storyFloatRemixSettings = storyGameMode.storyFloatRemixSettings;
                 storyIntRemixSettings = storyGameMode.storyIntRemixSettings;
-
-                ghostsTalkedTo = storyGameMode.ghostsTalkedTo;
 
                 isInGame = RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame && RWCustom.Custom.rainWorld.processManager.upcomingProcess is null;
                 changedRegions = storyGameMode.changedRegions;
@@ -127,8 +121,6 @@ namespace RainMeadow
                     }
                 }
                 (lobby.gameMode as StoryGameMode).currentCampaign = currentCampaign;
-                (lobby.gameMode as StoryGameMode).ghostsTalkedTo = ghostsTalkedTo;
-                (lobby.gameMode as StoryGameMode).consumedItems = consumedItems;
                 (lobby.gameMode as StoryGameMode).storyBoolRemixSettings = storyBoolRemixSettings;
                 (lobby.gameMode as StoryGameMode).storyFloatRemixSettings = storyFloatRemixSettings;
                 (lobby.gameMode as StoryGameMode).storyIntRemixSettings = storyIntRemixSettings;

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -52,6 +52,8 @@ namespace RainMeadow
             public Dictionary<string, float> storyFloatRemixSettings;
             [OnlineField]
             public Dictionary<string, int> storyIntRemixSettings;
+            [OnlineField(nullable = true)]
+            public string? saveStateString;
 
 
             public State() { }
@@ -71,6 +73,7 @@ namespace RainMeadow
                 changedRegions = storyGameMode.changedRegions;
                 readyForWin = storyGameMode.readyForWin;
                 readyForGate = storyGameMode.readyForGate;
+                saveStateString = storyGameMode.saveStateString;
                 if (currentGameState?.session is StoryGameSession storySession)
                 {
                     cycleNumber = storySession.saveState.cycleNumber;
@@ -131,6 +134,8 @@ namespace RainMeadow
                 (lobby.gameMode as StoryGameMode).readyForGate = readyForGate;
                 (lobby.gameMode as StoryGameMode).friendlyFire = friendlyFire;
                 (lobby.gameMode as StoryGameMode).region = region;
+
+                (lobby.gameMode as StoryGameMode).saveStateString = saveStateString;
             }
         }
     }


### PR DESCRIPTION
fixes echoes and consumables

savestate string is ~15kb, can be compressed to ~3.7kb (3.4kb if we convert separators to ascii control chars)
only has to be synced on worldsession join

~~may cause duped creature spawns? though this seems to be a symptom of a bigger issue since clients shouldn't be allowed to spawn creatures in the first place~~ _EDIT: no longer seems to be an issue_

explicitly syncing all the relevant data (consumables, echoes, passages?, no need for creature spawns) thru onlinefields would be more efficient, did some progress in #267 (consumables) and #279 (echoes WIP)

but imo this is safer