### PR TITLE
Arena: Arena sync over flow ready up

### DIFF
--- a/Arena/ArenaHelpers.cs
+++ b/Arena/ArenaHelpers.cs
@@ -31,6 +31,11 @@ namespace RainMeadow
             }
             arena.allPlayersReadyLockLobby = false;
             arena.clientsAreReadiedUp = 0;
+            foreach (var player in OnlineManager.players)
+            {
+                arena.playersReadiedUp[player.id.name] = false;
+            }
+            
             arena.isInGame = false;
             arena.returnToLobby = false;
             lobby.manager.rainWorld.options.DeleteArenaSitting();

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -30,6 +30,8 @@ namespace RainMeadow
             public Dictionary<string, bool> onlineArenaSettingsInterfaceBool;
             [OnlineField]
             public Dictionary<string, int> playersChoosingSlugs;
+            [OnlineField]
+            public Dictionary<string, bool> playersReadiedUp;
 
             public State() { }
             public State(ArenaLobbyData arenaLobbyData, OnlineResource onlineResource)
@@ -43,6 +45,7 @@ namespace RainMeadow
                 onlineArenaSettingsInterfaceMultiChoice = arena.onlineArenaSettingsInterfaceMultiChoice;
                 onlineArenaSettingsInterfaceBool = arena.onlineArenaSettingsInterfaceeBool;
                 playersChoosingSlugs = arena.playersInLobbyChoosingSlugs;
+                playersReadiedUp = arena.playersReadiedUp;
             }
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
@@ -56,6 +59,8 @@ namespace RainMeadow
                 (lobby.gameMode as ArenaCompetitiveGameMode).onlineArenaSettingsInterfaceMultiChoice = onlineArenaSettingsInterfaceMultiChoice;
                 (lobby.gameMode as ArenaCompetitiveGameMode).onlineArenaSettingsInterfaceeBool = onlineArenaSettingsInterfaceBool;
                 (lobby.gameMode as ArenaCompetitiveGameMode).playersInLobbyChoosingSlugs = playersChoosingSlugs;
+                (lobby.gameMode as ArenaCompetitiveGameMode).playersReadiedUp = playersReadiedUp;
+
 
 
             }

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -30,8 +30,7 @@ namespace RainMeadow
             public Dictionary<string, bool> onlineArenaSettingsInterfaceBool;
             [OnlineField]
             public Dictionary<string, int> playersChoosingSlugs;
-            [OnlineField]
-            public Dictionary<string, bool> playersReadiedUp;
+
 
             public State() { }
             public State(ArenaLobbyData arenaLobbyData, OnlineResource onlineResource)
@@ -45,7 +44,6 @@ namespace RainMeadow
                 onlineArenaSettingsInterfaceMultiChoice = arena.onlineArenaSettingsInterfaceMultiChoice;
                 onlineArenaSettingsInterfaceBool = arena.onlineArenaSettingsInterfaceeBool;
                 playersChoosingSlugs = arena.playersInLobbyChoosingSlugs;
-                playersReadiedUp = arena.playersReadiedUp;
             }
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
@@ -59,7 +57,6 @@ namespace RainMeadow
                 (lobby.gameMode as ArenaCompetitiveGameMode).onlineArenaSettingsInterfaceMultiChoice = onlineArenaSettingsInterfaceMultiChoice;
                 (lobby.gameMode as ArenaCompetitiveGameMode).onlineArenaSettingsInterfaceeBool = onlineArenaSettingsInterfaceBool;
                 (lobby.gameMode as ArenaCompetitiveGameMode).playersInLobbyChoosingSlugs = playersChoosingSlugs;
-                (lobby.gameMode as ArenaCompetitiveGameMode).playersReadiedUp = playersReadiedUp;
 
 
 

--- a/Arena/ArenaLobbyMenu.cs
+++ b/Arena/ArenaLobbyMenu.cs
@@ -517,7 +517,7 @@ namespace RainMeadow
                         {
                             if (arena.playersInLobbyChoosingSlugs.TryGetValue(player.id.name, out var existingValue))
                             {
-                                RainMeadow.Debug("Player already exists in online dictionary");
+                                RainMeadow.Debug("Player already exists in slug dictionary");
                             }
                             else
                             {
@@ -527,7 +527,7 @@ namespace RainMeadow
 
                             if (arena.playersReadiedUp.TryGetValue(player.id.name, out var alreadyReady))
                             {
-                                RainMeadow.Debug("Player already exists in online dictionary");
+                                RainMeadow.Debug("Player already exists in readiedUp dictionary");
                             }
                             else
                             {

--- a/Arena/ArenaLobbyMenu.cs
+++ b/Arena/ArenaLobbyMenu.cs
@@ -676,7 +676,6 @@ namespace RainMeadow
 
                     classButtons[l] = new ArenaOnlinePlayerJoinButton(this, pages[0], new Vector2(600f + l * num3, 500f) + new Vector2(106f, -20f) + new Vector2((num - 120f) / 2f, 0f) - new Vector2((num3 - 120f) * classButtons.Length, 40f), l);
                     classButtons[l].buttonBehav.greyedOut = true;
-                    classButtons[l].readyForCombat = false;
 
                     classButtons[l].portraitBlack = Custom.LerpAndTick(classButtons[l].portraitBlack, 1f, 0.06f, 0.05f);
                     var currentColorIndex = arena.playersInLobbyChoosingSlugs[OnlineManager.players[l].id.name];

--- a/Arena/ArenaLobbyMenu.cs
+++ b/Arena/ArenaLobbyMenu.cs
@@ -524,6 +524,16 @@ namespace RainMeadow
                                 // Key does not exist, you can add it if needed
                                 arena.playersInLobbyChoosingSlugs.Add(player.id.name, 0);
                             }
+
+                            if (arena.playersReadiedUp.TryGetValue(player.id.name, out var alreadyReady))
+                            {
+                                RainMeadow.Debug("Player already exists in online dictionary");
+                            }
+                            else
+                            {
+                                // Key does not exist, you can add it if needed
+                                arena.playersReadiedUp.Add(player.id.name, false);
+                            }
                         }
                     }
                     AddOtherUsernameButtons();
@@ -612,6 +622,7 @@ namespace RainMeadow
                 arena.playersInLobbyChoosingSlugs[OnlineManager.mePlayer.id.name] = currentColorIndex;
 
 
+
             };
             pages[0].subObjects.Add(meClassButton);
             arena.avatarSettings.playingAs = allSlugs[currentColorIndex];
@@ -663,8 +674,10 @@ namespace RainMeadow
 
                     if (this.usernameButtons[l].menuLabel.text == OnlineManager.players[l].id.name) // we have our mark
 
-                        classButtons[l] = new ArenaOnlinePlayerJoinButton(this, pages[0], new Vector2(600f + l * num3, 500f) + new Vector2(106f, -20f) + new Vector2((num - 120f) / 2f, 0f) - new Vector2((num3 - 120f) * classButtons.Length, 40f), l);
+                    classButtons[l] = new ArenaOnlinePlayerJoinButton(this, pages[0], new Vector2(600f + l * num3, 500f) + new Vector2(106f, -20f) + new Vector2((num - 120f) / 2f, 0f) - new Vector2((num3 - 120f) * classButtons.Length, 40f), l);
                     classButtons[l].buttonBehav.greyedOut = true;
+                    classButtons[l].readyForCombat = false;
+
                     classButtons[l].portraitBlack = Custom.LerpAndTick(classButtons[l].portraitBlack, 1f, 0.06f, 0.05f);
                     var currentColorIndex = arena.playersInLobbyChoosingSlugs[OnlineManager.players[l].id.name];
 
@@ -813,6 +826,13 @@ namespace RainMeadow
                 }
                 classButtons[holdPlayerPosition].portrait.LoadFile();
                 classButtons[holdPlayerPosition].portrait.sprite.SetElementByName(classButtons[holdPlayerPosition].portrait.fileName);
+                try
+                {
+                    classButtons[holdPlayerPosition].readyForCombat = arena.playersReadiedUp[OnlineManager.players[currentPlayerPosition + 1].id.name];
+                } catch
+                {
+                    classButtons[holdPlayerPosition].readyForCombat = false;
+                }
 
                 currentPlayerPosition++;
 
@@ -857,6 +877,14 @@ namespace RainMeadow
                 }
                 classButtons[holdPlayerPosition].portrait.LoadFile();
                 classButtons[holdPlayerPosition].portrait.sprite.SetElementByName(classButtons[holdPlayerPosition].portrait.fileName);
+                try
+                {
+                    classButtons[holdPlayerPosition].readyForCombat = arena.playersReadiedUp[OnlineManager.players[currentPlayerPosition - 1].id.name];
+                }
+                catch
+                {
+                    classButtons[holdPlayerPosition].readyForCombat = false;
+                }
 
                 currentPlayerPosition--;
                 if (currentPlayerPosition - 1 <= 3)

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -155,6 +155,7 @@ namespace RainMeadow
                     return;
                 }
                 arena.clientsAreReadiedUp++;
+                arena.playersReadiedUp[userIsReady] = true;
 
                 try
                 {
@@ -165,7 +166,6 @@ namespace RainMeadow
                         {
 
                             game.classButtons[i].readyForCombat = true;
-                            arena.playersReadiedUp[userIsReady] = true;
 
                         }
 

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -165,6 +165,8 @@ namespace RainMeadow
                         {
 
                             game.classButtons[i].readyForCombat = true;
+                            arena.playersReadiedUp[userIsReady] = true;
+
                         }
 
                     }

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -12,6 +12,8 @@ namespace RainMeadow
         public Dictionary<string, int> onlineArenaSettingsInterfaceMultiChoice = new Dictionary<string, int>();
         public Dictionary<string, bool> onlineArenaSettingsInterfaceeBool = new Dictionary<string, bool>();
         public Dictionary<string, int> playersInLobbyChoosingSlugs = new Dictionary<string, int>();
+        public Dictionary<string, bool> playersReadiedUp = new Dictionary<string, bool>();
+
 
 
         public ArenaClientSettings arenaClientSettings;


### PR DESCRIPTION
Enables users to view slugs in overflow list if they're ready, which is a pre-req prior to implementing banning users from lobby (presumedly from being AFK )

- [ ] Test