### PR TITLE
HUD: refactor and cleanup

### DIFF
--- a/Story/OnlineUIComponents/OnlineHud.cs
+++ b/Story/OnlineUIComponents/OnlineHud.cs
@@ -12,12 +12,23 @@ namespace RainMeadow
 
         private RoomCamera camera;
         private readonly OnlineGameMode onlineGameMode;
+        public bool showFriends;
 
         public OnlineHUD(HUD.HUD hud, RoomCamera camera, OnlineGameMode onlineGameMode) : base(hud)
         {
             this.camera = camera;
             this.onlineGameMode = onlineGameMode;
             UpdatePlayers();
+        }
+
+        public override void Draw(float timeStacker)
+        {
+            if (!RainMeadow.rainMeadowOptions.FriendViewClickToActivate.Value)
+                showFriends = Input.GetKey(RainMeadow.rainMeadowOptions.FriendsListKey.Value);
+            else if (Input.GetKeyDown(RainMeadow.rainMeadowOptions.FriendsListKey.Value))
+                showFriends = !showFriends;
+
+            base.Draw(timeStacker);
         }
 
         public void UpdatePlayers()
@@ -27,13 +38,12 @@ namespace RainMeadow
 
             clientSettings.Except(currentSettings).Do(PlayerAdded); 
             currentSettings.Except(clientSettings).Do(PlayerRemoved);
-
         }
 
         public void PlayerAdded(ClientSettings clientSettings)
         {
             RainMeadow.DebugMe();
-            PlayerSpecificOnlineHud indicator = new PlayerSpecificOnlineHud(hud, camera, onlineGameMode, clientSettings);
+            PlayerSpecificOnlineHud indicator = new PlayerSpecificOnlineHud(this, camera, onlineGameMode, clientSettings);
             this.indicators.Add(indicator);
             hud.AddPart(indicator);
         }

--- a/Story/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/Story/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -94,21 +94,17 @@ namespace RainMeadow
                 this.blink = 1f;
                 if (owner.found)
                 {
-                    this.alpha = Custom.LerpAndTick(this.alpha, owner.needed ? 1 : 0, 0.08f, 0.033333335f);
+                    this.alpha = owner.PlayerConsideredDead ? 0.5f : Custom.LerpAndTick(this.alpha, owner.needed ? 1 : 0, 0.08f, 0.033333335f);
 
                     this.pos = owner.drawpos;
                     if (owner.pointDir == Vector2.down) pos += new Vector2(0f, 45f);
 
-                    if (owner.PlayerConsideredDead)
+                    if (owner.PlayerConsideredDead != switchedToDeathIcon)
                     {
-                        this.alpha = 0.5f;
-                        if (!switchedToDeathIcon)
-                        {
-                            slugIcon.RemoveFromContainer();
-                            slugIcon = new FSprite("Multiplayer_Death");
-                            owner.hud.fContainers[0].AddChild(slugIcon);
-                            switchedToDeathIcon = true;
-                        }
+                        slugIcon.RemoveFromContainer();
+                        slugIcon = new FSprite(owner.PlayerConsideredDead ? "Multiplayer_Death" : "Kill_Slugcat");
+                        owner.hud.fContainers[0].AddChild(slugIcon);
+                        switchedToDeathIcon = owner.PlayerConsideredDead;
                     }
                 }
                 else

--- a/Story/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/Story/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -17,13 +17,11 @@ namespace RainMeadow
         public float blink;
         public float lastBlink;
         public bool switchedToDeathIcon;
-        private bool isButtonToggled;
         public int onlineTimeSinceSpawn;
 
         public OnlinePlayerDisplay(PlayerSpecificOnlineHud owner) : base(owner)
         {
             this.owner = owner;
-
 
             this.pos = new Vector2(-1000f, -1000f);
             this.lastPos = this.pos;
@@ -54,9 +52,6 @@ namespace RainMeadow
             this.blink = 1f;
             this.switchedToDeathIcon = false;
 
-            this.isButtonToggled = false;
-
-
             if (RainMeadow.isStoryMode(out var _))
             {
                 this.label.color = (owner.clientSettings as StoryClientSettings).SlugcatColor(); ;
@@ -81,23 +76,22 @@ namespace RainMeadow
         {
             base.Update();
             onlineTimeSinceSpawn++;
-            
-            if (RainMeadow.rainMeadowOptions.FriendViewClickToActivate.Value && Input.GetKeyDown(RainMeadow.rainMeadowOptions.FriendsListKey.Value))
-            {
-                this.isButtonToggled = !this.isButtonToggled;
-            }
 
-            
-            if ((this.owner.clientSettings.owner.isMe &&  onlineTimeSinceSpawn < 120) || isButtonToggled || (!RainMeadow.rainMeadowOptions.FriendViewClickToActivate.Value && Input.GetKey(RainMeadow.rainMeadowOptions.FriendsListKey.Value)))
+            bool show = owner.owner.showFriends || (owner.clientSettings.owner.isMe && onlineTimeSinceSpawn < 120);
+            if (show || this.alpha > 0)
             {
                 this.lastAlpha = this.alpha;
                 this.blink = 1f;
+                this.alpha = Custom.LerpAndTick(this.alpha, owner.needed && show ? 1 : 0, 0.08f, 0.033333335f);
+
                 if (owner.found)
                 {
-                    this.alpha = owner.PlayerConsideredDead ? 0.5f : Custom.LerpAndTick(this.alpha, owner.needed ? 1 : 0, 0.08f, 0.033333335f);
-
                     this.pos = owner.drawpos;
                     if (owner.pointDir == Vector2.down) pos += new Vector2(0f, 45f);
+
+                    if (this.lastAlpha == 0) this.lastPos = pos;
+
+                    if (owner.PlayerConsideredDead) this.alpha = Mathf.Min(this.alpha, 0.5f);
 
                     if (owner.PlayerConsideredDead != switchedToDeathIcon)
                     {
@@ -114,18 +108,11 @@ namespace RainMeadow
 
                 this.counter++;
             }
-            else
-            {
-                this.alpha = Custom.LerpAndTick(this.alpha, owner.needed ? 0 : 1, 0.08f, 0.0033333335f);
-                this.lastAlpha = this.alpha;
-
-            }
-
+            if (!show) this.lastAlpha = this.alpha;
         }
 
         public override void Draw(float timeStacker)
         {
-
             Vector2 vector = Vector2.Lerp(this.lastPos, this.pos, timeStacker) + new Vector2(0.01f, 0.01f);
             float num = Mathf.Pow(Mathf.Max(0f, Mathf.Lerp(this.lastAlpha, this.alpha, timeStacker)), 0.7f);
             this.gradient.x = vector.x;

--- a/Story/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/Story/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -6,6 +6,7 @@ namespace RainMeadow
 {
     public class PlayerSpecificOnlineHud : HudPart
     {
+        public OnlineHUD owner;
         public OnlineGameMode onlineGameMode;
         public ClientSettings clientSettings;
 
@@ -37,9 +38,10 @@ namespace RainMeadow
             }
         }
 
-        public PlayerSpecificOnlineHud(HUD.HUD hud, RoomCamera camera, OnlineGameMode onlineGameMode, ClientSettings clientSettings) : base(hud)
+        public PlayerSpecificOnlineHud(OnlineHUD owner, RoomCamera camera, OnlineGameMode onlineGameMode, ClientSettings clientSettings) : base(owner.hud)
         {
             RainMeadow.Debug("Adding PlayerSpecificOnlineHud for " + clientSettings.owner);
+            this.owner = owner;
             this.camera = camera;
             camrect = new Rect(Vector2.zero, this.camera.sSize).CloneWithExpansion(-30f);
             this.onlineGameMode = onlineGameMode;
@@ -92,8 +94,8 @@ namespace RainMeadow
                 }
             }
 
-            if (camera.room == null || !camera.room.shortCutsReady) return;
             if (!clientSettings.inGame) return;
+            if (camera.room == null || !camera.room.shortCutsReady) return;
             if (abstractPlayer == null)
             {
                 RainMeadow.Debug("finding player abscrt for " + clientSettings.owner);
@@ -101,7 +103,10 @@ namespace RainMeadow
                 {
                     abstractPlayer = oc.abstractCreature;
                 }
-                return;
+                else
+                {
+                    return;
+                }
             }
             if (this.playerDisplay == null)
             {
@@ -109,7 +114,6 @@ namespace RainMeadow
                 this.playerDisplay = new OnlinePlayerDisplay(this);
                 this.parts.Add(this.playerDisplay);
             }
-
 
             // tracking
             this.found = false;


### PR DESCRIPTION
each player hud thing had their own toggle so toggling one could enable some and disable others, fixed by unifying the toggles into a single bool in OnlineHUD

this requires passing down the OnlineHUD though, lmk if there's a better way

also fixed indicators for revived players being stuck on dead