### PR TITLE
refactor swallowed items

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -139,6 +139,8 @@ public partial class RainMeadow
 
     private void Player_Update1(On.Player.orig_Update orig, Player self, bool eu)
     {
+        if (OnlineManager.lobby != null && self.objectInStomach != null)
+            self.objectInStomach.pos = self.abstractCreature.pos;
         if (isStoryMode(out var gameMode) && self.abstractCreature.IsLocal())
             gameMode.storyClientData.readyForWin = false;
         orig(self, eu);
@@ -506,7 +508,7 @@ public partial class RainMeadow
                 {
                     if (!oe.isMine) return false;
                     if (objectInStomach.GetOnlineObject(out var oeInStomach))
-                        oeInStomach.realized = false; // don't release ownership
+                        oeInStomach.realized = false;  // don't release ownership
                 }
                 return true;
             });
@@ -525,7 +527,11 @@ public partial class RainMeadow
             c.EmitDelegate((Player self) =>
             {
                 if (OnlineManager.lobby != null && self.abstractPhysicalObject.GetOnlineObject(out var oe))
-                    self.objectInStomach.pos.room = -1; // signal not-in-a-room
+                {
+                    // signal not-in-a-room
+                    self.objectInStomach.InDen = true;
+                    self.objectInStomach.pos.WashNode();
+                }
             });
             c.MarkLabel(skip);
         }
@@ -540,7 +546,11 @@ public partial class RainMeadow
         if (OnlineManager.lobby != null && self.abstractPhysicalObject.GetOnlineObject(out var oe))
         {
             if (!oe.isMine) return; // prevent execution
-            if (self.objectInStomach != null) self.objectInStomach.pos = self.abstractCreature.pos; // so it picks up in room.addentity hook, otherwise skipped
+            if (self.objectInStomach != null)
+            {
+                self.objectInStomach.pos = self.abstractCreature.pos; // so it picks up in room.addentity hook, otherwise skipped
+                self.objectInStomach.InDen = false;
+            }
         }
         orig(self);
     }

--- a/Online/Entity/OnlinePhysicalObject.cs
+++ b/Online/Entity/OnlinePhysicalObject.cs
@@ -439,6 +439,16 @@ namespace RainMeadow
         public override void ResolveRequest(GenericResult requestResult)
         {
             base.ResolveRequest(requestResult);
+            if (requestResult is GenericResult.Ok)
+            {
+                if (apo.InDen && !apo.pos.NodeDefined)  // was stomach object
+                {
+                    apo.InDen = false;
+                    apo.Room.AddEntity(apo);
+                    if (apo.Room.realizedRoom is not null)
+                        apo.RealizeInRoom();
+                }
+            }
             if (requestResult is GenericResult.Error && apo.realizedObject is not null)
             {
                 foreach (var grasp in apo.realizedObject.grabbedBy)

--- a/Online/State/PhysicalObjectEntityState.cs
+++ b/Online/State/PhysicalObjectEntityState.cs
@@ -67,45 +67,22 @@ namespace RainMeadow
             var wasPos = apo.pos;
             try
             {
-                if (pos.room == -1)
+                if (inDen != apo.InDen)
                 {
-                    if (wasPos.room != -1)
+                    if (inDen)
                     {
-                        if (apo.world.game.session is StoryGameSession storyGameSession)
+                        RainMeadow.Debug("moving to den: " + onlineObject);
+                        if (!apo.pos.NodeDefined && apo.world.game.session is StoryGameSession storyGameSession)
                         {
                             storyGameSession.RemovePersistentTracker(apo);
                         }
-                        if (apo.realizedObject is PhysicalObject po)
-                        {
-                            po.RemoveFromRoom();
-                            apo.Abstractize(wasPos);
-                        }
-                        apo.Room.RemoveEntity(apo);
-                    }
-                }
-                else
-                {
-                    if (inDen != apo.InDen)
-                    {
-                        if (inDen)
-                        {
-                            RainMeadow.Debug("moving to den: " + onlineObject);
-                            apo.IsEnteringDen(pos);
-                        }
-                        else
-                        {
-                            RainMeadow.Debug("moving out of den: " + onlineObject);
-                            apo.IsExitingDen();
-                        }
-                    }
-                    if (wasPos.room != -1)
-                    {
-                        apo.Move(pos);
+                        apo.IsEnteringDen(pos);
                     }
                     else
                     {
-                        if (apo.world.IsRoomInRegion(pos.room)) apo.world.GetAbstractRoom(pos).AddEntity(apo);
-                        if (ModManager.MMF && MoreSlugcats.MMF.cfgKeyItemTracking.Value && AbstractPhysicalObject.UsesAPersistantTracker(apo) && apo.world.game.session is StoryGameSession storyGameSession)
+                        RainMeadow.Debug("moving out of den: " + onlineObject);
+                        if (!apo.pos.NodeDefined && apo.world.game.session is StoryGameSession storyGameSession
+                            && ModManager.MMF && MoreSlugcats.MMF.cfgKeyItemTracking.Value && AbstractPhysicalObject.UsesAPersistantTracker(apo))
                         {
                             storyGameSession.AddNewPersistentTracker(apo);
                             /* remix key item tracking TODO: get player that puked this up
@@ -117,8 +94,10 @@ namespace RainMeadow
                             }
                             */
                         }
+                        apo.IsExitingDen();
                     }
                 }
+                apo.Move(pos);
             }
             catch (Exception e)
             {

--- a/Online/State/PlayerStateState.cs
+++ b/Online/State/PlayerStateState.cs
@@ -21,7 +21,9 @@
 
             if ((abstractCreature.realizedCreature as Player)?.objectInStomach is AbstractPhysicalObject apo)
             {
-                apo.pos.room = -1; // signal not-in-a-room
+                // signal not-in-a-room
+                apo.InDen = true;
+                apo.pos.WashNode();
                 if (apo.realizedObject != null) apo.Abstractize(abstractCreature.pos);
                 if (!OnlinePhysicalObject.map.TryGetValue(apo, out var oe))
                 {


### PR DESCRIPTION
fixes client stomach items

use `InDen` instead of `room -1`

allows for preserving client stomach items across cycles, stomach items will appear inside the shelter