### PR TITLE
don't log applypalette, fix rwcustom logger

### DIFF
--- a/Game/RainMeadow.CustomizationHooks.cs
+++ b/Game/RainMeadow.CustomizationHooks.cs
@@ -73,7 +73,6 @@ namespace RainMeadow
                     if (RainMeadow.creatureCustomizations.TryGetValue(self.player, out var customization))
                     {
                         customization.ModifyBodyColor(ref originalBodyColor);
-                        RainMeadow.Debug("color became " + originalBodyColor);
                     }
                 });
             }

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -40,19 +40,19 @@ namespace RainMeadow
 
         private void Custom_LogWarning(On.RWCustom.Custom.orig_LogWarning orig, string[] values)
         {
-            values.Do(s => Logger.LogWarning(s));
+            Logger.LogWarning(string.Join(" ", values));
             orig(values);
         }
 
         private void Custom_LogImportant(On.RWCustom.Custom.orig_LogImportant orig, string[] values)
         {
-            values.Do(s => Logger.LogInfo(s));
+            Logger.LogInfo(string.Join(" ", values));
             orig(values);
         }
 
         private void Custom_Log(On.RWCustom.Custom.orig_Log orig, string[] values)
         {
-            values.Do(s => Logger.LogInfo(s));
+            Logger.LogInfo(string.Join(" ", values));
             orig(values);
         }
 


### PR DESCRIPTION
removes spammy applypalette logging

also fixes rwcustom logger printing each field in a newline so
```
[Warning:RainMeadow] Scavenger
[Warning:RainMeadow] stranded From All Exits, can't find den
```
becomes
```
[Warning:RainMeadow] Scavenger stranded From All Exits, can't find den
```