### PR TITLE
Add MeadowOnline to HiddenOrUnplayableSlugcats

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -50,6 +50,18 @@ public partial class RainMeadow
         IL.Player.ThrowObject += Player_ThrowObject1;
         On.Player.SlugOnBack.Update += SlugOnBack_Update;
 
+        On.SlugcatStats.HiddenOrUnplayableSlugcat += SlugcatStatsOnHiddenOrUnplayableSlugcat;
+    }
+
+    // Hide the Meadow mode slugcat so it doesn't appear in menus (e.g. arena)
+    private bool SlugcatStatsOnHiddenOrUnplayableSlugcat(On.SlugcatStats.orig_HiddenOrUnplayableSlugcat orig, SlugcatStats.Name i)
+    {
+        if (i == Ext_SlugcatStatsName.OnlineSessionPlayer)
+        {
+            return true;
+        }
+
+        return orig(i);
     }
 
     private void SlugOnBack_Update(On.Player.SlugOnBack.orig_Update orig, Player.SlugOnBack self, bool eu)


### PR DESCRIPTION
Wanted to suggest this change as I saw this popping up in the Arena selection screen for instance

Was wondering if there was a particular reason it's not being used already tbh, did a quick test with LocalP2P and seemed alright but yeah, let me know