### PR TITLE
Chat Updates

### DIFF
--- a/Arena/ArenaOnlineGameModes/Competitive.cs
+++ b/Arena/ArenaOnlineGameModes/Competitive.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using RainMeadow.Story.OnlineUIComponents;
+using System.Collections.Generic;
 using System.Linq;
 namespace RainMeadow
 {
@@ -72,5 +73,10 @@ namespace RainMeadow
 
         }
 
+        public override void Killing(ArenaOnlineGameMode arena, On.ArenaGameSession.orig_Killing orig, ArenaGameSession self, Player player, Creature killedCrit, int playerIndex)
+        {
+            base.Killing(arena, orig, self, player, killedCrit, playerIndex);
+            DeathMessage.PlayerKillCreature(player, killedCrit);
+        }
     }
 }

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -2,6 +2,7 @@
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
+using RainMeadow.Story.OnlineUIComponents;
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -225,6 +226,10 @@ namespace RainMeadow
             if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is MeadowGameMode)
             {
                 return;
+            }
+            if (!self.dead) // Prevent death messages from firing 987343 times.
+            {
+                DeathMessage.CreatureDeath(self);
             }
             orig(self);
         }

--- a/Story/OnlineUIComponents/ChatHud.cs
+++ b/Story/OnlineUIComponents/ChatHud.cs
@@ -19,6 +19,8 @@ namespace RainMeadow
 
         public bool Active => game.processActive;
 
+        public static bool isLogToggled; // Lets us keep chat log toggled across process switches.
+
         public ChatHud(HUD.HUD hud, RoomCamera camera) : base(hud)
         {
             textPrompt = hud.textPrompt;
@@ -30,6 +32,13 @@ namespace RainMeadow
             {
                 hud.textPrompt.AddMessage(hud.rainWorld.inGameTranslator.Translate($"Press 'Enter' to chat, press '{RainMeadow.rainMeadowOptions.ChatLogKey.Value}' to toggle the chat log"), 60, 160, false, true);
                 ChatLogManager.shownChatTutorial = true;
+            }
+
+            if (isLogToggled)
+            {
+                RainMeadow.Debug("creating log");
+                chatLogOverlay = new ChatLogOverlay(this, game.manager, game);
+                showChatLog = true;
             }
         }
 
@@ -54,12 +63,14 @@ namespace RainMeadow
                 {
                     ShutDownChatLog();
                     showChatLog = false;
+                    isLogToggled = false;
                 }
                 else if (!textPrompt.pausedMode)
                 {
                     RainMeadow.Debug("creating log");
                     chatLogOverlay = new ChatLogOverlay(this, game.manager, game);
                     showChatLog = true;
+                    isLogToggled = true;
                 }
             }
 

--- a/Story/OnlineUIComponents/ChatLogOverlay.cs
+++ b/Story/OnlineUIComponents/ChatLogOverlay.cs
@@ -11,6 +11,8 @@ namespace RainMeadow
         public RainWorldGame game;
         private Dictionary<string, Color> colorDictionary = new();
 
+        public static Color SYSTEM_COLOR = new(1f, 1f, 0.3333333f);
+
         public ChatLogOverlay(ChatHud chatHud, ProcessManager manager, RainWorldGame game) : base(manager, RainMeadow.Ext_ProcessID.ChatMode)
         {
             this.chatHud = chatHud;
@@ -60,6 +62,7 @@ namespace RainMeadow
                             new Vector2((1366f - manager.rainWorld.options.ScreenSize.x) / 2f - 660f, 330f - yOffSet),
                             new Vector2(manager.rainWorld.options.ScreenSize.x, 30f), false);
                         messageLabel.label.alignment = FLabelAlignment.Left;
+                        messageLabel.label.color = SYSTEM_COLOR;
                         pages[0].subObjects.Add(messageLabel);
                     }
                     else

--- a/Story/OnlineUIComponents/DeathMessage.cs
+++ b/Story/OnlineUIComponents/DeathMessage.cs
@@ -1,0 +1,173 @@
+﻿using MoreSlugcats;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RainMeadow.Story.OnlineUIComponents
+{
+    public static class DeathMessage
+    {
+        public static void Environment(Player player, DeathType cause)
+        {
+            try
+            {
+                if (player == null)
+                {
+                    return;
+                }
+                var t = FindOnlineFromPlayer(player).id.name;
+                switch (cause)
+                {
+                    default:
+                        ChatLogManager.LogMessage("", $"{t} died.");
+                        break;
+                    case DeathType.Rain:
+                        ChatLogManager.LogMessage("", $"{t} was crushed by the rain.");
+                        break;
+                    case DeathType.Abyss:
+                        ChatLogManager.LogMessage("", $"{t} fell into the abyss.");
+                        break;
+                    case DeathType.Drown:
+                        if (player.grabbedBy.Count > 0)
+                        {
+                            ChatLogManager.LogMessage("", $"{t} was drowned by {player.grabbedBy[0].grabber.Template.name}.");
+                        }
+                        ChatLogManager.LogMessage("", $"{t} drowned.");
+                        break;
+                    case DeathType.FallDamage:
+                        ChatLogManager.LogMessage("", $"{t} hit the ground too hard.");
+                        break;
+                    case DeathType.Oracle:
+                        ChatLogManager.LogMessage("", $"{t} was killed through unknown means.");
+                        break;
+                    case DeathType.Acid:
+                        ChatLogManager.LogMessage("", $"{t} tried to swim in acid.");
+                        break;
+                    case DeathType.PyroDeath:
+                        ChatLogManager.LogMessage("", $"{t} spontaneously combusted.");
+                        break;
+                    case DeathType.Freeze:
+                        ChatLogManager.LogMessage("", $"{t} froze to death.");
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                RainMeadow.Error("Error displaying death message. " + e);
+            }
+        }
+        public static void PlayerKillPlayer(Player killer, Player target)
+        {
+            try
+            {
+                var k = FindOnlineFromPlayer(killer).id.name;
+                var t = FindOnlineFromPlayer(target).id.name;
+                ChatLogManager.LogMessage("", $"{t} was slain by {k}.");
+            }
+            catch (Exception e)
+            {
+                RainMeadow.Error("Error displaying death message. " + e);
+            }
+        }
+
+        public static void CreatureKillPlayer(Creature killer, Player target)
+        {
+            try
+            {
+                var k = killer.Template.name;
+                var t = FindOnlineFromPlayer(target).id.name;
+                ChatLogManager.LogMessage("", $"{t} was slain by a {k}.");
+            }
+            catch (Exception e)
+            {
+                RainMeadow.Error("Error displaying death message. " + e);
+            }
+        }
+
+        public static void PlayerKillCreature(Player killer, Creature target)
+        {
+            if (target is Player)
+            {
+                PlayerKillPlayer(killer, (Player)target);
+                return;
+            }
+            try
+            {
+                var k = FindOnlineFromPlayer(killer).id.name;
+                var t = target.Template.name;
+                ChatLogManager.LogMessage("", $"{t} was slain by {k}.");
+            }
+            catch (Exception e)
+            {
+                RainMeadow.Error("Error displaying death message. " + e);
+            }
+        }
+
+        public static OnlinePlayer? FindOnlineFromPlayer(Player player)
+        {
+            if (player.abstractCreature.GetOnlineCreature(out var crit) && crit != null)
+            {
+                return crit.owner;
+            }
+            return null;
+        }
+
+        public static void CreatureDeath(Creature crit)
+        {
+            if (crit.killTag != null && crit.killTag.realizedCreature != null)
+            {
+                if (crit.killTag.realizedCreature is Player && !RainMeadow.isArenaMode(out var _))
+                {
+                    PlayerKillCreature(crit.killTag.realizedCreature as Player, crit);
+                }
+                else if (crit is Player)
+                {
+                    CreatureKillPlayer(crit.killTag.realizedCreature, crit as Player);
+                }
+            }
+            else
+            {
+                // (try to) Determine the cause of death if it wasn't from a kill.
+                // Will probably be way better to have this information sent by the client that actually died for accuracy but this should work good enough for now.
+                if (crit is Player player)
+                {
+                    if (player.drown >= 1f)
+                    {
+                        Environment(player, DeathType.Drown);
+                        return;
+                    }
+                    if (player.Hypothermia >= 1f)
+                    {
+                        Environment(player, DeathType.Freeze);
+                        return;
+                    }
+                    if (ModManager.MSC && player.SlugCatClass == MoreSlugcatsEnums.SlugcatStatsName.Artificer)
+                    {
+                        if (player.airInLungs <= Player.PyroDeathThreshold(player.room.game))
+                        {
+                            Environment(player, DeathType.PyroDeath);
+                            return;
+                        }
+                    }
+                    // If nothing works we'll just say they died.
+                    Environment(player, DeathType.Invalid);
+                }
+            }
+        }
+
+        public enum DeathType
+        {
+            Invalid,
+            Rain,
+            Abyss,
+            Drown,
+            FallDamage,
+            Oracle,
+            Acid,
+            PyroDeath,
+            Freeze,
+        }
+    }
+}


### PR DESCRIPTION
Added experimental death messages. They currently display PVP & PVE related deaths and any death where Creature.Die() is called on a player.
Chat will now stay toggled across arena/lobby switches. 
System messages will show up in yellow for easier readability

![RainWorld_WxyhZBUVW0](https://github.com/user-attachments/assets/19e2922e-f2e2-42d1-a19e-9df51cc03851)
