### PR TITLE
Infrequent State Sends

### DIFF
--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -222,6 +222,8 @@ namespace RainMeadow
                 onlineIntRemixSettings = lobby.configurableInts;
             }
 
+            public override float SendFrequency(Player? player) => 0.25f;
+
             public override void ReadTo(OnlineResource resource)
             {
                 var lobby = (Lobby)resource;

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -112,6 +112,8 @@ namespace RainMeadow
                 }
             }
 
+            public override float SendFrequency(Player? player) => 0.25f;
+
             public override void ReadTo(OnlineResource resource)
             {
                 if (resource.isActive)

--- a/Online/State/OnlineState.cs
+++ b/Online/State/OnlineState.cs
@@ -145,6 +145,8 @@ namespace RainMeadow
             }
         }
 
+        public virtual float SendFrequency(Player? player) => 1f;
+
         public class OnlineFieldAttribute : Attribute
         {
             public string group; // things on the same group are gruped in deltas, saving bytes

--- a/Online/State/RealizedOracleSwarmerState.cs
+++ b/Online/State/RealizedOracleSwarmerState.cs
@@ -17,6 +17,9 @@
             this.floaty = swarmer.affectedByGravity < 1f;
         }
 
+        //neurons are half as important, simply because there are SO MANY of them in iterators
+        public override float SendFrequency(Player? player) => base.SendFrequency(player) * 0.5f;
+
         public override void ReadTo(OnlineEntity onlineEntity)
         {
             base.ReadTo(onlineEntity);

--- a/Online/State/RealizedPhysicalObjectState.cs
+++ b/Online/State/RealizedPhysicalObjectState.cs
@@ -12,12 +12,22 @@ namespace RainMeadow
         private ChunkState[] chunkStates;
         [OnlineField(group = "chunkstate")]
         private byte collisionLayer;
+        private AbstractPhysicalObject abstractPhysicalObject;
 
         public RealizedPhysicalObjectState() { }
         public RealizedPhysicalObjectState(OnlinePhysicalObject onlineEntity)
         {
             chunkStates = onlineEntity.apo.realizedObject.bodyChunks.Select(c => new ChunkState(c)).ToArray();
             collisionLayer = (byte)onlineEntity.apo.realizedObject.collisionLayer;
+            abstractPhysicalObject = onlineEntity.apo;
+        }
+
+        //0.2f if not in same room; 1f at 20 tile distance, higher at lower distances, minimum = 0.2f
+        public override float SendFrequency(Player? player)
+        {
+            if (player != null && abstractPhysicalObject.realizedObject != null && player.abstractPhysicalObject.Room.index == abstractPhysicalObject.Room.index)
+                return Mathf.Max(0.2f, 160000 / (player.firstChunk.pos - abstractPhysicalObject.realizedObject.firstChunk.pos).sqrMagnitude);
+            return 0.2f; //(20*20)^2 == ^^^
         }
 
         public virtual void ReadTo(OnlineEntity onlineEntity)


### PR DESCRIPTION
**THIS IS JUST A TESTING DRAFT! I AM NOT YET SUGGESTING THAT WE ACTUALLY IMPLEMENT THIS YET!!**

I've been getting annoyed having Rain Meadow get super glitchy in Five Pebbles due to the sheer quantity of neurons. That's a _lot_ of data that's being synced every tick.

So I had the basic idea of making states for distant realized objects sync less often. I haven't tested it very much, but it's quite difficult to tell any different in-game, because every object in the same room within 20 tiles is still synced every frame.

If this does get implemented, I would suggest it as an optional thing in the Remix menu. Maybe there could be an entire tab called "Optimization" with options like this that might slightly help those with poor internet.

Oh, and one last idea: What if instead of grouping all OnlineFields with unspecified groups into the same group called "default", we give each one with an unspecified name its own unique group name. This (from testing) significantly increases the number of deltas per State, but also then decreases the amount of data sent overall. Just an idea, though.