### PR TITLE
handle duplicate room names

### DIFF
--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -36,7 +36,18 @@ namespace RainMeadow
             foreach (var room in world.abstractRooms)
             {
                 var rs = new RoomSession(this, room);
-                roomSessions.Add(room.name, rs);
+                try
+                {
+                    roomSessions.Add(room.name, rs);
+                }
+                catch (Exception)
+                {
+                    RainMeadow.Error($"duplicate room {room.name} for rs {rs}");
+                    var name = "";
+                    for (var i = 0; roomSessions.Keys.Contains((name = room.name + "." + i)); i++);
+                    RainMeadow.Error($"adding as {name}");
+                    roomSessions.Add(name, rs);
+                }
                 subresources.Add(rs);
             }
             foreach (var item in earlyApos)


### PR DESCRIPTION
appends a `.$number` suffix to duplicate room names in worldsession dictionary (could this clash with modded regions?)

fixes red room bug in gilded sanctuary, may fix outer expanse too

we can't skip the rooms because they're still counted in World

```C#
for (var i = 0; roomSessions.Keys.Contains((name = room.name + "." + i)); i++);
```
not too proud of this code, feel free to refactor it