### PR TITLE
Optimization for lenientPos

### DIFF
--- a/Online/State/RealizedPhysicalObjectState.cs
+++ b/Online/State/RealizedPhysicalObjectState.cs
@@ -16,11 +16,7 @@ namespace RainMeadow
         public RealizedPhysicalObjectState() { }
         public RealizedPhysicalObjectState(OnlinePhysicalObject onlineEntity)
         {
-            if (chunkStates is null || !onlineEntity.lenientPos)
-            {
-                chunkStates = onlineEntity.apo.realizedObject.bodyChunks.Select(c => new ChunkState(c)).ToArray();
-            }
-
+            chunkStates = onlineEntity.apo.realizedObject.bodyChunks.Select(c => onlineEntity.lenientPos ? new ChunkState { vel = Vector2.zero, pos = Vector2.zero } : new ChunkState(c)).ToArray();
             collisionLayer = (byte)onlineEntity.apo.realizedObject.collisionLayer;
         }
 

--- a/Online/State/RealizedPhysicalObjectState.cs
+++ b/Online/State/RealizedPhysicalObjectState.cs
@@ -16,7 +16,7 @@ namespace RainMeadow
         public RealizedPhysicalObjectState() { }
         public RealizedPhysicalObjectState(OnlinePhysicalObject onlineEntity)
         {
-            chunkStates = onlineEntity.apo.realizedObject.bodyChunks.Select(c => onlineEntity.lenientPos ? new ChunkState { vel = Vector2.zero, pos = Vector2.zero } : new ChunkState(c)).ToArray();
+            chunkStates = onlineEntity.apo.realizedObject.bodyChunks.Select(c => onlineEntity.lenientPos ? new ChunkState() : new ChunkState(c)).ToArray();
             collisionLayer = (byte)onlineEntity.apo.realizedObject.collisionLayer;
         }
 

--- a/Online/State/RealizedPhysicalObjectState.cs
+++ b/Online/State/RealizedPhysicalObjectState.cs
@@ -16,7 +16,11 @@ namespace RainMeadow
         public RealizedPhysicalObjectState() { }
         public RealizedPhysicalObjectState(OnlinePhysicalObject onlineEntity)
         {
-            chunkStates = onlineEntity.apo.realizedObject.bodyChunks.Select(c => new ChunkState(c)).ToArray();
+            if (chunkStates is null || !onlineEntity.lenientPos)
+            {
+                chunkStates = onlineEntity.apo.realizedObject.bodyChunks.Select(c => new ChunkState(c)).ToArray();
+            }
+
             collisionLayer = (byte)onlineEntity.apo.realizedObject.collisionLayer;
         }
 


### PR DESCRIPTION
Don't need to update chunkStates if lenientPos is set to true, save sending some data (assuming meadow can recognise there's no change in the array)

Tested it with Raindeer as I saw it being used there, and with Pearlcat (which uses lenientPos for pearls) and seemed fine, let me know if you can see any issues with this though