### PR TITLE
Split RequireCampaignSlugcat from SlugcatCustomToggle

### DIFF
--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -108,13 +108,14 @@ public class RainMeadowOptions : OptionInterface
                 new OpLabel(10f, 400, "[Experimental Features]", bigText: true),
                 new OpLabel(10f, 380, "WARNING: Experimental features may cause data corruption, back up your saves", bigText: false),
 
-                new OpLabel(10f, 350, "Custom Story Slugcat", bigText: false),
+                new OpLabel(10f, 350, "Custom Story Slugcat:", bigText: false),
 
-                new OpCheckBox(SlugcatCustomToggle, new Vector2(10f, 320)),
-                new OpLabel(40f, 320, RWCustom.Custom.ReplaceLineDelimeters("If selected, hosts can choose slugcat campaigns that are unstable. <LINE>Clients can choose their own Slugcats inside a host's Story campaign"))
+                new OpCheckBox(SlugcatCustomToggle, new Vector2(160f, 350)),
+
+                new OpLabel(40f, 320, RWCustom.Custom.ReplaceLineDelimeters("If selected, hosts can choose slugcat campaigns that are unstable."))
                 {
                     verticalAlignment = OpLabel.LabelVAlignment.Center
-                },
+                }
            };
             storyTab.AddItems(OnlineStorySettings);
 

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -14,6 +14,7 @@ namespace RainMeadow
         public string? defaultDenPos;
         public string? region = null;
         public SlugcatStats.Name currentCampaign;
+        public bool requireCampaignSlugcat;
         public string? saveStateString;
 
         // TODO: split these out for other gamemodes to reuse (see Story/StoryMenuHelpers for methods)

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -140,6 +140,11 @@ namespace RainMeadow
                     return storyGameMode.friendlyFire;
                 }
 
+                if (box.IDString == "CAMPAIGNSLUGONLY")
+                {
+                    return storyGameMode.requireCampaignSlugcat;
+
+                }
                 return false;
             }
             else
@@ -182,6 +187,12 @@ namespace RainMeadow
                 if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
                 {
                     storyGameMode.friendlyFire = c;
+
+                }
+
+                if (box.IDString == "CAMPAIGNSLUGONLY")
+                {
+                    storyGameMode.requireCampaignSlugcat = c;
 
                 }
             }

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -54,7 +54,8 @@ namespace RainMeadow
             public Dictionary<string, int> storyIntRemixSettings;
             [OnlineField(nullable = true)]
             public string? saveStateString;
-
+            [OnlineField]
+            public bool requireCampaignSlugcat;
 
             public State() { }
 
@@ -68,6 +69,7 @@ namespace RainMeadow
                 storyBoolRemixSettings = storyGameMode.storyBoolRemixSettings;
                 storyFloatRemixSettings = storyGameMode.storyFloatRemixSettings;
                 storyIntRemixSettings = storyGameMode.storyIntRemixSettings;
+                requireCampaignSlugcat = storyGameMode.requireCampaignSlugcat;
 
                 isInGame = RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame && RWCustom.Custom.rainWorld.processManager.upcomingProcess is null;
                 changedRegions = storyGameMode.changedRegions;
@@ -128,6 +130,7 @@ namespace RainMeadow
                 (lobby.gameMode as StoryGameMode).storyFloatRemixSettings = storyFloatRemixSettings;
                 (lobby.gameMode as StoryGameMode).storyIntRemixSettings = storyIntRemixSettings;
 
+                (lobby.gameMode as StoryGameMode).requireCampaignSlugcat = requireCampaignSlugcat;
                 (lobby.gameMode as StoryGameMode).isInGame = isInGame;
                 (lobby.gameMode as StoryGameMode).changedRegions = changedRegions;
                 (lobby.gameMode as StoryGameMode).readyForWin = readyForWin;

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Menu;
 using Steamworks;
 using System;
@@ -93,6 +93,14 @@ namespace RainMeadow
 
             if (!OnlineManager.lobby.isOwner) 
             {
+
+                if (onlineDifficultyLabel == null)
+                {
+                    onlineDifficultyLabel = new MenuLabel(this, pages[0], $"{GetCurrentCampaignName()}", new Vector2(startButton.pos.x - 100f, startButton.pos.y + 100f), new Vector2(200f, 30f), bigText: true);
+                    onlineDifficultyLabel.label.alignment = FLabelAlignment.Center;
+                    onlineDifficultyLabel.label.alpha = 0.5f;
+                    pages[0].subObjects.Add(onlineDifficultyLabel);
+                }
                 // Remove all buttons scug buttons if requireCampaignSlugcat is on.
                 if (scugButtons != null && storyGameMode.requireCampaignSlugcat) 
                 {
@@ -101,8 +109,8 @@ namespace RainMeadow
                     };
 
                     scugButtons = null;
-                } 
-                // Reall buttons scug buttons if requireCampaignSlugcat is off.
+                }
+                // Recall buttons scug buttons if requireCampaignSlugcat is off.
                 else if (scugButtons == null && !storyGameMode.requireCampaignSlugcat) 
                 {
                     SetupSlugcatList();
@@ -123,7 +131,7 @@ namespace RainMeadow
             {
                 if (startButton != null)
                 {
-                    startButton.buttonBehav.greyedOut = !storyGameMode.isInGame || storyGameMode.changedRegions || storyGameMode.readyForGate == 1 || storyGameMode.readyForWin;
+                    startButton.buttonBehav.greyedOut = !storyGameMode.canJoinGame;
                 }
                 if (onlineDifficultyLabel != null)
                 {
@@ -212,10 +220,6 @@ namespace RainMeadow
 
         private void SetupSlugcatList()
         {
-            onlineDifficultyLabel = new MenuLabel(this, pages[0], $"{GetCurrentCampaignName()}", new Vector2(startButton.pos.x - 100f, startButton.pos.y + 100f), new Vector2(200f, 30f), bigText: true);
-            onlineDifficultyLabel.label.alignment = FLabelAlignment.Center;
-            onlineDifficultyLabel.label.alpha = 0.5f;
-            pages[0].subObjects.Add(onlineDifficultyLabel);
 
             var pos = new Vector2(394, 553);
             pages[0].subObjects.Add(new MenuLabel(this, pages[0], Translate("Slugcats"), pos, new(110, 30), true));

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -12,9 +12,10 @@ namespace RainMeadow
     {
         CheckBox clientWantsToOverwriteSave;
         CheckBox friendlyFire;
+        CheckBox reqCampaignSlug;
         List<SimplerButton> playerButtons = new();
         SlugcatCustomization personaSettings;
-        EventfulSelectOneButton[] scugButtons;
+        EventfulSelectOneButton[]? scugButtons;
         StoryGameMode storyGameMode;
         MenuLabel onlineDifficultyLabel;
         Vector2 restartCheckboxPos;
@@ -34,16 +35,13 @@ namespace RainMeadow
 
             if (OnlineManager.lobby.isOwner)
             {
+                storyGameMode.requireCampaignSlugcat = false; // Default option is in remix menu.
                 storyGameMode.saveToDisk = true;
                 (storyGameMode.storyBoolRemixSettings, storyGameMode.storyFloatRemixSettings, storyGameMode.storyIntRemixSettings) = StoryMenuHelpers.GetHostBoolStoryRemixSettings();
             }
             else
             {
                 SetupClientOptions();
-                if (RainMeadow.rainMeadowOptions.SlugcatCustomToggle.Value)
-                {
-                    SetupSlugcatList();
-                }
             }
 
             SetupOnlineCustomization();
@@ -66,7 +64,7 @@ namespace RainMeadow
                 {
                     StoryMenuHelpers.SetClientStoryRemixSettings(storyGameMode.storyBoolRemixSettings, storyGameMode.storyFloatRemixSettings, storyGameMode.storyIntRemixSettings); // Set client remix settings to Host's on StartGame()
                 }
-                if (!RainMeadow.rainMeadowOptions.SlugcatCustomToggle.Value) // I'm a client and I want to match the host's
+                if (storyGameMode.requireCampaignSlugcat) // I'm a client and I want to match the host's
                 {
                     personaSettings.playingAs = storyGameMode.currentCampaign;
                 }
@@ -92,6 +90,25 @@ namespace RainMeadow
         public override void Update()
         {
             base.Update();
+
+            if (!OnlineManager.lobby.isOwner) 
+            {
+                // Remove all buttons scug buttons if requireCampaignSlugcat is on.
+                if (scugButtons != null && storyGameMode.requireCampaignSlugcat) 
+                {
+                    foreach (var button in scugButtons) {
+                        pages[0].subObjects.Remove(button);
+                    };
+
+                    scugButtons = null;
+                } 
+                // Reall buttons scug buttons if requireCampaignSlugcat is off.
+                else if (scugButtons == null && !storyGameMode.requireCampaignSlugcat) 
+                {
+                    SetupSlugcatList();
+                }
+            }
+
 
             if (OnlineManager.lobby.isOwner)
             {
@@ -274,8 +291,13 @@ namespace RainMeadow
 
             var sameSpotOtherSide = restartCheckboxPos.x - startButton.pos.x;
             friendlyFire = new CheckBox(this, pages[0], this, new Vector2(startButton.pos.x - sameSpotOtherSide, restartCheckboxPos.y + 30), 70f, Translate("Friendly Fire"), "ONLINEFRIENDLYFIRE", false);
-            if (!OnlineManager.lobby.isOwner) friendlyFire.buttonBehav.greyedOut = true;
+            reqCampaignSlug = new CheckBox(this, pages[0], this, new Vector2(startButton.pos.x - sameSpotOtherSide, restartCheckboxPos.y), 150f, Translate("Require Campaign Slugcat"), "CAMPAIGNSLUGONLY", false);
+            if (!OnlineManager.lobby.isOwner) {
+                friendlyFire.buttonBehav.greyedOut = true;
+                reqCampaignSlug.buttonBehav.greyedOut = true;
+            }
             pages[0].subObjects.Add(friendlyFire);
+            pages[0].subObjects.Add(reqCampaignSlug);
         }
 
         private void ModifyExistingMenuItems()


### PR DESCRIPTION
Splits RequireCampaignSlugcat configuration from SlugcatCustomToggle. So host can choose to use unstable campaigns without allowing clients to select their own slugcats.