### PR TITLE
Arena: Slugpup management

### DIFF
--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -39,6 +39,22 @@ namespace RainMeadow
             On.Creature.Die += Creature_Die; // do not die!
             IL.Player.TerrainImpact += Player_TerrainImpact;
             On.DeafLoopHolder.Update += DeafLoopHolder_Update;
+            On.Weapon.HitThisObject += Weapon_HitThisObject;
+
+        }
+
+        private bool Weapon_HitThisObject(On.Weapon.orig_HitThisObject orig, Weapon self, PhysicalObject obj)
+        {
+            if (isStoryMode(out var story) && story.friendlyFire && obj is Player && self is Spear && self.thrownBy != null && self.thrownBy is Player)
+            {
+                return true;
+            }
+
+            if (isArenaMode(out var _) && ModManager.MSC && self.IsLocal() && obj is Player pl && pl.slugOnBack?.slugcat != null && pl.slugOnBack.slugcat == self.thrownBy)
+            {
+                return false;
+            }
+            return orig(self, obj);
         }
 
         private void DeafLoopHolder_Update(On.DeafLoopHolder.orig_Update orig, DeafLoopHolder self, bool eu)

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -90,8 +90,7 @@ public partial class RainMeadow
         orig(self, eu);
         if (isArenaMode(out var _) && self.slugcat != null)
         {
-
-            if (self.owner.input[0].thrw && self.owner.grasps == null || self.slugcat.input[0].jmp)
+            if (self.slugcat.input[0].jmp)
             {
                 self.owner.slugOnBack.DropSlug();
 

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -53,12 +53,10 @@ public partial class RainMeadow
 
         On.SlugcatStats.HiddenOrUnplayableSlugcat += SlugcatStatsOnHiddenOrUnplayableSlugcat;
     }
-
-
     private void Player_GrabUpdate1(On.Player.orig_GrabUpdate orig, Player self, bool eu)
     {
         orig(self, eu);
-        if (isArenaMode(out var _) && self.IsLocal())
+        if (isArenaMode(out var _))
         {
             if (self.grasps != null)
             {
@@ -92,16 +90,11 @@ public partial class RainMeadow
         orig(self, eu);
         if (isArenaMode(out var _) && self.slugcat != null)
         {
-            if (self.slugcat.input[0].jmp)
+
+            if (self.owner.input[0].thrw && self.owner.grasps == null || self.slugcat.input[0].jmp)
             {
-                for (int j = 0; j < self.owner.grasps.Length; j++)
-                {
-                    if (self.owner.grasps[j]?.grabbed is Player)
-                    {
-                        self.owner.ReleaseGrasp(j);
-                    }
-                }
                 self.owner.slugOnBack.DropSlug();
+
             }
         }
     }

--- a/Online/State/AbstractObjStickRepr.cs
+++ b/Online/State/AbstractObjStickRepr.cs
@@ -57,7 +57,14 @@ namespace RainMeadow
                 case AbstractPhysicalObject.ImpaledOnSpearStick s:
                     return new ImpaledOnSpearStick(b, s);
                 case Player.AbstractOnBackStick s:
-                    return new OnBackStick(b, s);
+                    if (b.owner == a.owner)
+                    {
+                        return new OnBackStick(b, s);
+                    }
+                    else
+                    {
+                        return new SlugcatOnBackStick(b, s);
+                    }
                 case AbstractPhysicalObject.CreatureGripStick s:
                     return new CreatureGripStick(b, s);
                 default:
@@ -182,6 +189,25 @@ namespace RainMeadow
             {
                 RainMeadow.Debug(this);
                 if (OnlinePhysicalObject.map.TryGetValue(A, out OnlinePhysicalObject a) && a.owner == b.owner && !a.isPending && !b.isPending)
+                {
+                    var stick = new Player.AbstractOnBackStick(a.apo, b.apo);
+                    map.Remove(stick);
+                    map.Add(stick, this);
+                }
+            }
+        }
+
+        public class SlugcatOnBackStick : AbstractObjStickRepr
+        {
+            public SlugcatOnBackStick () { }
+            public SlugcatOnBackStick(OnlinePhysicalObject b, Player.AbstractOnBackStick s) : base(b)
+            {
+            }
+
+            internal override void MakeStick(AbstractPhysicalObject A)
+            {
+                RainMeadow.Debug(this);
+                if (OnlinePhysicalObject.map.TryGetValue(A, out OnlinePhysicalObject a) && a.owner != b.owner && !a.isPending && !b.isPending)
                 {
                     var stick = new Player.AbstractOnBackStick(a.apo, b.apo);
                     map.Remove(stick);

--- a/Online/State/RealizedPlayerState.cs
+++ b/Online/State/RealizedPlayerState.cs
@@ -93,6 +93,7 @@ namespace RainMeadow
 
     public class RealizedPlayerState : RealizedCreatureState
     {
+        private Player? slugcatOnBackTemp;
         [OnlineField(nullable = true)]
         private VinePositionState? vinePosState;
         [OnlineField(nullable = true)]
@@ -114,7 +115,7 @@ namespace RainMeadow
         [OnlineField(nullable = true)]
         private OnlineEntity.EntityId? spearOnBack;
         [OnlineField(nullable = true)]
-        private OnlineEntity.EntityId? slugOnBack;
+        private OnlineEntity.EntityId? slugcatRidingOnBack;
         [OnlineField(group = "inputs")]
         private ushort inputs;
         [OnlineFieldHalf(group = "inputs")]
@@ -155,7 +156,7 @@ namespace RainMeadow
             burstY = p.burstY;
             spearOnBack = (p.spearOnBack?.spear?.abstractPhysicalObject is AbstractPhysicalObject apo
                 && OnlinePhysicalObject.map.TryGetValue(apo, out var oe)) ? oe.id : null;
-            slugOnBack = (p.slugOnBack?.slugcat?.abstractPhysicalObject is AbstractPhysicalObject apo0
+            slugcatRidingOnBack = (p.slugOnBack?.slugcat?.abstractPhysicalObject is AbstractPhysicalObject apo0
                 && OnlinePhysicalObject.map.TryGetValue(apo0, out var oe0)) ? oe0.id : null;
             if (p.tongue is Player.Tongue tongue)
             {
@@ -218,7 +219,7 @@ namespace RainMeadow
         public override void ReadTo(OnlineEntity onlineEntity)
         {
             RainMeadow.Trace(this + " - " + onlineEntity);
-            
+
             var oc = onlineEntity as OnlineCreature;
             var p = oc?.apo.realizedObject as Player;
             if (p is not null) oc.lenientPos = ShouldPosBeLenient(p);
@@ -237,10 +238,24 @@ namespace RainMeadow
             p.glowing = glowing;
             if (p.playerState.isPup != isPup)
                 p.playerState.isPup = isPup;
+
             if (p.spearOnBack != null)
                 p.spearOnBack.spear = (spearOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Spear;
+
             if (p.slugOnBack != null)
-                p.slugOnBack.slugcat = (slugOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Player;
+            {
+                p.slugOnBack.slugcat = (slugcatRidingOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Player;
+                if (p.slugOnBack?.slugcat != null)
+                {
+                    slugcatOnBackTemp = p.slugOnBack?.slugcat;
+                }
+                if (p.slugOnBack?.slugcat == null && slugcatOnBackTemp != null)
+                {
+                    p.slugOnBack.slugcat = slugcatOnBackTemp;
+                    p.slugOnBack.DropSlug();
+                    slugcatOnBackTemp = null;
+                }
+            }
 
             if (p.tongue is Player.Tongue tongue)
             {

--- a/Online/State/RealizedPlayerState.cs
+++ b/Online/State/RealizedPlayerState.cs
@@ -113,8 +113,8 @@ namespace RainMeadow
         private bool isPup;
         [OnlineField(nullable = true)]
         private OnlineEntity.EntityId? spearOnBack;
-        //[OnlineField(nullable = true)]
-        //private OnlineEntity.EntityId? slugOnBack;
+        [OnlineField(nullable = true)]
+        private OnlineEntity.EntityId? slugOnBack;
         [OnlineField(group = "inputs")]
         private ushort inputs;
         [OnlineFieldHalf(group = "inputs")]
@@ -155,8 +155,8 @@ namespace RainMeadow
             burstY = p.burstY;
             spearOnBack = (p.spearOnBack?.spear?.abstractPhysicalObject is AbstractPhysicalObject apo
                 && OnlinePhysicalObject.map.TryGetValue(apo, out var oe)) ? oe.id : null;
-            //slugOnBack = (p.slugOnBack?.slugcat?.abstractPhysicalObject is AbstractPhysicalObject apo0
-            //    && OnlinePhysicalObject.map.TryGetValue(apo0, out var oe0)) ? oe0.id : null;
+            slugOnBack = (p.slugOnBack?.slugcat?.abstractPhysicalObject is AbstractPhysicalObject apo0
+                && OnlinePhysicalObject.map.TryGetValue(apo0, out var oe0)) ? oe0.id : null;
             if (p.tongue is Player.Tongue tongue)
             {
                 tongueMode = (byte)tongue.mode;
@@ -239,8 +239,8 @@ namespace RainMeadow
                 p.playerState.isPup = isPup;
             if (p.spearOnBack != null)
                 p.spearOnBack.spear = (spearOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Spear;
-            //if (pl.slugOnBack != null)
-            //    pl.slugOnBack.slugcat = (slugOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Player;
+            if (p.slugOnBack != null)
+                p.slugOnBack.slugcat = (slugOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Player;
 
             if (p.tongue is Player.Tongue tongue)
             {

--- a/Online/State/RealizedPlayerState.cs
+++ b/Online/State/RealizedPlayerState.cs
@@ -93,7 +93,6 @@ namespace RainMeadow
 
     public class RealizedPlayerState : RealizedCreatureState
     {
-        private Player? slugcatOnBackTemp;
         [OnlineField(nullable = true)]
         private VinePositionState? vinePosState;
         [OnlineField(nullable = true)]
@@ -116,6 +115,7 @@ namespace RainMeadow
         private OnlineEntity.EntityId? spearOnBack;
         [OnlineField(nullable = true)]
         private OnlineEntity.EntityId? slugcatRidingOnBack;
+        private Player? slugcatOnBackTemp; // need this for clients to fix their overlap when slugpup is dropped
         [OnlineField(group = "inputs")]
         private ushort inputs;
         [OnlineFieldHalf(group = "inputs")]

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -104,8 +104,6 @@ namespace RainMeadow
             On.HUD.TextPrompt.Update += TextPrompt_Update;
             On.HUD.TextPrompt.UpdateGameOverString += TextPrompt_UpdateGameOverString;
 
-            On.Weapon.HitThisObject += Weapon_HitThisObject;
-
             IL.Menu.SlugcatSelectMenu.ctor += SlugcatSelectMenu_ctor;
             IL.Menu.SlugcatSelectMenu.UpdateSelectedSlugcatInMiscProg += SlugcatSelectMenu_UpdateSelectedSlugcatInMiscProg;
             On.Menu.SlugcatSelectMenu.SetChecked += SlugcatSelectMenu_SetChecked;
@@ -237,15 +235,6 @@ namespace RainMeadow
                 RainMeadow.rainMeadowOptions.BodyColor.Value = self.colorInterface.bodyColors[0].color;
                 RainMeadow.rainMeadowOptions.EyeColor.Value = self.colorInterface.bodyColors[1].color;
             }
-        }
-
-        private bool Weapon_HitThisObject(On.Weapon.orig_HitThisObject orig, Weapon self, PhysicalObject obj)
-        {
-            if (isStoryMode(out var story) && story.friendlyFire && obj is Player && self is Spear && self.thrownBy != null && self.thrownBy is Player)
-            {
-                return true;
-            }
-            return orig(self, obj);
         }
 
         private void TextPrompt_UpdateGameOverString(On.HUD.TextPrompt.orig_UpdateGameOverString orig, TextPrompt self, Options.ControlSetup.Preset controllerType)


### PR DESCRIPTION
- [x] Don't hit slugcat carrying me
- [x] If player throws me without weapon. drop me
- [x]  Figure out why pup overlap is messed up if player throws instead slugpup jumping off (Check ThrowObject not calling DropSlug(), test early return with dropslug, test slugonback update and blocking throwobject?)