### PR TITLE
register and clean out missing remotes

### DIFF
--- a/Online/Entity/OnlinePhysicalObject.cs
+++ b/Online/Entity/OnlinePhysicalObject.cs
@@ -172,6 +172,14 @@ namespace RainMeadow
             }
         }
 
+        public static void RegisterAndCleanOutRemoteEntity(AbstractPhysicalObject apo, OnlineResource rs)
+        {
+            RainMeadow.Debug("Unregistered entity being registered and exiting...");
+            var opo = RegisterPhysicalObject(apo);
+            opo.ExitResource(rs);
+
+        }
+
         protected virtual AbstractPhysicalObject ApoFromDef(OnlinePhysicalObjectDefinition newObjectEvent, OnlineResource inResource, AbstractPhysicalObjectState initialState)
         {
             World world = inResource is RoomSession rs ? rs.World : inResource is WorldSession ws ? ws.world : throw new InvalidProgrammerException("not room nor world");

--- a/Online/Resource/RoomSession.Entities.cs
+++ b/Online/Resource/RoomSession.Entities.cs
@@ -33,6 +33,7 @@ namespace RainMeadow
                 if (OnlineManager.lobby.gameMode.ShouldSyncAPOInRoom(this, apo))
                 {
                     RainMeadow.Error($"Unregistered entity leaving {this} : {apo} - {Environment.StackTrace}");
+                    OnlinePhysicalObject.RegisterAndCleanOutRemoteEntity(apo, this);
                 }
             }
         }

--- a/Online/Resource/WorldSession.Entities.cs
+++ b/Online/Resource/WorldSession.Entities.cs
@@ -44,6 +44,7 @@ namespace RainMeadow
                 if (OnlineManager.lobby.gameMode.ShouldSyncAPOInWorld(this, apo))
                 {
                     RainMeadow.Error($"Unregistered entity leaving {this} : {apo} - {Environment.StackTrace}");
+                    OnlinePhysicalObject.RegisterAndCleanOutRemoteEntity(apo, this);
                 }
             }
         }


### PR DESCRIPTION
- Most useful in story scenarios where a remote object may be left in unowned and unhandled state around gates