### PR TITLE
Rename Private visibility to Invite Only

### DIFF
--- a/Online/Matchmaking/MatchmakingManager.cs
+++ b/Online/Matchmaking/MatchmakingManager.cs
@@ -31,7 +31,7 @@ namespace RainMeadow
             Public = 1,
             [Description("Friends Only")]
             FriendsOnly,
-            [Description("Private")]
+            [Description("Invite Only")]
             Private
         }
 


### PR DESCRIPTION
Limit confusion as giving a public lobby a password causes it to appear as "private" in the lobby select, whereas the Private visibility (now Invite Only) was just an invite only lobby

![image](https://github.com/user-attachments/assets/a94ec0db-e15e-4a82-9e5e-5b4c8a90de17)
