### PR TITLE
Switch DeathMessages to use RPC

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -120,7 +120,15 @@ namespace RainMeadow
                         {
                             if (!opo.isMine)
                             {
-                                opo.owner.InvokeOnceRPC(RPCs.Creature_Die, opo);
+                                var saint = self.abstractCreature.GetOnlineCreature();
+                                if (saint != null)
+                                {
+                                    opo.owner.InvokeOnceRPC(RPCs.Creature_Die, opo, saint);
+                                } 
+                                else
+                                {
+                                    opo.owner.InvokeOnceRPC(RPCs.Creature_Die, opo, null);
+                                }
 
                             }
                         }

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -58,7 +58,7 @@ namespace RainMeadow
         public virtual void Killing(ArenaOnlineGameMode arena, On.ArenaGameSession.orig_Killing orig, ArenaGameSession self, Player player, Creature killedCrit, int playerIndex)
         {
             //DeathMessage.PlayerKillCreature(player, killedCrit);
-            DeathMessage.PvPRPC(player, killedCrit);
+            DeathMessage.PvPRPC(player, killedCrit, 0);
 
         }
         public virtual void LandSpear(ArenaOnlineGameMode arena, ArenaGameSession self, Player player, Creature target, ArenaSitting.ArenaPlayer aPlayer)

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -57,7 +57,8 @@ namespace RainMeadow
         }
         public virtual void Killing(ArenaOnlineGameMode arena, On.ArenaGameSession.orig_Killing orig, ArenaGameSession self, Player player, Creature killedCrit, int playerIndex)
         {
-            DeathMessage.PlayerKillCreature(player, killedCrit);
+            //DeathMessage.PlayerKillCreature(player, killedCrit);
+            DeathMessage.PvPRPC(player, killedCrit);
 
         }
         public virtual void LandSpear(ArenaOnlineGameMode arena, ArenaGameSession self, Player player, Creature target, ArenaSitting.ArenaPlayer aPlayer)

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -57,9 +57,6 @@ namespace RainMeadow
         }
         public virtual void Killing(ArenaOnlineGameMode arena, On.ArenaGameSession.orig_Killing orig, ArenaGameSession self, Player player, Creature killedCrit, int playerIndex)
         {
-            //DeathMessage.PlayerKillCreature(player, killedCrit);
-            DeathMessage.PvPRPC(player, killedCrit, 0);
-
         }
         public virtual void LandSpear(ArenaOnlineGameMode arena, ArenaGameSession self, Player player, Creature target, ArenaSitting.ArenaPlayer aPlayer)
         {

--- a/Game/DeathContextualizer.cs
+++ b/Game/DeathContextualizer.cs
@@ -23,7 +23,7 @@ namespace RainMeadow.Game
             // NOT PRETTY BUT IT WORKS
             // Doing things like getting DeclaringType and IsStatic through ILContext is really funky so we'll instead get it straight from the source.
             IL.ZapCoil.Update += (il) => Bind(il, typeof(ZapCoil).GetMethod(nameof(ZapCoil.Update)));
-            IL.WormGrass.WormGrassPatch.InteractWithCreature += (il) => Bind(il, typeof(WormGrass.WormGrassPatch).GetMethod(nameof(WormGrass.WormGrassPatch.Update)));
+            //IL.WormGrass.WormGrassPatch.InteractWithCreature += (il) => Bind(il, typeof(WormGrass.WormGrassPatch).GetMethod(nameof(WormGrass.WormGrassPatch.Update)));
             IL.SSOracleBehavior.Update += (il) => Bind(il, typeof(SSOracleBehavior).GetMethod(nameof(SSOracleBehavior.Update)));
             IL.SSOracleBehavior.ThrowOutBehavior.Update += (il) => Bind(il, typeof(SSOracleBehavior.ThrowOutBehavior).GetMethod(nameof(SSOracleBehavior.ThrowOutBehavior.Update)));
             IL.DaddyCorruption.EatenCreature.Update += (il) => Bind(il, typeof(DaddyCorruption.EatenCreature).GetMethod(nameof(DaddyCorruption.EatenCreature.Update)));

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -80,6 +80,7 @@ namespace RainMeadow
             }
         }
 
+        // Keep this for now despite having DeathContextualizer
         private void Player_TerrainImpact(ILContext il)
         {
             try
@@ -94,7 +95,8 @@ namespace RainMeadow
                 {
                     if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is not MeadowGameMode)
                     {
-                        DeathMessage.EnvironmentalDeathMessage(self, DeathMessage.DeathType.FallDamage);
+                        //DeathMessage.EnvironmentalDeathMessage(self, DeathMessage.DeathType.FallDamage);
+                        DeathMessage.EnvironmentalRPC(self, DeathMessage.DeathType.FallDamage);
                     }
 
                 });
@@ -469,7 +471,8 @@ namespace RainMeadow
                     if (self.bodyChunks[0].pos.y < num && (!self.room.water || self.room.waterInverted || self.room.defaultWaterLevel < -10) && (!self.Template.canFly || self.Stunned || self.dead) && (self is Player || self.room.game.GetArenaGameSession.chMeta == null || !self.room.game.GetArenaGameSession.chMeta.oobProtect))
                     {
 
-                        DeathMessage.EnvironmentalDeathMessage(self as Player, DeathMessage.DeathType.Abyss);
+                        //DeathMessage.EnvironmentalDeathMessage(self as Player, DeathMessage.DeathType.Abyss);
+                        DeathMessage.EnvironmentalRPC(self as Player, DeathMessage.DeathType.Abyss);
                         RainMeadow.Debug("prevent abstract creature destroy: " + self); // need this so that we don't release the world session on death
                         self.Die();
                         self.State.alive = false;

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -70,8 +70,8 @@ namespace RainMeadow
                 c.Emit(OpCodes.Ldarg_1);
                 c.EmitDelegate((Centipede self, PhysicalObject shockObj) =>
                 {
-                    if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is not MeadowGameMode && shockObj is Player)
-                        DeathMessage.CreatureKillPlayer(self, shockObj as Player);
+                    if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is not MeadowGameMode && shockObj is Player player)
+                        DeathMessage.CvPRPC(self, player);
                 });
             }
             catch (Exception e)

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -85,11 +85,15 @@ namespace RainMeadow
         }
 
         [RPCMethod]
-        public static void Creature_Die(OnlinePhysicalObject opo)
+        public static void Creature_Die(OnlinePhysicalObject opo, OnlinePhysicalObject saint)
         {
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
 
             (opo.apo as AbstractCreature)?.realizedCreature?.Die();
+            if (saint != null)
+            {
+                DeathMessage.PvPRPC(saint.apo.realizedObject as Player, opo.apo.realizedObject as Creature, 1);
+            }
         }
 
         [RPCMethod]
@@ -98,21 +102,21 @@ namespace RainMeadow
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
             if ((opo.apo as AbstractCreature)?.realizedCreature == null) return;
             DeathMessage.DeathType type = (DeathMessage.DeathType)index;
-            DeathMessage.EnvironmentalDeathMessage((opo.apo as AbstractCreature)?.realizedCreature as Player, type);
+            DeathMessage.EnvironmentalDeathMessage((opo.apo as AbstractCreature), type);
         }
 
         [RPCMethod]
-        public static void KillFeedPvP(OnlinePhysicalObject killer, OnlinePhysicalObject target)
+        public static void KillFeedPvP(OnlinePhysicalObject killer, OnlinePhysicalObject target, int context)
         {
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
-            if ((killer.apo as AbstractCreature)?.realizedCreature == null || (target.apo as AbstractCreature)?.realizedCreature == null) return;
-            if ((target.apo as AbstractCreature)?.realizedCreature is Player)
+            if ((killer.apo as AbstractCreature) == null || (target.apo as AbstractCreature) == null) return;
+            if ((target.apo as AbstractCreature).creatureTemplate.type == CreatureTemplate.Type.Slugcat)
             {
-                DeathMessage.PlayerKillPlayer((killer.apo as AbstractCreature)?.realizedCreature as Player, (target.apo as AbstractCreature)?.realizedCreature as Player);
+                DeathMessage.PlayerKillPlayer((killer.apo as AbstractCreature), (target.apo as AbstractCreature), context);
             } 
             else
             {
-                DeathMessage.PlayerKillCreature((killer.apo as AbstractCreature)?.realizedCreature as Player, (target.apo as AbstractCreature)?.realizedCreature);
+                DeathMessage.PlayerKillCreature((killer.apo as AbstractCreature), (target.apo as AbstractCreature), context);
             }
             
         }

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -91,5 +91,37 @@ namespace RainMeadow
 
             (opo.apo as AbstractCreature)?.realizedCreature?.Die();
         }
+
+        [RPCMethod]
+        public static void KillFeedEnvironment(OnlinePhysicalObject opo, int index)
+        {
+            if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
+            if ((opo.apo as AbstractCreature)?.realizedCreature == null) return;
+            DeathMessage.DeathType type = (DeathMessage.DeathType)index;
+            DeathMessage.EnvironmentalDeathMessage((opo.apo as AbstractCreature)?.realizedCreature as Player, type);
+        }
+
+        [RPCMethod]
+        public static void KillFeedPvP(OnlinePhysicalObject killer, OnlinePhysicalObject target)
+        {
+            if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
+            if ((killer.apo as AbstractCreature)?.realizedCreature == null || (target.apo as AbstractCreature)?.realizedCreature == null) return;
+            if ((target.apo as AbstractCreature)?.realizedCreature is Player)
+            {
+                DeathMessage.PlayerKillPlayer((killer.apo as AbstractCreature)?.realizedCreature as Player, (target.apo as AbstractCreature)?.realizedCreature as Player);
+            } 
+            else
+            {
+                DeathMessage.PlayerKillCreature((killer.apo as AbstractCreature)?.realizedCreature as Player, (target.apo as AbstractCreature)?.realizedCreature);
+            }
+            
+        }
+        [RPCMethod]
+        public static void KillFeedCvP(OnlinePhysicalObject killer, OnlinePhysicalObject target)
+        {
+            if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
+            if ((killer.apo as AbstractCreature)?.realizedCreature == null || (target.apo as AbstractCreature)?.realizedCreature == null) return;
+            DeathMessage.CreatureKillPlayer((killer.apo as AbstractCreature)?.realizedCreature, (target.apo as AbstractCreature)?.realizedCreature as Player);
+        }
     }
 }

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -100,32 +100,81 @@ namespace RainMeadow
         public static void KillFeedEnvironment(OnlinePhysicalObject opo, int index)
         {
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
-            if ((opo.apo as AbstractCreature)?.realizedCreature == null) return;
-            DeathMessage.DeathType type = (DeathMessage.DeathType)index;
-            DeathMessage.EnvironmentalDeathMessage((opo.apo as AbstractCreature), type);
+            foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Select(kv => kv.Value))
+            {
+                if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
+                if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo1 && opo1.apo is AbstractCreature ac)
+                {
+                    if (opo1.id == opo.id)
+                    {
+                        DeathMessage.DeathType type = (DeathMessage.DeathType)index;
+                        DeathMessage.EnvironmentalDeathMessage(opo, type);
+                        break;
+                    }
+                }
+            }
         }
 
         [RPCMethod]
         public static void KillFeedPvP(OnlinePhysicalObject killer, OnlinePhysicalObject target, int context)
         {
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
-            if ((killer.apo as AbstractCreature) == null || (target.apo as AbstractCreature) == null) return;
-            if ((target.apo as AbstractCreature).creatureTemplate.type == CreatureTemplate.Type.Slugcat)
+            OnlinePhysicalObject myKiller = null;
+            OnlinePhysicalObject myTarget = null;
+            foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Select(kv => kv.Value))
             {
-                DeathMessage.PlayerKillPlayer((killer.apo as AbstractCreature), (target.apo as AbstractCreature), context);
-            } 
-            else
-            {
-                DeathMessage.PlayerKillCreature((killer.apo as AbstractCreature), (target.apo as AbstractCreature), context);
+                if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
+                if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo1 && opo1.apo is AbstractCreature ac)
+                {
+                    if (opo1.id == killer.id)
+                    {
+                        myKiller = opo1;
+                    }
+                    if (opo1.id == target.id)
+                    {
+                        myTarget = opo1;
+                    }
+                }
             }
-            
+            if (myKiller != null)
+            {
+                if (myTarget == null && target.id.FindEntity(true) is OnlinePhysicalObject opo1 && opo1.apo is AbstractCreature ac)
+                {
+                    myTarget = opo1;
+                }
+                if ((target.apo as AbstractCreature).creatureTemplate.type == CreatureTemplate.Type.Slugcat)
+                {
+                    DeathMessage.PlayerKillPlayer(myKiller, myTarget, context);
+                } 
+                else
+                {
+                    DeathMessage.PlayerKillCreature(myKiller, myTarget, context);
+                }
+            }
         }
         [RPCMethod]
         public static void KillFeedCvP(OnlinePhysicalObject killer, OnlinePhysicalObject target)
         {
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
-            if ((killer.apo as AbstractCreature)?.realizedCreature == null || (target.apo as AbstractCreature)?.realizedCreature == null) return;
-            DeathMessage.CreatureKillPlayer((killer.apo as AbstractCreature)?.realizedCreature, (target.apo as AbstractCreature)?.realizedCreature as Player);
+            OnlinePhysicalObject myTarget = null;
+            OnlinePhysicalObject myKiller = null;
+            foreach (var playerAvatar in OnlineManager.lobby.playerAvatars.Select(kv => kv.Value))
+            {
+                if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none) continue; // not in game
+                if (playerAvatar.FindEntity(true) is OnlinePhysicalObject opo1 && opo1.apo is AbstractCreature)
+                {
+                    if (opo1.id == target.id)
+                    {
+                        myTarget = opo1;
+                        break;
+                    }
+                }
+            }
+            if (killer.id.FindEntity(true) is OnlinePhysicalObject opo2 && opo2.apo is AbstractCreature)
+            {
+                myKiller = opo2;
+            }
+            DeathMessage.CreatureKillPlayer(myKiller, myTarget);
         }
     }
 }

--- a/OnlineUIComponents/DeathMessage.cs
+++ b/OnlineUIComponents/DeathMessage.cs
@@ -259,7 +259,7 @@ public static class DeathMessage
     {
         if (crit.killTag != null && crit.killTag.realizedCreature != null)
         {
-            if (crit.killTag.realizedCreature is Player && !RainMeadow.isArenaMode(out var _))
+            if (crit.killTag.realizedCreature is Player)
             {
                 PvPRPC(crit.killTag.realizedCreature as Player, crit, 0);
             }

--- a/OnlineUIComponents/DeathMessage.cs
+++ b/OnlineUIComponents/DeathMessage.cs
@@ -20,6 +20,7 @@ public static class DeathMessage
         var kopo = killer.abstractPhysicalObject.GetOnlineObject();
         var topo = target.abstractPhysicalObject.GetOnlineObject();
         if (kopo == null || topo == null) return;
+        if (target is not Player && target.TotalMass < 0.2f) return;
         foreach (var op in OnlineManager.players)
         {
             op.InvokeRPC(RPCs.KillFeedPvP, kopo, topo, context);
@@ -204,7 +205,6 @@ public static class DeathMessage
             var t = (target.apo as AbstractCreature).creatureTemplate.name;
             var realized = (target.apo as AbstractCreature).realizedCreature;
             if (!ShouldShowDeath(target)) return;
-            if (realized != null && realized.TotalMass < 0.2f) return;
             switch (context)
             {
                 default:

--- a/OnlineUIComponents/DeathMessage.cs
+++ b/OnlineUIComponents/DeathMessage.cs
@@ -161,6 +161,7 @@ public static class DeathMessage
             var k = killer.Template.name;
             var opo = target.abstractPhysicalObject.GetOnlineObject();
             var t = opo.owner.id.name;
+            if (!ShouldShowDeath(opo)) return;
             if (killer.Template.TopAncestor().type == CreatureTemplate.Type.Centipede)
             {
                 ChatLogManager.LogMessage("", $"{t} was zapped by a {k}.");
@@ -194,7 +195,19 @@ public static class DeathMessage
         {
             var k = killer.abstractPhysicalObject.GetOnlineObject().owner.id.name;
             var t = target.Template.name;
+            var opo = target.abstractPhysicalObject.GetOnlineObject();
+            if (!ShouldShowDeath(opo)) return;
             if (target.TotalMass > 0.2f) ChatLogManager.LogMessage("", $"{t} was slain by {k}.");
+
+            if (opo != null)
+            {
+                var onlineHuds = target.room.game.cameras[0].hud.parts.OfType<PlayerSpecificOnlineHud>();
+
+                foreach (var onlineHud in onlineHuds)
+                {
+                    onlineHud.killFeed.Add(opo.id);
+                }
+            }
         }
         catch (Exception e)
         {
@@ -232,7 +245,7 @@ public static class DeathMessage
         {
             if (crit.killTag.realizedCreature is Player && !RainMeadow.isArenaMode(out var _))
             {
-                PlayerKillCreature(crit.killTag.realizedCreature as Player, crit);
+                PvPRPC(crit.killTag.realizedCreature as Player, crit);
             }
             else if (crit is Player)
             {

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -24,6 +24,7 @@ namespace RainMeadow
         //public int antiNightcatFlicker;
 
         public List<OnlinePlayerHudPart> parts = new();
+        public List<OnlineEntity.EntityId> killFeed = new();
 
         public bool lastDead;
         public Player RealizedPlayer => this.abstractPlayer.realizedCreature as Player;


### PR DESCRIPTION
The kill feed now gets sent via RPCMethods. When a message is sent the creature's online ID gets stored in the local PlayerSpecificHud and won't display any more messages pertaining to it until the next session. This should prevent duplicates and ensure everyone gets an accurate and consistent kill feed.

It'll definitely be worth community testing this at some point but it works much better than before from my testing over LAN.