### PR TITLE
Deflate Compression on Every Packet

### DIFF
--- a/Online/Matchmaking/UdpPeer.cs
+++ b/Online/Matchmaking/UdpPeer.cs
@@ -832,7 +832,8 @@ namespace RainMeadow
                 }
 
                 //decompressed as early as possible
-                buffer = Compression.DecompressBytes(buffer);
+                buffer = Compression.DecompressBytes(buffer, len);
+                len = buffer.Length;
                 
 
                 IPEndPoint? ipsender = sender as IPEndPoint;

--- a/Online/Serialization/Serializer.cs
+++ b/Online/Serialization/Serializer.cs
@@ -23,7 +23,7 @@ namespace RainMeadow
         private long eventHeader;
         private uint stateCount;
         private long stateHeader;
-        public int zipTreshold = 4000;
+        public int zipTreshold = Int32.MaxValue; //4000; // essentially disabled the zipThreshold, since the entire packet is zipped, which is more efficient
 
         static Serializer scratchpad;
         public Serializer(long bufferCapacity, bool scratch = false)

--- a/Online/Serialization/SteamNetIO.cs
+++ b/Online/Serialization/SteamNetIO.cs
@@ -77,9 +77,9 @@ namespace RainMeadow
                                 //Marshal.Copy(message.m_pData, OnlineManager.serializer.buffer, 0, message.m_cbSize);
                                 Marshal.Copy(message.m_pData, buffer, 0, message.m_cbSize);
 
-                                buffer = Compression.DecompressBytes(buffer); //decompress as soon as the packet is read
+                                buffer = Compression.DecompressBytes(buffer, message.m_cbSize); //decompress as soon as the packet is read
                                 OnlineManager.serializer.buffer.CopyTo(buffer, 0);
-                                OnlineManager.serializer.ReadData(fromPlayer, message.m_cbSize);
+                                OnlineManager.serializer.ReadData(fromPlayer, buffer.Length);
                             }
                         }
                         catch (Exception e)

--- a/Utils/Compression.cs
+++ b/Utils/Compression.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace RainMeadow;
+
+public static class Compression
+{
+    /// <summary>
+    /// Compresses the input bytes using a DeflateStream.
+    /// </summary>
+    /// <param name="bytes">The input, uncompressed bytes.</param>
+    /// <returns>An array of compressed bytes.</returns>
+    public static byte[] CompressBytes(byte[] bytes)
+    {
+        if (bytes.Length == 0) return bytes;
+        try
+        {
+            using (MemoryStream inputStream = new(bytes))
+            using (MemoryStream compressStream = new())
+            using (DeflateStream compressor = new(compressStream, CompressionMode.Compress))
+            {
+                inputStream.CopyTo(compressor, bytes.Length);
+                compressor.Close();
+
+                var output = compressStream.ToArray();
+                //if (bytes.Length > 128) //don't spam me with useless debug messages please
+                RainMeadow.Debug($"Compressed {bytes.Length} bytes into {output.Length} bytes.");
+                return output;
+            }
+        }
+        catch (Exception ex)
+        {
+            RainMeadow.Error(ex);
+        }
+        return bytes; //fallback: just return the input
+    }
+
+    /// <summary>
+    /// Decompresses the input bytes using a DeflateStream.
+    /// </summary>
+    /// <param name="bytes">The input, compressed bytes.</param>
+    /// <returns>An array of uncompressed bytes.</returns>
+    public static byte[] DecompressBytes(byte[] bytes)
+    {
+        if (bytes.Length == 0) return bytes;
+        try
+        {
+            using (MemoryStream outputStream = new())
+            using (MemoryStream compressedStream = new(bytes))
+            using (DeflateStream decompressor = new(compressedStream, CompressionMode.Decompress))
+            {
+                decompressor.CopyTo(outputStream);
+                decompressor.Close();
+
+                var output = outputStream.ToArray();
+                //if (output.Length > 128) //don't spam me with useless debug messages please
+                RainMeadow.Debug($"Decompressed {bytes.Length} bytes into {output.Length} bytes.");
+                return output;
+            }
+        }
+        catch (Exception ex)
+        {
+            RainMeadow.Error(ex);
+        }
+        return bytes; //fallback: just return the input
+    }
+}


### PR DESCRIPTION
This is very much a draft: I am still unsure how much this impacts the CPU.
However, functionality-wise, this is pretty much finished. The only choice is whether to use LZ4 or Deflate.

Current observations:
* Halves the amount of data sent (huge bonus for folks with low upload speeds, like me!).
* Definitely has a negative impact on CPU performance,
* But I genuinely cannot tell the difference during normal gameplay.

This really just needs: Some very good profiling and playtesting to determine if people think performance has decreased. Unfortunately, I am very bad at supplying either of those...