### PR TITLE
Ext Enum Sync by Choc

### DIFF
--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -99,16 +99,10 @@ namespace RainMeadow
         {
             return ExtEnumBase.valueDictionary.First(kvp => EnumTypeToID(kvp.Key) == shortName).Key;
         }
-        //adds a lazy hash of the assembly name, just in case
+        //appends the assembly name, just in case (shouldn't ever be necessary; just a precaution)
         private static string EnumTypeToID(Type T)
         {
-            return T.ToString() + "" + HashString(T.Assembly.FullName);
-        }
-        private static string HashString(string s)
-        {
-            int value = 0;
-            for (int i = 0; i < s.Length; i++) value ^= (s[i] << (i & 15)) | (s[i] >>> (16 - (i & 15)));
-            return value.ToString().Substring(0, 4); //keep the string short; it shouldn't ever be necessary, hopefully
+            return T.ToString() + ":" + T.Assembly.FullName;
         }
 
         public void RequestLobby(string? key)

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -57,6 +57,8 @@ namespace RainMeadow
             {
                 this.password = password;
                 (configurableBools, configurableFloats, configurableInts) = OnlineGameMode.GetHostRemixSettings(this.gameMode);
+
+                //determine ExtEnum values to be used within the lobby
                 this.strEnumMap = ExtEnumBase.valueDictionary.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value.entries.ToArray());
                 RainMeadow.Debug(string.Join("\n", strEnumMap.Select(kvp => $"{kvp.Key}: [ {string.Join(", ", kvp.Value)} ]")));
                 foreach (var kvp in this.strEnumMap)
@@ -70,7 +72,7 @@ namespace RainMeadow
                             map.Add(i, ExtEnumBase.valueDictionary[type].entries.IndexOf(kvp.Value[i]));
                     }
                     this.enumMapToLocal.Add(type, map);
-                    this.enumMapToRemote.Add(type, map.ToDictionary(x => x.Value, x => x.Key));
+                    this.enumMapToRemote.Add(type, map.ToDictionary(x => x.Value, x => x.Key)); //make the two dictionaries distinct
                 }
             }
             else
@@ -289,6 +291,7 @@ namespace RainMeadow
                     lobby.modsChecked = true;
                 }
 
+                //set the ExtEnum map received from the lobby owner
                 if (lobby.strEnumMap.Count == 0)
                 {
                     try
@@ -311,11 +314,12 @@ namespace RainMeadow
                     {
                         RainMeadow.Error($"failed to sync enums: {e}");
 
+                        //inform user of the error
                         var manager = RWCustom.Custom.rainWorld.processManager;
 
                         manager.ShowDialog(new Menu.DialogNotify(manager.rainWorld.inGameTranslator.Translate("Mod Mismatch!") + Environment.NewLine + e, manager));
 
-                        OnlineManager.LeaveLobby();
+                        OnlineManager.LeaveLobby(); //and leave the lobby
                     }
                 }
 

--- a/Online/Serialization/Serializer.Classes.cs
+++ b/Online/Serialization/Serializer.Classes.cs
@@ -17,11 +17,15 @@ namespace RainMeadow
             if (IsReading)
             {
                 int idx = reader.ReadByte();
-                extEnum = (T)Activator.CreateInstance(typeof(T),
-                    new object[] { ExtEnum<T>.values.GetEntry(
-                        OnlineManager.lobby.enumMapToLocal.TryGetValue(typeof(T), out var map) ? map[idx]
-                        : idx //default to the idx given... this isn't a nice solution, but it's a fallback
-                        ), false });
+                if (OnlineManager.lobby.enumMapToLocal.TryGetValue(typeof(T), out var map))
+                    extEnum = (T)Activator.CreateInstance(typeof(T),
+                        new object[] { ExtEnum<T>.values.GetEntry(map[idx]), false });
+                else
+                {
+                    RainMeadow.Error($"Failed to find ExtEnum map for {typeof(T)}; using backup value of {idx}");
+                    extEnum = (T)Activator.CreateInstance(typeof(T),
+                        new object[] { ExtEnum<T>.values.GetEntry(idx), false });
+                }
             }
         }
 

--- a/Online/Serialization/Serializer.Classes.cs
+++ b/Online/Serialization/Serializer.Classes.cs
@@ -16,8 +16,12 @@ namespace RainMeadow
             }
             if (IsReading)
             {
+                int idx = reader.ReadByte();
                 extEnum = (T)Activator.CreateInstance(typeof(T),
-                    new object[] { ExtEnum<T>.values.GetEntry(OnlineManager.lobby.enumMapToLocal[typeof(T)][reader.ReadByte()]), false });
+                    new object[] { ExtEnum<T>.values.GetEntry(
+                        OnlineManager.lobby.enumMapToLocal.TryGetValue(typeof(T), out var map) ? map[idx]
+                        : idx //default to the idx given... this isn't a nice solution, but it's a fallback
+                        ), false });
             }
         }
 

--- a/Online/Serialization/Serializer.Classes.cs
+++ b/Online/Serialization/Serializer.Classes.cs
@@ -39,7 +39,7 @@ namespace RainMeadow
 #endif
                 for (int i = 0; i < extEnum.Length; i++)
                 {
-                    writer.Write((byte)extEnum[i].Index);
+                    writer.Write(OnlineManager.lobby.enumMapToRemote[typeof(T)][extEnum[i].Index]);
                 }
             }
             if (IsReading)
@@ -47,7 +47,16 @@ namespace RainMeadow
                 extEnum = new T[reader.ReadByte()];
                 for (int i = 0; i < extEnum.Length; i++)
                 {
-                    extEnum[i] = (T)Activator.CreateInstance(typeof(T), new object[] { ExtEnum<T>.values.GetEntry(reader.ReadByte()), false });
+                    int idx = reader.ReadByte();
+                    if (OnlineManager.lobby.enumMapToLocal.TryGetValue(typeof(T), out var map))
+                        extEnum[i] = (T)Activator.CreateInstance(typeof(T),
+                            new object[] { ExtEnum<T>.values.GetEntry(map[idx]), false });
+                    else
+                    {
+                        RainMeadow.Error($"Failed to find ExtEnum map for {typeof(T)}; using backup value of {idx}");
+                        extEnum[i] = (T)Activator.CreateInstance(typeof(T),
+                            new object[] { ExtEnum<T>.values.GetEntry(idx), false });
+                    }
                 }
             }
         }
@@ -62,7 +71,7 @@ namespace RainMeadow
 #endif
                 for (int i = 0; i < extEnum.Count; i++)
                 {
-                    writer.Write((byte)extEnum[i].Index);
+                    writer.Write(OnlineManager.lobby.enumMapToRemote[typeof(T)][extEnum[i].Index]);
                 }
             }
             if (IsReading)
@@ -71,7 +80,16 @@ namespace RainMeadow
                 extEnum = new(count);
                 for (int i = 0; i < count; i++)
                 {
-                    extEnum.Add((T)Activator.CreateInstance(typeof(T), new object[] { ExtEnum<T>.values.GetEntry(reader.ReadByte()), false }));
+                    int idx = reader.ReadByte();
+                    if (OnlineManager.lobby.enumMapToLocal.TryGetValue(typeof(T), out var map))
+                        extEnum.Add((T)Activator.CreateInstance(typeof(T),
+                            new object[] { ExtEnum<T>.values.GetEntry(map[idx]), false }));
+                    else
+                    {
+                        RainMeadow.Error($"Failed to find ExtEnum map for {typeof(T)}; using backup value of {idx}");
+                        extEnum.Add((T)Activator.CreateInstance(typeof(T),
+                            new object[] { ExtEnum<T>.values.GetEntry(idx), false }));
+                    }
                 }
             }
         }

--- a/Online/Serialization/Serializer.Data.cs
+++ b/Online/Serialization/Serializer.Data.cs
@@ -1537,7 +1537,10 @@ namespace RainMeadow
                     {
                         value[j] = reader.ReadString();
                     }
-                    data.Add(key, value);
+                    try
+                    {
+                        data.Add(key, value);
+                    } catch (System.Exception ex) { RainMeadow.Error(ex); }
                 }
             }
 #if TRACING


### PR DESCRIPTION
Prevents most issues due to ExtEnums having different indices.

Currently marked as a draft because I'm not confident about the quality of my changes to Choc's code. Unfortunately, I mostly just tried random changes until it worked. I think the overall result is decent functionality-wise, but I still want to do some more testing with this.

### Why not just ensure mod load orders are the same?
According to a group of stubborn mod testers in the Rain Meadow Discord, identical mod load order does not guarantee identical ExtEnum index order. It seems that if mods are applied at different times or reordered, the enums can become jumbled up. While ensuring mod load order is undoubtedly important, this adds an extra level of stability to the game.

@youbitchoc Thoughts? (Your code did end up throwing critical errors in like 4 different places, so sorry for mangling it so severely.)