### PR TITLE
Hud pointing

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -515,7 +515,7 @@ namespace RainMeadow
             if (isArenaMode(out var _))
             {
                 self.AddPart(new TextPrompt(self));
-                self.AddPart(new Pointing(self));
+                // self.AddPart(new Pointing(self)); // no grasps on arena player? Bu why
 
             }
             else

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -515,7 +515,7 @@ namespace RainMeadow
             if (isArenaMode(out var _))
             {
                 self.AddPart(new TextPrompt(self));
-                // self.AddPart(new Pointing(self)); // no grasps on arena player? Bu why
+                self.AddPart(new Pointing(self)); // no grasps on arena player? Bu why
 
             }
             else

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -515,7 +515,7 @@ namespace RainMeadow
             if (isArenaMode(out var _))
             {
                 self.AddPart(new TextPrompt(self));
-                self.AddPart(new Pointing(self)); // no grasps on arena player? Bu why
+                self.AddPart(new Pointing(self));
 
             }
             else

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -515,6 +515,8 @@ namespace RainMeadow
             if (isArenaMode(out var _))
             {
                 self.AddPart(new TextPrompt(self));
+                self.AddPart(new Pointing(self));
+
             }
             else
             {

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -10,6 +10,8 @@ public class RainMeadowOptions : OptionInterface
     public readonly Configurable<Color> BodyColor;
     public readonly Configurable<Color> EyeColor;
     public readonly Configurable<KeyCode> SpectatorKey;
+    public readonly Configurable<KeyCode> PointingKey;
+
 
 
     private UIelement[] UIArrPlayerOptions;
@@ -22,6 +24,8 @@ public class RainMeadowOptions : OptionInterface
         BodyColor = config.Bind("BodyColor", Color.white);
         EyeColor = config.Bind("EyeColor", Color.black);
         SpectatorKey = config.Bind("SpectatorKey", KeyCode.Tab);
+        PointingKey = config.Bind("PointingKey", KeyCode.Mouse0);
+
 
     }
 
@@ -31,7 +35,7 @@ public class RainMeadowOptions : OptionInterface
         {
             OpTab opTab = new OpTab(this, "Options");
             Tabs = new OpTab[1] { opTab };
-            UIArrPlayerOptions = new UIelement[13]
+            UIArrPlayerOptions = new UIelement[15]
             {
                 new OpLabel(10f, 550f, "Options", bigText: true),
 
@@ -45,13 +49,16 @@ public class RainMeadowOptions : OptionInterface
                 new OpLabel(10, 320f, "Key used for toggling spectator mode"),
                 new OpKeyBinder(SpectatorKey, new Vector2(10f, 280f), new Vector2(150f, 30f)),
 
-                new OpLabel(10f, 230f, "[Experimental Features]", bigText: true),
-                new OpLabel(10f, 215f, "WARNING: Experimental features may cause data corruption, back up your saves", bigText: false),
+                new OpLabel(10, 245f, "Story / Arena: Pointing"),
+                new OpKeyBinder(PointingKey, new Vector2(10f, 215), new Vector2(150f, 30f)),
 
-                new OpLabel(10f, 185f, "Custom Story Slugcat", bigText: false),
+                new OpLabel(10f, 105f, "[Experimental Features]", bigText: true),
+                new OpLabel(10f, 85, "WARNING: Experimental features may cause data corruption, back up your saves", bigText: false),
 
-                new OpCheckBox(SlugcatCustomToggle, new Vector2(10f, 160f)),
-                new OpLabel(40f, 160f, RWCustom.Custom.ReplaceLineDelimeters("If selected, hosts can choose slugcat campaigns that are unstable. <LINE>Clients can choose their own Slugcats inside a host's Story campaign"))
+                new OpLabel(10f, 65, "Custom Story Slugcat", bigText: false),
+
+                new OpCheckBox(SlugcatCustomToggle, new Vector2(10f, 40)),
+                new OpLabel(40f, 45, RWCustom.Custom.ReplaceLineDelimeters("If selected, hosts can choose slugcat campaigns that are unstable. <LINE>Clients can choose their own Slugcats inside a host's Story campaign"))
                 {
                     verticalAlignment = OpLabel.LabelVAlignment.Center
                 }

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -43,7 +43,6 @@ namespace RainMeadow
 
                 for (int handy = 1; handy >= 0; handy--)
                 {
-                    // Arena hates player grasps for some reason
                     if ((realizedPlayer.grasps[handy] == null || realizedPlayer.grasps[handy].grabbed is Weapon) && (realizedPlayer.graphicsModule as PlayerGraphics).hands[1 - handy].reachedSnapPosition)
                     {
                         hand = handy;

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -59,13 +59,6 @@ namespace RainMeadow
             }
         }
 
-
-        public override void Update()
-        {
-            base.Update();
-
-        }
-
         public Vector2 OnlinePointing()
         {
 

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -1,0 +1,94 @@
+﻿using HUD;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+using HarmonyLib;
+using static RainMeadow.CreatureController;
+
+namespace RainMeadow
+{
+    public class Pointing : HudPart
+    {
+
+        Player playerPointing;
+        int hand;
+        Vector2 pointDirection;
+
+
+        public Pointing(HUD.HUD hud) : base(hud)
+        {
+            playerPointing = (hud.owner as Player);
+
+        }
+
+        public override void Draw(float timeStacker)
+        {
+            base.Draw(timeStacker);
+            if (Input.GetKey(RainMeadow.rainMeadowOptions.FriendsListKey.Value))
+            {
+                Vector2 vector = OnlinePointing();
+                if (vector == Vector2.zero)
+                {
+                    return;
+                }
+
+
+                for (int num2 = 1; num2 >= 0; num2--)
+                {
+                    if ((playerPointing.grasps[num2] == null || playerPointing.grasps[num2].grabbed is Weapon) && (playerPointing.graphicsModule as PlayerGraphics).hands[1 - num2].reachedSnapPosition)
+                    {
+                        hand = num2;
+                    }
+                }
+
+                float num3 = 100f;
+
+
+                Vector2 pos = playerPointing.mainBodyChunk.pos;
+                Vector2 vector2 = new Vector2(playerPointing.mainBodyChunk.pos.x + vector.x * num3, playerPointing.mainBodyChunk.pos.y + vector.y * num3);
+                (playerPointing.graphicsModule as PlayerGraphics).LookAtPoint(vector2, 10f);
+                if (hand > -1)
+                {
+                    (playerPointing.graphicsModule as PlayerGraphics).hands[hand].reachingForObject = true;
+                    (playerPointing.graphicsModule as PlayerGraphics).hands[hand].absoluteHuntPos = vector2;
+                }
+            }
+        }
+
+
+        public override void Update()
+        {
+            base.Update();
+
+        }
+
+        public Vector2 OnlinePointing()
+        {
+
+            SpecialInput specialInput = default;
+            var controller = RWCustom.Custom.rainWorld.options.controls[0].GetActiveController();
+            if (controller is Rewired.Joystick joystick)
+            {
+                specialInput.direction = Vector2.ClampMagnitude(new Vector2(joystick.GetAxis(2), joystick.GetAxis(3)), 1f);
+            }
+            else
+            {
+                if (Input.GetMouseButton(0))
+                {
+                    specialInput.direction = Vector2.ClampMagnitude((((Vector2)Futile.mousePosition) - playerPointing.input[0].IntVec.ToVector2().normalized) / 500f, 1f);
+                }
+            }
+
+
+            if (specialInput.direction != Vector2.zero)
+            {
+
+                return specialInput.direction;
+            }
+
+            return Vector2.zero;
+
+        }
+
+    }
+}

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -19,6 +19,7 @@ namespace RainMeadow
         {
             playerPointing = (hud.owner as Player);
 
+
         }
 
         public override void Draw(float timeStacker)
@@ -33,11 +34,12 @@ namespace RainMeadow
                 }
 
 
-                for (int num2 = 1; num2 >= 0; num2--)
+                for (int handy = 1; handy >= 0; handy--)
                 {
-                    if ((playerPointing.grasps[num2] == null || playerPointing.grasps[num2].grabbed is Weapon) && (playerPointing.graphicsModule as PlayerGraphics).hands[1 - num2].reachedSnapPosition)
+                    // Arena hates player grasps for some reason
+                    if ((playerPointing.grasps[handy] == null || playerPointing.grasps[handy].grabbed is Weapon) && (playerPointing.graphicsModule as PlayerGraphics).hands[1 - handy].reachedSnapPosition)
                     {
-                        hand = num2;
+                        hand = handy;
                     }
                 }
 
@@ -65,6 +67,7 @@ namespace RainMeadow
         {
 
             SpecialInput specialInput = default;
+            // Good for when we have a specific choice in Options menu, but doesn't work well with the "ANY" input
             var controller = RWCustom.Custom.rainWorld.options.controls[0].GetActiveController();
             if (controller is Rewired.Joystick joystick)
             {
@@ -85,7 +88,7 @@ namespace RainMeadow
                 return specialInput.direction;
             }
 
-            return Vector2.ClampMagnitude((((Vector2)Futile.mousePosition) - playerPointing.input[0].IntVec.ToVector2().normalized) / 500f, 1f);
+            return Vector2.zero;
 
         }
 

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -12,12 +12,9 @@ namespace RainMeadow
     {
         public Creature realizedPlayer;
         int hand;
-        Vector2 pointDirection;
-        public ClientSettings clientSettings;
 
         public Pointing(HUD.HUD hud) : base(hud)
         {
-
         }
 
         public override void Draw(float timeStacker)

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -12,7 +12,6 @@ namespace RainMeadow
 
         Player playerPointing;
         int hand;
-        Vector2 pointDirection;
 
 
         public Pointing(HUD.HUD hud) : base(hud)

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -24,7 +24,7 @@ namespace RainMeadow
         {
             base.Draw(timeStacker);
 
-            if (Input.GetKey(RainMeadow.rainMeadowOptions.FriendsListKey.Value))
+            if (Input.GetKey(RainMeadow.rainMeadowOptions.FriendsListKey.Value)) // TODO: Change this input
             {
                 if (OnlineManager.lobby.playerAvatars[OnlineManager.mePlayer].FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
                 {

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -1,10 +1,5 @@
 ﻿using HUD;
-using System.Collections.Generic;
 using UnityEngine;
-using System.Linq;
-using HarmonyLib;
-using static RainMeadow.CreatureController;
-using RainMeadow.GameModes;
 using Rewired;
 
 namespace RainMeadow

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -4,39 +4,47 @@ using UnityEngine;
 using System.Linq;
 using HarmonyLib;
 using static RainMeadow.CreatureController;
+using RainMeadow.GameModes;
 
 namespace RainMeadow
 {
     public class Pointing : HudPart
     {
-
-        Player playerPointing;
+        public Creature realizedPlayer;
         int hand;
-
+        Vector2 pointDirection;
+        public ClientSettings clientSettings;
 
         public Pointing(HUD.HUD hud) : base(hud)
         {
-            playerPointing = (hud.owner as Player);
-
 
         }
 
         public override void Draw(float timeStacker)
         {
             base.Draw(timeStacker);
+
             if (Input.GetKey(RainMeadow.rainMeadowOptions.FriendsListKey.Value))
             {
+                if (OnlineManager.lobby.playerAvatars[OnlineManager.mePlayer].FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
+                {
+                    realizedPlayer = ac.realizedCreature;
+
+                } else
+                {
+                    return;
+                }
+
                 Vector2 vector = OnlinePointing();
                 if (vector == Vector2.zero)
                 {
                     return;
                 }
 
-
                 for (int handy = 1; handy >= 0; handy--)
                 {
                     // Arena hates player grasps for some reason
-                    if ((playerPointing.grasps[handy] == null || playerPointing.grasps[handy].grabbed is Weapon) && (playerPointing.graphicsModule as PlayerGraphics).hands[1 - handy].reachedSnapPosition)
+                    if ((realizedPlayer.grasps[handy] == null || realizedPlayer.grasps[handy].grabbed is Weapon) && (realizedPlayer.graphicsModule as PlayerGraphics).hands[1 - handy].reachedSnapPosition)
                     {
                         hand = handy;
                     }
@@ -45,12 +53,12 @@ namespace RainMeadow
                 float num3 = 100f;
 
 
-                Vector2 vector2 = new Vector2(playerPointing.mainBodyChunk.pos.x + vector.x * num3, playerPointing.mainBodyChunk.pos.y + vector.y * num3);
-                (playerPointing.graphicsModule as PlayerGraphics).LookAtPoint(vector2, 10f);
+                Vector2 vector2 = new Vector2(realizedPlayer.mainBodyChunk.pos.x + vector.x * num3, realizedPlayer.mainBodyChunk.pos.y + vector.y * num3);
+                (realizedPlayer.graphicsModule as PlayerGraphics).LookAtPoint(vector2, 10f);
                 if (hand > -1)
                 {
-                    (playerPointing.graphicsModule as PlayerGraphics).hands[hand].reachingForObject = true;
-                    (playerPointing.graphicsModule as PlayerGraphics).hands[hand].absoluteHuntPos = vector2;
+                    (realizedPlayer.graphicsModule as PlayerGraphics).hands[hand].reachingForObject = true;
+                    (realizedPlayer.graphicsModule as PlayerGraphics).hands[hand].absoluteHuntPos = vector2;
                 }
             }
         }
@@ -76,7 +84,7 @@ namespace RainMeadow
             {
                 if (Input.GetMouseButton(0))
                 {
-                    specialInput.direction = Vector2.ClampMagnitude((((Vector2)Futile.mousePosition) - playerPointing.input[0].IntVec.ToVector2().normalized) / 500f, 1f);
+                    specialInput.direction = Vector2.ClampMagnitude((((Vector2)Futile.mousePosition) - (realizedPlayer as Player).input[0].IntVec.ToVector2().normalized) / 500f, 1f);
                 }
             }
 

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -21,7 +21,7 @@ namespace RainMeadow
         {
             base.Draw(timeStacker);
 
-            if (Input.GetKey(RainMeadow.rainMeadowOptions.FriendsListKey.Value)) // TODO: Change this input
+            if (Input.GetKey(RainMeadow.rainMeadowOptions.PointingKey.Value))
             {
                 if (OnlineManager.lobby.playerAvatars[OnlineManager.mePlayer].FindEntity(true) is OnlinePhysicalObject opo && opo.apo is AbstractCreature ac)
                 {
@@ -63,7 +63,6 @@ namespace RainMeadow
         {
 
             SpecialInput specialInput = default;
-            // Good for when we have a specific choice in Options menu, but doesn't work well with the "ANY" input
             var controller = RWCustom.Custom.rainWorld.options.controls[0].GetActiveController();
             if (controller is Rewired.Joystick joystick)
             {
@@ -71,10 +70,8 @@ namespace RainMeadow
             }
             else
             {
-                if (Input.GetMouseButton(0))
-                {
                     specialInput.direction = Vector2.ClampMagnitude((((Vector2)Futile.mousePosition) - (realizedPlayer as Player).input[0].IntVec.ToVector2().normalized) / 500f, 1f);
-                }
+              
             }
 
 

--- a/Story/OnlineUIComponents/Pointing.cs
+++ b/Story/OnlineUIComponents/Pointing.cs
@@ -44,7 +44,6 @@ namespace RainMeadow
                 float num3 = 100f;
 
 
-                Vector2 pos = playerPointing.mainBodyChunk.pos;
                 Vector2 vector2 = new Vector2(playerPointing.mainBodyChunk.pos.x + vector.x * num3, playerPointing.mainBodyChunk.pos.y + vector.y * num3);
                 (playerPointing.graphicsModule as PlayerGraphics).LookAtPoint(vector2, 10f);
                 if (hand > -1)
@@ -86,7 +85,7 @@ namespace RainMeadow
                 return specialInput.direction;
             }
 
-            return Vector2.zero;
+            return Vector2.ClampMagnitude((((Vector2)Futile.mousePosition) - playerPointing.input[0].IntVec.ToVector2().normalized) / 500f, 1f);
 
         }
 

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -682,6 +682,8 @@ namespace RainMeadow
 
                 self.room.game.cameras[0].hud.parts.Add(new OnlineHUD(self.room.game.cameras[0].hud, self.room.game.cameras[0], storyGameMode));
                 self.room.game.cameras[0].hud.parts.Add(new SpectatorHud(self.room.game.cameras[0].hud, self.room.game.cameras[0], storyGameMode));
+                self.room.game.cameras[0].hud.parts.Add(new Pointing(self.room.game.cameras[0].hud));
+
 
                 return true;
             }

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -453,7 +453,7 @@ namespace RainMeadow
             {
                 self.AddPart(new OnlineHUD(self, cam, gameMode));
                 self.AddPart(new SpectatorHud(self, cam, gameMode));
-                self.AddPart(new Pointing(self, cam, gameMode));
+                self.AddPart(new Pointing(self));
 
             }
         }

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -453,6 +453,7 @@ namespace RainMeadow
             {
                 self.AddPart(new OnlineHUD(self, cam, gameMode));
                 self.AddPart(new SpectatorHud(self, cam, gameMode));
+                self.AddPart(new Pointing(self, cam, gameMode));
 
             }
         }


### PR DESCRIPTION
A few things:

1. This input logic lets you:
A. If using controller, use a button and still allow movement while pointing
B. If using MK, use mouse to orient hand and allow movement

This only works so far if the player has a specific choice in the Options menu for the input. Probably need to add a default behavior for standing still and allowing vector to control input. 

We could also support double hand raising for more complex emotions if desired.

If you're *really* wanting us to have pointing only when still then I'll add an override for arena since stillness is death in that mode and I have future plans for pointing features there

https://github.com/user-attachments/assets/9ad7c8bf-556f-4ed4-bd2c-b8536ab56929

