### PR TITLE
Chat Enhancement 1.1

### DIFF
--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -16,6 +16,7 @@ public class RainMeadowOptions : OptionInterface
     public readonly Configurable<KeyCode> SpectatorKey;
     public readonly Configurable<KeyCode> PointingKey;
     public readonly Configurable<KeyCode> ChatLogKey;
+    public readonly Configurable<KeyCode> ChatButtonKey;
     public readonly Configurable<int> ArenaCountDownTimer;
     public readonly Configurable<int> ArenaSaintAscendanceTimer;
     public readonly Configurable<bool> ArenaSAINOT;
@@ -40,6 +41,7 @@ public class RainMeadowOptions : OptionInterface
         SpectatorKey = config.Bind("SpectatorKey", KeyCode.Tab);
         PointingKey = config.Bind("PointingKey", KeyCode.Mouse0);
         ChatLogKey = config.Bind("ChatLogKey", KeyCode.Comma);
+        ChatButtonKey = config.Bind("ChatButtonKey", KeyCode.Return);
         ArenaCountDownTimer = config.Bind("ArenaCountDownTimer", 300);
         ArenaSaintAscendanceTimer = config.Bind("ArenaSaintAscendanceTimer", 260);
         ArenaSAINOT = config.Bind("ArenaSAINOT", false);
@@ -90,7 +92,7 @@ public class RainMeadowOptions : OptionInterface
             cheatReset.OnClick += (UIfocusable trigger) => { trigger.Menu.PlaySound(SoundID.HUD_Karma_Reinforce_Flicker); MeadowProgression.progressionData = null; MeadowProgression.LoadDefaultProgression(); cheatEmote.greyedOut = cheatSkin.greyedOut = cheatCharacter.greyedOut = false; };
 
             meadowTab.AddItems(OnlineMeadowSettings);
-            GeneralUIArrPlayerOptions = new UIelement[13]
+            GeneralUIArrPlayerOptions = new UIelement[15]
             {
                 new OpLabel(10f, 550f, "General", bigText: true),
                 new OpLabel(10f, 530f, "Note: These inputs are not used in Meadow mode", bigText: false),
@@ -111,6 +113,9 @@ public class RainMeadowOptions : OptionInterface
 
                 new OpLabel(10, 180f, "Chat Log Toggle"),
                 new OpKeyBinder(ChatLogKey, new Vector2(10f, 150), new Vector2(150f, 30f)),
+
+                new OpLabel(10, 115f, "Chat Talk Button"),
+                new OpKeyBinder(ChatButtonKey, new Vector2(10f, 85), new Vector2(150f, 30f)),
             };
 
             opTab.AddItems(GeneralUIArrPlayerOptions);

--- a/Menu/Objects/ButtonTypingHandler.cs
+++ b/Menu/Objects/ButtonTypingHandler.cs
@@ -9,7 +9,7 @@ namespace RainMeadow
         public new string _lastInput = "";
         public new HashSet<ICanBeTyped> _assigned = new HashSet<ICanBeTyped>();
         public new ICanBeTyped? _focused;
-        public void Update()
+        public new void Update()
         {
             if (_assigned.Count < 1)
             {
@@ -53,17 +53,17 @@ namespace RainMeadow
             }
             _lastInput = inputString;
         }
-        public void OnDestroy()
+        public new void OnDestroy()
         {
             _assigned.Clear();
             _focused = null;
             CanBeTypedExt._HandlerOnDestroy();
         }
-        public void Assign(ICanBeTyped typable)
+        public new void Assign(ICanBeTyped typable)
         {
             _assigned.Add(typable);
         }
-        public void Unassign(ICanBeTyped typable)
+        public new void Unassign(ICanBeTyped typable)
         {
             _assigned.Clear();
             _assigned.Remove(typable);

--- a/Menu/Objects/ChatButton.cs
+++ b/Menu/Objects/ChatButton.cs
@@ -1,25 +1,45 @@
 ﻿using UnityEngine;
 using Menu;
+using Menu.Remix.MixedUI;
 
 namespace RainMeadow
 {
     public abstract class ChatButton : ButtonTemplate
     {
         public HSLColor labelColor;
-
         public MenuLabel menuLabel;
-
         public RoundedRect roundedRect;
+
+        public FSprite _cursor;
+        public float _cursorWidth;
+        public FSpriteWrap cursorWrap;
 
         public ChatButton(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : base(menu, owner, pos, size)
         {
-            RainMeadow.Error("This is my parent constructor coming to life");
             labelColor = Menu.Menu.MenuColor(Menu.Menu.MenuColors.White);
             roundedRect = new RoundedRect(menu, owner, new Vector2(0f, 0f), size, true);
             this.subObjects.Add(roundedRect);
+
             menuLabel = new MenuLabel(menu, owner, displayText, new Vector2(-roundedRect.size.x / 2 + 10f, 0f), size, false);
             menuLabel.label.alignment = FLabelAlignment.Left;
             this.subObjects.Add(menuLabel);
+
+            this._cursor = new FSprite("modInputCursor", true);
+            this._cursor.SetPosition(menuLabel.size.x, (float)(this.size.y * 0.5));
+            cursorWrap = new FSpriteWrap(menu, owner, _cursor);
+            this.subObjects.Add(cursorWrap);
+
+        }
+
+        public override void Update()
+        {
+            _cursorWidth = LabelTest.GetWidth(menuLabel.label.text, false);
+            RainMeadow.Debug(_cursorWidth);
+            cursorWrap.sprite.x = _cursorWidth + 20f;
+            RainMeadow.Debug(cursorWrap.sprite.x);
+            base.Update();
+            this.buttonBehav.Update();
+            this.roundedRect.fillAlpha = buttonBehav.col;
         }
     }
 }

--- a/Menu/Objects/ChatButton.cs
+++ b/Menu/Objects/ChatButton.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+using Menu;
+
+namespace RainMeadow
+{
+    public abstract class ChatButton : ButtonTemplate
+    {
+        public HSLColor labelColor;
+
+        public MenuLabel menuLabel;
+
+        public RoundedRect roundedRect;
+
+        public ChatButton(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : base(menu, owner, pos, size)
+        {
+            RainMeadow.Error("This is my parent constructor coming to life");
+            labelColor = Menu.Menu.MenuColor(Menu.Menu.MenuColors.White);
+            roundedRect = new RoundedRect(menu, owner, new Vector2(0f, 0f), size, true);
+            this.subObjects.Add(roundedRect);
+            menuLabel = new MenuLabel(menu, owner, displayText, new Vector2(-roundedRect.size.x / 2 + 10f, 0f), size, false);
+            menuLabel.label.alignment = FLabelAlignment.Left;
+            this.subObjects.Add(menuLabel);
+        }
+    }
+}

--- a/Menu/Objects/ChatButton.cs
+++ b/Menu/Objects/ChatButton.cs
@@ -34,9 +34,8 @@ namespace RainMeadow
         public override void Update()
         {
             _cursorWidth = LabelTest.GetWidth(menuLabel.label.text, false);
-            RainMeadow.Debug(_cursorWidth);
-            cursorWrap.sprite.x = _cursorWidth + 20f;
-            RainMeadow.Debug(cursorWrap.sprite.x);
+            cursorWrap.sprite.x = _cursorWidth + 17f;
+            cursorWrap.sprite.alpha = Mathf.PingPong(Time.time * 4f, 1f);
             base.Update();
             this.buttonBehav.Update();
             this.roundedRect.fillAlpha = buttonBehav.col;

--- a/Menu/Objects/ChatTemplate.cs
+++ b/Menu/Objects/ChatTemplate.cs
@@ -4,7 +4,7 @@ using Menu.Remix.MixedUI;
 
 namespace RainMeadow
 {
-    public abstract class ChatButton : ButtonTemplate
+    public abstract class ChatTemplate : ButtonTemplate
     {
         public HSLColor labelColor;
         public MenuLabel menuLabel;
@@ -14,7 +14,7 @@ namespace RainMeadow
         public float _cursorWidth;
         public FSpriteWrap cursorWrap;
 
-        public ChatButton(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : base(menu, owner, pos, size)
+        public ChatTemplate(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : base(menu, owner, pos, size)
         {
             labelColor = Menu.Menu.MenuColor(Menu.Menu.MenuColors.White);
             roundedRect = new RoundedRect(menu, owner, new Vector2(0f, 0f), size, true);

--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 namespace RainMeadow
 {
-    public class ChatTextBox : ChatButton, ICanBeTyped
+    public class ChatTextBox : ChatTemplate, ICanBeTyped
     {
         private SteamMatchmakingManager steamMatchmakingManager;
         private ButtonTypingHandler typingHandler;
@@ -20,6 +20,8 @@ namespace RainMeadow
         public Action<char> OnKeyDown { get; set; }
         public static int textLimit = 75;
         public static string lastSentMessage = "";
+
+        public static event Action? OnShutDownRequest;
         public ChatTextBox(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : base(menu, owner, displayText, pos, size)
         {
             steamMatchmakingManager = MatchmakingManager.instance as SteamMatchmakingManager;
@@ -81,6 +83,7 @@ namespace RainMeadow
                     menu.PlaySound(SoundID.MENY_Already_Selected_MultipleChoice_Clicked);
                     RainMeadow.Debug("Could not send lastSentMessage because it had no text or only had whitespaces");
                 }
+                OnShutDownRequest.Invoke();
                 typingHandler.Unassign(this);
             }
             else

--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 namespace RainMeadow
 {
-    public class ChatTextBox : SimpleButton, ICanBeTyped
+    public class ChatTextBox : ChatButton, ICanBeTyped
     {
         private SteamMatchmakingManager steamMatchmakingManager;
         private ButtonTypingHandler typingHandler;
@@ -20,7 +20,7 @@ namespace RainMeadow
         public Action<char> OnKeyDown { get; set; }
         public static int textLimit = 75;
         public static string lastSentMessage = "";
-        public ChatTextBox(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : base(menu, owner, displayText, "", pos, size)
+        public ChatTextBox(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : base(menu, owner, displayText, pos, size)
         {
             steamMatchmakingManager = MatchmakingManager.instance as SteamMatchmakingManager;
             lastSentMessage = "";

--- a/Menu/Objects/FSpriteWrap.cs
+++ b/Menu/Objects/FSpriteWrap.cs
@@ -11,11 +11,6 @@ namespace RainMeadow
             Container.AddChild(fSprite);
         }
 
-        public override void GrafUpdate(float timeStacker)
-        {
-            base.GrafUpdate(timeStacker);
-        }
-
         public override void RemoveSprites()
         {
             base.RemoveSprites();

--- a/Menu/Objects/FSpriteWrap.cs
+++ b/Menu/Objects/FSpriteWrap.cs
@@ -1,0 +1,25 @@
+﻿using Menu;
+
+namespace RainMeadow
+{
+    public class FSpriteWrap : MenuObject
+    {
+        public FSprite sprite;
+        public FSpriteWrap(Menu.Menu menu, MenuObject owner, FSprite fSprite) : base(menu, owner) 
+        {
+            this.sprite = fSprite;
+            Container.AddChild(fSprite);
+        }
+
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+        }
+
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+            sprite.RemoveFromContainer();
+        }
+    }
+}

--- a/Menu/Objects/FSpriteWrap.cs
+++ b/Menu/Objects/FSpriteWrap.cs
@@ -5,10 +5,10 @@ namespace RainMeadow
     public class FSpriteWrap : MenuObject
     {
         public FSprite sprite;
-        public FSpriteWrap(Menu.Menu menu, MenuObject owner, FSprite fSprite) : base(menu, owner) 
+        public FSpriteWrap(Menu.Menu menu, MenuObject owner, FSprite sprite) : base(menu, owner) 
         {
-            this.sprite = fSprite;
-            Container.AddChild(fSprite);
+            this.sprite = sprite;
+            Container.AddChild(this.sprite);
         }
 
         public override void RemoveSprites()

--- a/Story/OnlineUIComponents/ChatHud.cs
+++ b/Story/OnlineUIComponents/ChatHud.cs
@@ -28,7 +28,7 @@ namespace RainMeadow
             ChatLogManager.Subscribe(this);
             if (!ChatLogManager.shownChatTutorial)
             {
-                hud.textPrompt.AddMessage(hud.rainWorld.inGameTranslator.Translate($"Press '{RainMeadow.rainMeadowOptions.ChatButtonKey.Value}' to chat, press '{RainMeadow.rainMeadowOptions.ChatLogKey.Value}' to toggle the chat log"), 60, 160, false, true);
+                hud.textPrompt.AddMessage(hud.rainWorld.inGameTranslator.Translate($"Press '{RainMeadow.rainMeadowOptions.ChatButtonKey.Value}' to chat, press '{RainMeadow.rainMeadowOptions.ChatLogKey.Value}' to toggle the chat log"), 60, 320, true, true);
                 ChatLogManager.shownChatTutorial = true;
             }
 
@@ -77,7 +77,7 @@ namespace RainMeadow
                     RainMeadow.Debug("creating input");
                     chatInputOverlay = new ChatInputOverlay(game.manager);
                     if (chatLogOverlay is null)
-                    {
+                    { 
                         RainMeadow.Debug("creating log");
                         chatLogOverlay = new ChatLogOverlay(this, game.manager, game);
                     }

--- a/Story/OnlineUIComponents/ChatHud.cs
+++ b/Story/OnlineUIComponents/ChatHud.cs
@@ -28,9 +28,11 @@ namespace RainMeadow
             ChatLogManager.Subscribe(this);
             if (!ChatLogManager.shownChatTutorial)
             {
-                hud.textPrompt.AddMessage(hud.rainWorld.inGameTranslator.Translate($"Press 'Enter' to chat, press '{RainMeadow.rainMeadowOptions.ChatLogKey.Value}' to toggle the chat log"), 60, 160, false, true);
+                hud.textPrompt.AddMessage(hud.rainWorld.inGameTranslator.Translate($"Press '{RainMeadow.rainMeadowOptions.ChatButtonKey.Value}' to chat, press '{RainMeadow.rainMeadowOptions.ChatLogKey.Value}' to toggle the chat log"), 60, 160, false, true);
                 ChatLogManager.shownChatTutorial = true;
             }
+
+            ChatTextBox.OnShutDownRequest += ShutDownChatInput;
         }
 
         public void AddMessage(string user, string message)
@@ -63,7 +65,7 @@ namespace RainMeadow
                 }
             }
 
-            if (Input.GetKeyDown(KeyCode.Return))
+            if (Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
             {
                 if (chatInputOverlay is not null)
                 {
@@ -99,7 +101,7 @@ namespace RainMeadow
         public void ShutDownChatInput()
         {
             RainMeadow.DebugMe();
-            if (chatInputOverlay != null)
+            if (chatInputOverlay != null )
             {
                 chatInputOverlay.chat.DelayedUnload(0.1f);
                 chatInputOverlay.ShutDownProcess();
@@ -109,6 +111,7 @@ namespace RainMeadow
 
         public void Destroy()
         {
+            ChatTextBox.OnShutDownRequest -= ShutDownChatInput;
             ChatLogManager.Unsubscribe(this);
         }
 

--- a/Story/OnlineUIComponents/ChatHud.cs
+++ b/Story/OnlineUIComponents/ChatHud.cs
@@ -101,7 +101,7 @@ namespace RainMeadow
         public void ShutDownChatInput()
         {
             RainMeadow.DebugMe();
-            if (chatInputOverlay != null )
+            if (chatInputOverlay != null)
             {
                 chatInputOverlay.chat.DelayedUnload(0.1f);
                 chatInputOverlay.ShutDownProcess();

--- a/Story/OnlineUIComponents/ChatLogOverlay.cs
+++ b/Story/OnlineUIComponents/ChatLogOverlay.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Menu;
+using Menu.Remix.MixedUI;
 using UnityEngine;
 
 namespace RainMeadow
@@ -81,9 +82,9 @@ namespace RainMeadow
                         usernameLabel.label.color = colorNew;
                         pages[0].subObjects.Add(usernameLabel);
 
-                        var usernameWidth = usernameLabel.size.x;
+                        var usernameWidth = LabelTest.GetWidth(usernameLabel.label.text);
                         var messageLabel = new MenuLabel(this, pages[0], $": {message}",
-                            new Vector2((1366f - manager.rainWorld.options.ScreenSize.x) / 2f - 660f + usernameWidth + 10, 330f - yOffSet),
+                            new Vector2((1366f - manager.rainWorld.options.ScreenSize.x) / 2f - 660f + usernameWidth + 2f, 330f - yOffSet),
                             new Vector2(manager.rainWorld.options.ScreenSize.x, 30f), false);
                         messageLabel.label.alignment = FLabelAlignment.Left;
                         pages[0].subObjects.Add(messageLabel);

--- a/Story/OnlineUIComponents/ChatLogOverlay.cs
+++ b/Story/OnlineUIComponents/ChatLogOverlay.cs
@@ -64,11 +64,21 @@ namespace RainMeadow
                     }
                     else
                     {
+                        float H = 0f;
+                        float S = 0f;
+                        float V = 0f;
+
+                        var color = colorDictionary.TryGetValue(username, out var colorOrig) ? colorOrig : Color.white;
+                        var colorNew = color;
+
+                        Color.RGBToHSV(color, out H, out S, out V);
+                        if (V < 0.8f) { colorNew = Color.HSVToRGB(H, S, 0.8f); }
+
                         var usernameLabel = new MenuLabel(this, pages[0], username,
                             new Vector2((1366f - manager.rainWorld.options.ScreenSize.x) / 2f - 660f, 330f - yOffSet),
                             new Vector2(manager.rainWorld.options.ScreenSize.x, 30f), false);
                         usernameLabel.label.alignment = FLabelAlignment.Left;
-                        usernameLabel.label.color = colorDictionary.TryGetValue(username, out var color) ? color : Color.white;
+                        usernameLabel.label.color = colorNew;
                         pages[0].subObjects.Add(usernameLabel);
 
                         var usernameWidth = usernameLabel.size.x;

--- a/Story/OnlineUIComponents/ChatLogOverlay.cs
+++ b/Story/OnlineUIComponents/ChatLogOverlay.cs
@@ -71,7 +71,7 @@ namespace RainMeadow
                         usernameLabel.label.color = colorDictionary.TryGetValue(username, out var color) ? color : Color.white;
                         pages[0].subObjects.Add(usernameLabel);
 
-                        var usernameWidth = username.Length * 5;
+                        var usernameWidth = usernameLabel.size.x;
                         var messageLabel = new MenuLabel(this, pages[0], $": {message}",
                             new Vector2((1366f - manager.rainWorld.options.ScreenSize.x) / 2f - 660f + usernameWidth + 10, 330f - yOffSet),
                             new Vector2(manager.rainWorld.options.ScreenSize.x, 30f), false);


### PR DESCRIPTION
- Brought back changing the enter key bind, original reason for the removal was it would mess stuff up if you had a different bind that's not enter, it's handled now with events
- Slight changes to chat tutorial, hopefully to get people to look down and read the text with the darker bool being set to true
- Brighten dark usernames for chat log
- Fixed message positioning with using labeltest getwidth as opposed to multiplying username length by five
- Added a cursor, currently it's just for visual purposes
- New parent object for ChatTextBox, allowing for text alignment being set to left instead of middle