### PR TITLE
OnlineCreature: handle swallowed creatures

### DIFF
--- a/Online/Entity/OnlineCreature.cs
+++ b/Online/Entity/OnlineCreature.cs
@@ -64,13 +64,10 @@ namespace RainMeadow
                 RainMeadow.Debug("Unknown creature: " + array[0] + " creature not spawning");
                 return null;
             }
-            string[] array2 = array[2].Split(new char[]
-            {
-            '.'
-            });
+            string[] array2 = array[2].Split('.');
             EntityID id = EntityID.FromString(array[1]);
             int? num = BackwardsCompatibilityRemix.ParseRoomIndex(array2[0]);
-            if (num == null || !world.IsRoomInRegion(num.Value)) // handle non-unique (GATE) roomcodes
+            if (num == null || (num != -1 && !world.IsRoomInRegion(num.Value))) // handle non-unique (GATE) roomcodes
             {
                 num = world.GetAbstractRoom(array2[0]).index;
             }
@@ -83,16 +80,9 @@ namespace RainMeadow
             }
 
             abstractCreature.state.LoadFromString(Regex.Split(array[3], "<cB>"));
-            if (abstractCreature.Room == null)
+            if (abstractCreature.Room == null && num != -1)
             {
-                RainMeadow.Debug(string.Concat(new string[]
-                    {
-                        "Spawn room does not exist: ",
-                        array2[0],
-                        " ~ ",
-                        id.spawner.ToString(),
-                        " creature not spawning"
-                    }));
+                RainMeadow.Debug("Spawn room does not exist: " + array2[0] + " ~ " + id.spawner.ToString() + " creature not spawning");
                 return null;
             }
             abstractCreature.setCustomFlags();


### PR DESCRIPTION
swallowed creatures are denoted by room -1, handle it properly

returning a null abstractcreature seems to freeze the game