### PR TITLE
Hotfix story load creatures

### DIFF
--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -268,6 +268,7 @@ namespace RainMeadow
                 if (isStoryMode(out var story))
                 {
                     story.storyClientData.isDead = false;
+                    OnlineManager.mePlayer.isActuallySpectating = false;
                 }
             }
             orig(self, saveStateNumber, game);

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -226,7 +226,6 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null)
             {
-                OnlineManager.mePlayer.isActuallySpectating = false;
                 playerCharacter = OnlineManager.lobby.gameMode.LoadWorldAs(game);
 
 

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -226,6 +226,7 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null)
             {
+                OnlineManager.mePlayer.isActuallySpectating = false;
                 playerCharacter = OnlineManager.lobby.gameMode.LoadWorldAs(game);
 
 

--- a/Story/OnlineUIComponents/SpectatorOverlay.cs
+++ b/Story/OnlineUIComponents/SpectatorOverlay.cs
@@ -50,7 +50,10 @@ namespace RainMeadow
                 {
                     this.button.toggled = !this.button.toggled;
                     overlay.spectatee = this.button.toggled ? opo.apo as AbstractCreature : null;
-                    OnlineManager.mePlayer.isActuallySpectating = overlay.spectatee == null || !this.player.isMine;
+                    bool result = OnlineManager.mePlayer.isActuallySpectating
+                    ? (overlay.spectatee == null || !this.player.isMine)
+                    : false;
+                    OnlineManager.mePlayer.isActuallySpectating = result;
 
                 };
                 this.button.owner.subObjects.Add(button);

--- a/Story/OnlineUIComponents/SpectatorOverlay.cs
+++ b/Story/OnlineUIComponents/SpectatorOverlay.cs
@@ -154,7 +154,6 @@ namespace RainMeadow
         public override void Update()
         {
             base.Update();
-            RainMeadow.Debug(OnlineManager.mePlayer.isActuallySpectating);
             UpdateList();
 
             foreach (var button in playerButtons)

--- a/Story/OnlineUIComponents/SpectatorOverlay.cs
+++ b/Story/OnlineUIComponents/SpectatorOverlay.cs
@@ -50,9 +50,7 @@ namespace RainMeadow
                 {
                     this.button.toggled = !this.button.toggled;
                     overlay.spectatee = this.button.toggled ? this.player.apo as AbstractCreature : null;
-                    bool result = !this.player.isMine ? true : overlay.spectatee == null ? false : false;
-
-                    OnlineManager.mePlayer.isActuallySpectating = result;
+                    OnlineManager.mePlayer.isActuallySpectating = overlay.spectatee == null || !this.player.isMine;
 
                 };
                 this.button.owner.subObjects.Add(button);

--- a/Story/OnlineUIComponents/SpectatorOverlay.cs
+++ b/Story/OnlineUIComponents/SpectatorOverlay.cs
@@ -49,10 +49,9 @@ namespace RainMeadow
                 this.button.OnClick += (_) =>
                 {
                     this.button.toggled = !this.button.toggled;
-                    overlay.spectatee = this.button.toggled ? opo.apo as AbstractCreature : null;
-                    bool result = OnlineManager.mePlayer.isActuallySpectating
-                    ? (overlay.spectatee == null || !this.player.isMine)
-                    : false;
+                    overlay.spectatee = this.button.toggled ? this.player.apo as AbstractCreature : null;
+                    bool result = !this.player.isMine ? true : overlay.spectatee == null ? false : false;
+
                     OnlineManager.mePlayer.isActuallySpectating = result;
 
                 };
@@ -155,7 +154,7 @@ namespace RainMeadow
         public override void Update()
         {
             base.Update();
-
+            RainMeadow.Debug(OnlineManager.mePlayer.isActuallySpectating);
             UpdateList();
 
             foreach (var button in playerButtons)

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -484,9 +484,7 @@ namespace RainMeadow
         private void RainWorldGame_GoToDeathScreen(On.RainWorldGame.orig_GoToDeathScreen orig, RainWorldGame self)
         {
             if (isStoryMode(out var gameMode))
-            {
-                OnlineManager.mePlayer.isActuallySpectating = false;
-                
+            {                
                 if (OnlineManager.lobby.isOwner)
                 {
                     RPCs.MovePlayersToDeathScreen();
@@ -657,7 +655,6 @@ namespace RainMeadow
 
             if (isStoryMode(out var gameMode))
             {
-                OnlineManager.mePlayer.isActuallySpectating = false;
                 isPlayerReady = false;
                 gameMode.didStartCycle = false;
             }

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -485,6 +485,8 @@ namespace RainMeadow
         {
             if (isStoryMode(out var gameMode))
             {
+                OnlineManager.mePlayer.isActuallySpectating = false;
+                
                 if (OnlineManager.lobby.isOwner)
                 {
                     RPCs.MovePlayersToDeathScreen();

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -657,6 +657,7 @@ namespace RainMeadow
 
             if (isStoryMode(out var gameMode))
             {
+                OnlineManager.mePlayer.isActuallySpectating = false;
                 isPlayerReady = false;
                 gameMode.didStartCycle = false;
             }


### PR DESCRIPTION
Was investigating missing critters:

```
[Info   :RainMeadow] 18:31:43|914365|SpectatorOverlay.Update:True
[Info   :RainMeadow] 18:31:43|914365|RPCManager.BuildRPC:Sending RPC: Void GoToDeathScreen()

```

we're entering the next process still considered spectating 

- [x] Test
Tested, works.