### PR TITLE
log deduplication

### DIFF
--- a/CustomLogListener.cs
+++ b/CustomLogListener.cs
@@ -1,0 +1,116 @@
+using BepInEx.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace RainMeadow
+{
+    public partial class RainMeadow
+    {
+        public class CustomLogListener : ILogListener
+        {
+            public static HashSet<string> BlacklistedSources = new() { "Unity", "Unity Log" };
+
+            public CustomLogListener(string localPath, bool delayedFlushing = false)
+            {
+                DisplayedLogLevel = LogLevel.Info;
+
+                FileStream fileStream;
+
+                if (!BepInEx.Utility.TryOpenFileStream(Path.Combine(BepInEx.Paths.BepInExRootPath, localPath),
+                    FileMode.Create, out fileStream, share: FileShare.Read, access: FileAccess.Write))
+                {
+                    Error($"couldn't open logfile {localPath}!");
+                    return;
+                }
+
+                LogWriter = TextWriter.Synchronized(new StreamWriter(fileStream, BepInEx.Utility.UTF8NoBom));
+
+                if (delayedFlushing) FlushTimer = new Timer(o => { LogWriter?.Flush(); }, null, 2000, 2000);
+
+                InstantFlushing = !delayedFlushing;
+            }
+
+            public LogLevel DisplayedLogLevel { get; }
+
+            public TextWriter LogWriter { get; protected set; }
+
+            private Timer FlushTimer { get; }
+
+            private bool InstantFlushing { get; }
+
+            public LogLevel LogLevelFilter => DisplayedLogLevel;
+
+            public int counter;
+
+            public string StripTime(string line)
+            {
+                if (line.Length > 35 && line.Substring(8, 20) == "RainMeadow")
+                {
+                    for (int i = 0, count = 2; i < line.Length; i++)
+                    {
+                        if (line[i] == '|')
+                        {
+                            count--;
+                            if (count == 0) return line.Substring(i + 1);
+                        }
+                    }
+                }
+                return line;
+            }
+
+            private string? lastStrippedLine;
+            public bool LogEventIsRepeat(string line)
+            {
+                var origStrippedLine = lastStrippedLine;
+                lastStrippedLine = StripTime(line);
+                return origStrippedLine == lastStrippedLine;
+            }
+
+            public void LogEvent(object sender, LogEventArgs eventArgs)
+            {
+                if (LogWriter == null)
+                    return;
+
+                if (BlacklistedSources.Contains(eventArgs.Source.SourceName))
+                    return;
+
+                var line = eventArgs.ToString();
+                if (LogEventIsRepeat(line))
+                {
+                    if (counter == 0)
+                        LogWriter.WriteLine("... repeated");
+                    counter++;
+                }
+                else
+                {
+                    if (counter > 0)
+                        LogWriter.WriteLine($"... {counter} times");
+                    counter = 0;
+                    LogWriter.WriteLine(line);
+                }
+
+                if (InstantFlushing)
+                    LogWriter.Flush();
+            }
+
+            public void Dispose()
+            {
+                FlushTimer?.Dispose();
+
+                try
+                {
+                    LogWriter?.Flush();
+                    LogWriter?.Dispose();
+                }
+                catch (ObjectDisposedException) { }
+            }
+
+            ~CustomLogListener()
+            {
+                Dispose();
+            }
+        }
+    }
+}

--- a/CustomLogListener.cs
+++ b/CustomLogListener.cs
@@ -14,13 +14,34 @@ namespace RainMeadow
         {
             public static HashSet<string> BlacklistedSources = new() { "Unity", "Unity Log" };
 
-            public CustomLogListener(string localPath, bool delayedFlushing = false)
+            public CustomLogListener(string localPath, int maxLogFiles = 5, string? rootPath = null, bool delayedFlushing = false)
             {
+                rootPath ??= BepInEx.Paths.BepInExRootPath;
+
+                try
+                {
+                    var logFiles = Directory.GetFiles(rootPath, "meadowLog.*.log");
+                    if (logFiles.Count() > maxLogFiles)
+                    {
+                        var i = logFiles.Count() - maxLogFiles;
+                        foreach (var path in logFiles)
+                        {
+                            if (i == 0) break;
+                            File.Delete(path);
+                            i--;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Error($"couldn't clean up meadowLog files: {e}");
+                }
+
                 DisplayedLogLevel = LogLevel.Info;
 
                 FileStream fileStream;
 
-                if (!BepInEx.Utility.TryOpenFileStream(Path.Combine(BepInEx.Paths.BepInExRootPath, localPath),
+                if (!BepInEx.Utility.TryOpenFileStream(Path.Combine(rootPath, localPath),
                     FileMode.Create, out fileStream, share: FileShare.Read, access: FileAccess.Write))
                 {
                     Error($"couldn't open logfile {localPath}!");

--- a/CustomLogListener.cs
+++ b/CustomLogListener.cs
@@ -60,9 +60,15 @@ namespace RainMeadow
 
             public LogLevel LogLevelFilter => DisplayedLogLevel;
 
-            public string StripNumbers(string line)
+            public string Strip(string line)
             {
-                return Regex.Replace(line, @"\d+", "{#}");
+                // strip timestamps
+                if (line.Substring(8, 13) == ":RainMeadow] " && line[29] == '|' && line[36] == '|')
+                {
+                    return line.Substring(37);
+                }
+                return line;
+                //return Regex.Replace(line, @"\d+", "{#}", RegexOptions.Compiled);  // TODO: fine-tune and benchmark
             }
 
             private int repeat;
@@ -70,7 +76,7 @@ namespace RainMeadow
 
             public bool LogEventIsRepeat(string line)
             {
-                var stripped = StripNumbers(line);
+                var stripped = Strip(line);
                 int i;
                 for (i = lastLines.Count - 1; i >= 0; i--)
                     if (lastLines.ElementAt(i).Item2 == stripped)
@@ -89,7 +95,7 @@ namespace RainMeadow
                 else if (repeat > 0)
                 {
                     if (repeat > lastLines.Count)
-                        LogWriter.WriteLine($"... {(int)repeat / lastLines.Count} times");
+                        LogWriter.WriteLine($"... {repeat / lastLines.Count} times");
                     var remainder = repeat % lastLines.Count;
                     for (var j = lastLines.Count - remainder; j > 0; j--)
                         lastLines.Dequeue();

--- a/CustomLogListener.cs
+++ b/CustomLogListener.cs
@@ -14,21 +14,18 @@ namespace RainMeadow
         {
             public static HashSet<string> BlacklistedSources = new() { "Unity", "Unity Log" };
 
-            public CustomLogListener(string localPath, int maxLogFiles = 5, string? rootPath = null, bool delayedFlushing = false)
+            public CustomLogListener(string localPath, int maxLogFiles = 2, string? rootPath = null, bool delayedFlushing = false)
             {
                 rootPath ??= BepInEx.Paths.BepInExRootPath;
 
                 try
                 {
-                    var logFiles = Directory.GetFiles(rootPath, "meadowLog.*.log");
-                    if (logFiles.Count() > maxLogFiles)
+                    var logFiles = Directory.GetFiles(rootPath, "meadowLog.*.log");  // assume sorted from oldest to newest
+                    if (logFiles.Count() >= maxLogFiles)
                     {
-                        var i = logFiles.Count() - maxLogFiles;
-                        foreach (var path in logFiles)
+                        foreach (var path in logFiles.Take(logFiles.Count() - maxLogFiles + 1))
                         {
-                            if (i == 0) break;
                             File.Delete(path);
-                            i--;
                         }
                     }
                 }
@@ -39,10 +36,8 @@ namespace RainMeadow
 
                 DisplayedLogLevel = LogLevel.Info;
 
-                FileStream fileStream;
-
                 if (!BepInEx.Utility.TryOpenFileStream(Path.Combine(rootPath, localPath),
-                    FileMode.Create, out fileStream, share: FileShare.Read, access: FileAccess.Write))
+                    FileMode.Create, out var fileStream, share: FileShare.Read, access: FileAccess.Write))
                 {
                     Error($"couldn't open logfile {localPath}!");
                     return;

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -133,6 +133,8 @@ namespace RainMeadow
 
                 MachineConnector.SetRegisteredOI("henpemaz_rainmeadow", rainMeadowOptions);
 
+                BepInEx.Logging.Logger.Listeners.Add(new CustomLogListener($"meadowLog.{MeadowVersionStr}.{DateTime.Now.ToUniversalTime():yyyyMMddHHmmss}.log"));
+
                 var sw = Stopwatch.StartNew();
                 OnlineState.InitializeBuiltinTypes();
                 sw.Stop();


### PR DESCRIPTION
LogOutput gets overwritten on game relaunch and many users simply forget to send it beforehand

this changes the log system to write to our own logfiles as well