### PR TITLE
sync player grabbing vines

### DIFF
--- a/Online/Entity/OnlinePhysicalObject.cs
+++ b/Online/Entity/OnlinePhysicalObject.cs
@@ -92,6 +92,7 @@ namespace RainMeadow
 
         public readonly AbstractPhysicalObject apo;
         public bool realized;
+        public bool lenientPos;
 
         public bool beingMoved;
         public static ConditionalWeakTable<AbstractPhysicalObject, OnlinePhysicalObject> map = new();

--- a/Online/State/RealizedPlayerState.cs
+++ b/Online/State/RealizedPlayerState.cs
@@ -3,10 +3,28 @@
 namespace RainMeadow
 {
     [DeltaSupport(level = StateHandler.DeltaSupport.NullableDelta)]
+    public class VinePositionState : OnlineState
+    {
+        [OnlineField]
+        int vine;
+        [OnlineFieldHalf]
+        float floatPos;
+
+        public VinePositionState() { }
+        public VinePositionState(ClimbableVinesSystem.VinePosition vinePos)
+        {
+            vine = vinePos.vine;
+            floatPos = vinePos.floatPos;
+        }
+
+        public ClimbableVinesSystem.VinePosition GetVinePosition() => new(vine, floatPos);
+    }
+
+    [DeltaSupport(level = StateHandler.DeltaSupport.NullableDelta)]
     public class PlayerInAntlersState : OnlineState
     {
         [OnlineField(nullable = true)]
-        OnlinePhysicalObject? onlineDeer;
+        public OnlinePhysicalObject? onlineDeer;
         [OnlineField]
         bool dangle;
         [OnlineField(nullable = true)]
@@ -75,6 +93,8 @@ namespace RainMeadow
 
     public class RealizedPlayerState : RealizedCreatureState
     {
+        [OnlineField(nullable = true)]
+        private VinePositionState? vinePosState;
         [OnlineField(nullable = true)]
         private PlayerInAntlersState? playerInAntlersState;
         [OnlineField]
@@ -147,11 +167,14 @@ namespace RainMeadow
                 | (i.thrw ? 1 << 8 : 0)
                 | (i.mp ? 1 << 9 : 0));
 
+            vinePosState = p.animation != Player.AnimationIndex.VineGrab || p.vinePos is null ? null : new VinePositionState(p.vinePos);
+
             playerInAntlersState = p.playerInAntlers is null ? null : new PlayerInAntlersState(p.playerInAntlers);
 
             analogInputX = i.analogueDir.x;
             analogInputY = i.analogueDir.y;
         }
+
         public Player.InputPackage GetInput()
         {
             RainMeadow.Trace(inputs);
@@ -170,53 +193,69 @@ namespace RainMeadow
             i.analogueDir.y = analogInputY;
             return i;
         }
-        
+
+        private bool ShouldPosBeLenient(PhysicalObject po)
+        {
+            if (po is not Player p) { RainMeadow.Error("target is wrong type: " + po); return false; }
+
+            if (vinePosState is not null && p.animation == Player.AnimationIndex.VineGrab) return true;
+            if (p.playerInAntlers is not null && p.playerInAntlers.deer == playerInAntlersState?.onlineDeer?.apo.realizedObject) return true;
+
+            return false;
+        }
+
         public override void ReadTo(OnlineEntity onlineEntity)
         {
             RainMeadow.Trace(this + " - " + onlineEntity);
-            if (playerInAntlersState != null) this.chunkPosLeniency = 20f * 4;
+            var oc = onlineEntity as OnlineCreature;
+            var p = oc?.apo.realizedObject as Player;
+            if (p is not null) oc.lenientPos = ShouldPosBeLenient(p);
             base.ReadTo(onlineEntity);
-            if ((onlineEntity as OnlineCreature).apo.realizedObject is Player pl)
+            if (p is null) { RainMeadow.Error("target not realized: " + onlineEntity); return; }
+
+            var wasAnimation = p.animation;
+            p.animation = new Player.AnimationIndex(Player.AnimationIndex.values.GetEntry(animationIndex));
+            if (wasAnimation != p.animation) p.animationFrame = animationFrame;
+            p.bodyMode = new Player.BodyModeIndex(Player.BodyModeIndex.values.GetEntry(bodyModeIndex));
+            p.standing = standing;
+            p.glowing = glowing;
+            if (p.playerState.isPup != isPup)
+                p.playerState.isPup = isPup;
+            if (p.spearOnBack != null)
+                p.spearOnBack.spear = (spearOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Spear;
+            //if (pl.slugOnBack != null)
+            //    pl.slugOnBack.slugcat = (slugOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Player;
+
+            if (p.tongue is Player.Tongue tongue)
             {
-                var wasAnimation = pl.animation;
-                pl.animation = new Player.AnimationIndex(Player.AnimationIndex.values.GetEntry(animationIndex));
-                if (wasAnimation != pl.animation) pl.animationFrame = animationFrame;
-                pl.bodyMode = new Player.BodyModeIndex(Player.BodyModeIndex.values.GetEntry(bodyModeIndex));
-                pl.standing = standing;
-                pl.glowing = glowing;
-                if (pl.playerState.isPup != isPup)
-                    pl.playerState.isPup = isPup;
-                if (pl.spearOnBack != null)
-                    pl.spearOnBack.spear = (spearOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Spear;
-                //if (pl.slugOnBack != null)
-                //    pl.slugOnBack.slugcat = (slugOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Player;
-
-                if (pl.tongue is Player.Tongue tongue)
+                tongue.mode = new Player.Tongue.Mode(Player.Tongue.Mode.values.GetEntry(tongueMode));
+                tongue.pos = tonguePos;
+                tongue.idealRopeLength = tongueIdealLength;
+                tongue.requestedRopeLength = tongueRequestedLength;
+                if (tongue.mode == Player.Tongue.Mode.AttachedToTerrain)
                 {
-                    tongue.mode = new Player.Tongue.Mode(Player.Tongue.Mode.values.GetEntry(tongueMode));
-                    tongue.pos = tonguePos;
-                    tongue.idealRopeLength = tongueIdealLength;
-                    tongue.requestedRopeLength = tongueRequestedLength;
-                    if (tongue.mode == Player.Tongue.Mode.AttachedToTerrain)
-                    {
-                        tongue.terrainStuckPos = tongue.pos;
-                    }
-                    else if (tongue.mode == Player.Tongue.Mode.AttachedToObject)
-                    {
-                        tongue.attachedChunk = tongueAttachedChunk.ToBodyChunk();
-                    }
+                    tongue.terrainStuckPos = tongue.pos;
                 }
-
-                if (playerInAntlersState is not null) playerInAntlersState.ReadTo(pl);
-                else if (pl.playerInAntlers is not null)
+                else if (tongue.mode == Player.Tongue.Mode.AttachedToObject)
                 {
-                    pl.playerInAntlers.playerDisconnected = true;
-                    pl.playerInAntlers = null;
+                    tongue.attachedChunk = tongueAttachedChunk.ToBodyChunk();
                 }
             }
-            else
+
+            p.vinePos = vinePosState?.GetVinePosition();
+            if (vinePosState is not null)
             {
-                RainMeadow.Error("target not realized: " + onlineEntity);
+                p.room.climbableVines.ConnectChunkToVine(p.bodyChunks[0], p.vinePos, p.room.climbableVines.VineRad(p.vinePos));
+            }
+
+            if (playerInAntlersState is not null)
+            {
+                playerInAntlersState.ReadTo(p);
+            }
+            else if (p.playerInAntlers is not null)
+            {
+                p.playerInAntlers.playerDisconnected = true;
+                p.playerInAntlers = null;
             }
         }
     }


### PR DESCRIPTION
doesn't sync the position of the vine itself, which can get noticeably desynced

also change chunkPosLeniency to a bool in opo that skips chunk sync entirely rather than relying on a threshold, as suggested by henpe

(the diff looks weird because i unindented some stuff)