### PR TITLE
add isPup sync

### DIFF
--- a/Online/State/RealizedPlayerState.cs
+++ b/Online/State/RealizedPlayerState.cs
@@ -14,6 +14,8 @@ namespace RainMeadow
         private bool standing;
         [OnlineField]
         private bool glowing;
+        [OnlineField]
+        private bool isPup;
         [OnlineField(nullable = true)]
         private OnlineEntity.EntityId? spearOnBack;
         //[OnlineField(nullable = true)]
@@ -46,6 +48,7 @@ namespace RainMeadow
             bodyModeIndex = (byte)p.bodyMode.Index;
             standing = p.standing;
             glowing = p.glowing;
+            isPup = p.playerState.isPup;
             spearOnBack = (p.spearOnBack?.spear?.abstractPhysicalObject is AbstractPhysicalObject apo
                 && OnlinePhysicalObject.map.TryGetValue(apo, out var oe)) ? oe.id : null;
             //slugOnBack = (p.slugOnBack?.slugcat?.abstractPhysicalObject is AbstractPhysicalObject apo0
@@ -105,6 +108,8 @@ namespace RainMeadow
                 pl.bodyMode = new Player.BodyModeIndex(Player.BodyModeIndex.values.GetEntry(bodyModeIndex));
                 pl.standing = standing;
                 pl.glowing = glowing;
+                if (pl.playerState.isPup != isPup)
+                    pl.playerState.isPup = isPup;
                 if (pl.spearOnBack != null)
                     pl.spearOnBack.spear = (spearOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Spear;
                 //if (pl.slugOnBack != null)


### PR DESCRIPTION
Support for [Rain Meadow Pupifier](https://github.com/xamionex/RainMeadowPupifier) (and additionally other mods that want to change isPup)

Basically just syncs the playerstate.isPup between players
It doesn't do anything functionally other than telling the game how to visually render us
So for people without pup mods, we look like pups, but it doesn't do anything more than that
But for people with pup mods, it enables syncing if they're a pup and the mods will function normally

- Tested with [RMP](https://github.com/xamionex/RainMeadowPupifier) and it worked fine
- Tested without RMP and it worked fine
- Tested with/without mod in gourmand ending, worked both ways
- It works when we have host and client discrepancy (aka host has mod/client doesnt, host has/client doesnt)

Comment anything you want me to test here