### PR TITLE
RPC Error Prevention

### DIFF
--- a/Online/OnlineManager.cs
+++ b/Online/OnlineManager.cs
@@ -219,6 +219,8 @@ namespace RainMeadow
 
         public static void ProcessIncomingEvent(OnlineEvent onlineEvent)
         {
+            if (onlineEvent.aborted) return; //don't process aborted events!
+
             OnlinePlayer fromPlayer = onlineEvent.from;
             fromPlayer.needsAck = true;
             if (EventMath.IsNewer(onlineEvent.eventId, fromPlayer.lastEventFromRemote))


### PR DESCRIPTION
Adds:
1. The **option** to have a byte in RPCs that specify their length, so that erroneous or unrecognized RPCs don't cause serialization of the entire packet to fail (and apparently crashes as a result...)
2. (Unimportant: Adds the option for RPCs to specify a particular index, so they can possibly avoid load-order dependency)

### Why is this important?
1. Crashes are happening already; this'll fix that.
2. People clearly want soft-compatible mods like Push To Meow. Admittedly, this isn't *important*, but it is desired.
3. Overall adds an extra layer of safety and stability for a quite cheap cost.

### Why is the length byte enabled by default?
Feel free to alter this if it's a total hold-up for you, but I think the logic is simple: RPCs should check for errors *unless otherwise specified*. If anyone (especially a modder) is implementing an RPC, we should want it to have some error prevention unless it is explicitly stated not to (e.g: It is thoroughly tested and reliable).
RPCs that are important to optimize in Rain Meadow should be specified as optimized; or if necessary, all RPCs in Meadow can be changed to skip error correction by a simple find/replace action in the code.

### Why not make this a separate system?
1. Do you really want to maintain two separate events that do exactly the same thing, except one has an extra byte?
2. This encourages stability all around. *Apparently*, people will make their own mods with RPCs that can break the game. This will make them have to go out of their way to send erroneous RPCs. Modders will probably use whatever method is most convenient, and adding a second inferior method will likely not help much.

I have extremely carefully arranged this code to be as unintrusive as possible. If there is anything that can be changed to be more accommodating, please let me know.

(Thoroughly tested locally; but marked as a draft until it can be reviewed by people who care very deeply about this system and then tested through Steam.)