### PR TITLE
Improvements to Kick handling

### DIFF
--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -61,8 +61,10 @@ namespace RainMeadow
         }
 
         [RPCMethod]
-        public static void KickToLobby()
+        public static void KickToLobby(RPCEvent rpc)
         {
+            RainMeadow.Debug($"{rpc.from} is trying to kick {rpc.to}");
+            if (OnlineManager.lobby.owner != rpc.from) return; // Only respond if its the host kicking the player
             if ((RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is not null))
             {
                 if (RWCustom.Custom.rainWorld.processManager.musicPlayer != null)
@@ -72,6 +74,7 @@ namespace RainMeadow
 
                 game.ExitGame(asDeath: true, asQuit: true);
             }
+            OnlineManager.LeaveLobby();
             RWCustom.Custom.rainWorld.processManager.RequestMainProcessSwitch(RainMeadow.Ext_ProcessID.LobbySelectMenu);
             BanHammer.ShowBan(RWCustom.Custom.rainWorld.processManager);
         }


### PR DESCRIPTION
Some extra checks and safeguards to prevent lobby breaking exploits. Steamworks doesn't natively support kicking/bans so workarounds will be needed.

### Goals:

- [x] Only accept KickToLobby RPCs issued by the lobby host on the client side
- [ ] Immediately boot players out of the lobby and then show the dialog upon being kicked.
- [ ] Stop sending game updates and RPCs to anyone the host has verifiably kicked if they don't get immediately disconnected. Effectively renders them as disconnected to other users in the lobby.
- [ ] Test it all