### PR TITLE
Arena: syncs stats post avatar changes

### DIFF
--- a/Arena/ArenaHelpers.cs
+++ b/Arena/ArenaHelpers.cs
@@ -58,11 +58,10 @@ namespace RainMeadow
             {
 
                 var currentPlayer = ArenaHelpers.FindOnlinePlayerByLobbyId(arena.arenaSittingOnlineOrder[i]);
-
                 ArenaSitting.ArenaPlayer newPlayer = new ArenaSitting.ArenaPlayer(i)
                 {
                     playerNumber = i,
-                    playerClass = ((OnlineManager.lobby.clientSettings[currentPlayer].GetData<ArenaClientSettings>()).playingAs), // Set the playerClass to the OnlinePlayer
+                    playerClass = ((OnlineManager.lobby.clientSettings[currentPlayer].GetData<ArenaClientSettings>()).playingAs), // Set the playerClass to the OnlinePlayer. TODO: Try and find a way to go through avatarSettings for this
                     hasEnteredGameArea = true
                 };
 

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1037,8 +1037,6 @@ namespace RainMeadow
                         }
                     }
                 }
-
-
             }
         }
 

--- a/Arena/ArenaLobbyMenu.cs
+++ b/Arena/ArenaLobbyMenu.cs
@@ -141,11 +141,9 @@ namespace RainMeadow
 
         private void BindSettings()
         {
-            this.personaSettings = (OnlineManager.lobby.gameMode as ArenaCompetitiveGameMode).avatarSettings;
-            personaSettings.bodyColor = RainMeadow.rainMeadowOptions.BodyColor.Value;
-            personaSettings.eyeColor = RainMeadow.rainMeadowOptions.EyeColor.Value;
-            personaSettings.playingAs = SlugcatStats.Name.White;
-            arena.arenaClientSettings.playingAs = personaSettings.playingAs;
+            arena.avatarSettings.eyeColor = RainMeadow.rainMeadowOptions.EyeColor.Value;
+            arena.avatarSettings.bodyColor = RainMeadow.rainMeadowOptions.BodyColor.Value;
+            arena.avatarSettings.playingAs = SlugcatStats.Name.White;
         }
 
         void BuildLayout()
@@ -283,6 +281,7 @@ namespace RainMeadow
         private void StartGame()
         {
             RainMeadow.DebugMe();
+            
             if (OnlineManager.lobby == null || !OnlineManager.lobby.isActive) return;
 
             if (OnlineManager.lobby.isOwner && this.GetGameTypeSetup.playList != null && this.GetGameTypeSetup.playList.Count == 0)
@@ -539,7 +538,7 @@ namespace RainMeadow
             meClassButton = new ArenaOnlinePlayerJoinButton(this, pages[0], new Vector2(600f + 0 * num3, 500f) + new Vector2(106f, -20f) + new Vector2((num - 120f) / 2f, 0f) - new Vector2((num3 - 120f), 40f), 0);
             meClassButton.buttonBehav.greyedOut = false;
             meClassButton.readyForCombat = true;
-            var currentColorIndex = 0;
+            int currentColorIndex;
             if (arena.playersInLobbyChoosingSlugs.TryGetValue(OnlineManager.mePlayer.id.name, out var existingValue))
             {
                 currentColorIndex = arena.playersInLobbyChoosingSlugs[OnlineManager.mePlayer.id.name];
@@ -582,8 +581,8 @@ namespace RainMeadow
                 meClassButton.portrait.sprite.SetElementByName(meClassButton.portrait.fileName);
                 PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
 
-                personaSettings.playingAs = allSlugs[currentColorIndex];
-                arena.arenaClientSettings.playingAs = personaSettings.playingAs;
+                arena.avatarSettings.playingAs = allSlugs[currentColorIndex];
+                arena.arenaClientSettings.playingAs = arena.avatarSettings.playingAs;
 
                 if (OnlineManager.players.Count > 1 && !arena.allPlayersReadyLockLobby) // stop unnecessary RPCs
                 {
@@ -598,8 +597,13 @@ namespace RainMeadow
                 }
 
                 arena.playersInLobbyChoosingSlugs[OnlineManager.mePlayer.id.name] = currentColorIndex;
+
+
             };
             pages[0].subObjects.Add(meClassButton);
+            arena.avatarSettings.playingAs = allSlugs[currentColorIndex];
+            arena.arenaClientSettings.playingAs = arena.avatarSettings.playingAs;
+
         }
 
         private void AddMeUsername()


### PR DESCRIPTION
Ideally I'd use avatarSettings and not clientSettings anymore, but don't have access to that in the lobby data so am just having a dupe code to retrieve the playingAs in the lobby due to arenaSitting needs