### PR TITLE
Hotfix for multiple lobby select menu bugs

### DIFF
--- a/Menu/Dialogs/CustomInputDialogueBox.cs
+++ b/Menu/Dialogs/CustomInputDialogueBox.cs
@@ -7,7 +7,7 @@ namespace RainMeadow
     public class CustomInputDialogueBox : MenuDialogBox
     {
         protected MenuTabWrapper tabWrapper;
-
+        public SymbolButton cancelButton;
         public SimpleButton continueButton;
         public OpTextBox textBox;
         public UIelementWrapper textBoxWrapper;
@@ -28,6 +28,8 @@ namespace RainMeadow
             continueButton = new SimpleButton(menu, this, menu.Translate("CONFIRM"), signalText, where, new Vector2(110f, 30f));
             subObjects.Add(continueButton);
 
+            cancelButton = new SymbolButton(menu, this, "Menu_Symbol_Clear_All", "CLOSE_DIALOG", size - new Vector2(40f, 40f));
+            subObjects.Add(cancelButton);
         }
         public override void RemoveSprites()
         {

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -1,4 +1,4 @@
-﻿using Menu;
+using Menu;
 using Menu.Remix;
 using Menu.Remix.MixedUI;
 
@@ -215,6 +215,24 @@ namespace RainMeadow
         public override void Update()
         {
             base.Update();
+
+            bool popupVisible = popupDialog != null;
+
+            for (int i = 0; i < lobbyButtons.Length; i++)
+            {
+                lobbyButtons[i].buttonBehav.greyedOut = popupVisible;
+            }
+            lobbySearchInputBox.greyedOut = popupVisible;
+            modeDropDown.greyedOut = popupVisible;
+            visibilityDropDown.greyedOut = popupVisible;
+            enablePasswordCheckbox.buttonBehav.greyedOut = popupVisible;
+            passwordInputBox.greyedOut = popupVisible;
+            filterLobbyLimit.greyedOut = popupVisible;
+            filterModeDropDown.greyedOut = popupVisible;
+            filterPasswordDropDown.greyedOut = popupVisible;
+
+            if (popupVisible) return;
+
             int extraItems = Mathf.Max(lobbies.Length - 4, 0);
             scrollTo = Mathf.Clamp(scrollTo, -0.5f, extraItems + 0.5f);
             if (scrollTo < 0) scrollTo = RWCustom.Custom.LerpAndTick(scrollTo, 0, 0.1f, 0.1f);

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -155,14 +155,7 @@ namespace RainMeadow
                     SteamMatchmaking.SetLobbyData(lobbyID, CLIENT_KEY, CLIENT_VAL);
                     SteamMatchmaking.SetLobbyData(lobbyID, NAME_KEY, SteamFriends.GetPersonaName() + "'s Lobby");
                     SteamMatchmaking.SetLobbyData(lobbyID, MODE_KEY, creatingWithMode);
-                    if (lobbyPassword != null)
-                    {
-                        SteamMatchmaking.SetLobbyData(lobbyID, PASSWORD_KEY, "true");
-                    }
-                    else
-                    {
-                        SteamMatchmaking.SetLobbyData(lobbyID, PASSWORD_KEY, "false");
-                    }
+                    SteamMatchmaking.SetLobbyData(lobbyID, PASSWORD_KEY, lobbyPassword != null ? "true" : "false");
                     SteamMatchmaking.SetLobbyMemberLimit(lobbyID, MAX_LOBBY);
                     OnlineManager.lobby = new Lobby(new OnlineGameMode.OnlineGameModeType(creatingWithMode), OnlineManager.mePlayer, lobbyPassword);
                     SteamFriends.SetRichPresence("connect", lobbyID.ToString());


### PR DESCRIPTION
Grey out buttons when a popup dialog is open in the lobby menu to prevent accidentally clicking things outside of the popup dialog. Haven't had time to properly test it but I think it should work