### PR TITLE
SlugBase customColors fix

### DIFF
--- a/Game/RainMeadow.CustomizationHooks.cs
+++ b/Game/RainMeadow.CustomizationHooks.cs
@@ -124,6 +124,8 @@ namespace RainMeadow
         {
             if (hackySlugcatCustomization is not null)
             {
+                // SlugBase will attempt to access customColors, assuming it is not null as CustomColorsEnabled is true
+                PlayerGraphics.customColors = hackySlugcatCustomization.customColors;
                 return true;
             }
             return orig();


### PR DESCRIPTION
At the moment this throws cause SlugBase assumes customColors is not null if CustomColorsEnabled returns true

Might be a better place to set this, lmk if so