### PR TITLE
6fears7 story prevent self kill with spear

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -50,6 +50,7 @@ public partial class RainMeadow
     }
 
 
+
     private void PlayerGraphics_DrawSprites2(On.PlayerGraphics.orig_DrawSprites orig, PlayerGraphics self, RoomCamera.SpriteLeaser sLeaser, RoomCamera rCam, float timeStacker, Vector2 camPos)
     {
         orig(self, sLeaser, rCam, timeStacker, camPos);
@@ -144,20 +145,22 @@ public partial class RainMeadow
         if (isStoryMode(out var gameMode) && self.abstractCreature.IsLocal())
             gameMode.storyClientData.readyForWin = false;
         orig(self, eu);
-        if (isStoryMode(out var _) && !self.inShortcut && OnlineManager.players.Count > 4)
+        if (isStoryMode(out var _) && !self.inShortcut && OnlineManager.players.Count >= 1)
         {
             if (self.room.abstractRoom.shelter || self.room.IsGateRoom())
             {
-                if (self.collisionLayer != 0)
+                if (!self.IsLocal() && self.collisionLayer != 0)
                 {
                     self.room.ChangeCollisionLayerForObject(self, 0);
+
                 }
             }
             else
             {
-                if (self.collisionLayer != 1)
+                if (!self.IsLocal() && self.collisionLayer != 1)
                 {
                     self.room.ChangeCollisionLayerForObject(self, 1);
+
                 }
             }
         }
@@ -290,7 +293,6 @@ public partial class RainMeadow
             orig(self);
             return;
         }
-
         if (!OnlinePhysicalObject.map.TryGetValue(self.abstractPhysicalObject, out var onlineEntity)) throw new InvalidProgrammerException("Player doesn't have OnlineEntity counterpart!!");
         if (!onlineEntity.isMine) return;
 

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -145,7 +145,7 @@ public partial class RainMeadow
         if (isStoryMode(out var gameMode) && self.abstractCreature.IsLocal())
             gameMode.storyClientData.readyForWin = false;
         orig(self, eu);
-        if (isStoryMode(out var _) && !self.inShortcut && OnlineManager.players.Count >= 1)
+        if (isStoryMode(out var _) && !self.inShortcut && OnlineManager.players.Count > 4)
         {
             if (self.room.abstractRoom.shelter || self.room.IsGateRoom())
             {


### PR DESCRIPTION
This prevents killing yourself with a normal spear. Are there any conditions in base game where this kind of behavior would be expected?

Behavior now is that players are temporarily stunned from the physics of the spear impact. 

https://github.com/user-attachments/assets/af5fd18e-e6f3-4016-af62-1f75e92e7049


(worse) Alternatives:

1. Change collision layer for spear after it's collided (messier code)
2. Change collision layer for player after an object is thrown in those rooms
3. Remove change in player collision in rooms