### PR TITLE
Story: fix swallow tracker

### DIFF
--- a/Online/State/PhysicalObjectEntityState.cs
+++ b/Online/State/PhysicalObjectEntityState.cs
@@ -73,6 +73,10 @@ namespace RainMeadow
                 {
                     if (wasPos.room != -1)
                     {
+                        if (apo.world.game.session is StoryGameSession storyGameSession)
+                        {
+                            storyGameSession.RemovePersistentTracker(apo);
+                        }
                         if (apo.realizedObject is PhysicalObject po)
                         {
                             po.RemoveFromRoom();

--- a/Online/State/PhysicalObjectEntityState.cs
+++ b/Online/State/PhysicalObjectEntityState.cs
@@ -107,6 +107,18 @@ namespace RainMeadow
                     else
                     {
                         if (apo.world.IsRoomInRegion(pos.room)) apo.world.GetAbstractRoom(pos).AddEntity(apo);
+                        if (ModManager.MMF && MoreSlugcats.MMF.cfgKeyItemTracking.Value && AbstractPhysicalObject.UsesAPersistantTracker(apo) && apo.world.game.session is StoryGameSession storyGameSession)
+                        {
+                            storyGameSession.AddNewPersistentTracker(apo);
+                            /* remix key item tracking TODO: get player that puked this up
+                            if (apo.Room.NOTRACKERS)
+                            {
+                                apo.tracker.lastSeenRegion = lastGoodTrackerSpawnRegion;
+                                apo.tracker.lastSeenRoom = lastGoodTrackerSpawnRoom;
+                                apo.tracker.ChangeDesiredSpawnLocation(lastGoodTrackerSpawnCoord);
+                            }
+                            */
+                        }
                     }
                 }
             }


### PR DESCRIPTION
remove persistent tracker for remote swallowed items

was breaking map and sleepanddeathscreen