### PR TITLE
HUD: fix alive icon after falling out of world

### DIFF
--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -307,7 +307,7 @@ namespace RainMeadow
                 }
             }
 
-            if (OnlineManager.lobby.gameMode is ArenaCompetitiveGameMode) 
+            if (OnlineManager.lobby.gameMode is ArenaCompetitiveGameMode || OnlineManager.lobby.gameMode is StoryGameMode)
             {
                 if (self.room != null)
                 {

--- a/Story/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/Story/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -58,13 +58,9 @@ namespace RainMeadow
         {
             get
             {
-                return clientSettings.inGame && abstractPlayer != null
-                    && (
-                        abstractPlayer.state.dead ||
-                        (
-                            abstractPlayer.realizedCreature is Player player &&
-                            player.dangerGrasp != null && player.dangerGraspTime > 20
-                        )
+                return clientSettings.inGame && abstractPlayer != null && (
+                    abstractPlayer.state.dead
+                    || (RealizedPlayer?.dangerGrasp != null && RealizedPlayer.dangerGraspTime > 20)
                     );
             }
         }


### PR DESCRIPTION
enabling the fall out of world prevention for story mode could have unexpected side effects