### PR TITLE
set spawned stomach items as not in room

### DIFF
--- a/Online/State/PlayerStateState.cs
+++ b/Online/State/PlayerStateState.cs
@@ -24,6 +24,7 @@ namespace RainMeadow
 
             if ((abstractCreature.realizedCreature as Player)?.objectInStomach is AbstractPhysicalObject apo)
             {
+                apo.pos.room = -1; // signal not-in-a-room
                 if (apo.realizedObject != null) apo.Abstractize(abstractCreature.pos);
                 if (!OnlinePhysicalObject.map.TryGetValue(apo, out var oe))
                 {


### PR DESCRIPTION
fixes hunter and rivulet stomach pearls

swallowed creatures still broken, swallowed clientside but remote sees creature fall to ground