### PR TITLE
Soft RPCs, rpc reordering and version bump

### DIFF
--- a/Mod/modinfo.json
+++ b/Mod/modinfo.json
@@ -1,7 +1,7 @@
 {
   "id": "henpemaz_rainmeadow",
   "name": "Rain Meadow",
-  "version": "0.1.2.1",
+  "version": "0.1.3.01",
   "target_game_version": "v1.9.15",
   "authors": "Henpemaz - Lead Developer<LINE><LINE>Wolfycatt(Ana) - Lead Artist<LINE><LINE>Intikus - Lead Audio Designer<LINE><LINE>Noircatto - Programming, engine<LINE><LINE>HelloThere - Programming, sound<LINE><LINE>A1iex - UI Design<LINE><LINE>FranklyGD - Programming, engine<LINE><LINE>MC41Games - Programming, menus<LINE><LINE>Silvyger - Programming, arena<LINE><LINE>Vigaro - Programming, menus<LINE><LINE>BitiLope - Programming, story<LINE><LINE>Pudgy Turtle - Programming, story<LINE><LINE>ddemile - Programming, modsync<LINE><LINE>UO - Programming, story, arena<LINE><LINE>Saddest - Programming, UI, chat<LINE><LINE>notchoc - Programming, story<LINE><LINE>phanie_ - Illustration<LINE><LINE>Timbits - Programming, UI, menus<LINE><LINE>Zedreus - Programming, UI, story<LINE><LINE>Persondotexe - Programming, modsync<LINE><LINE>invalidunits - Programming, UI, LAN<LINE><LINE>forthfora - Programming, modsync",
   "description": "A multiplayer engine, custom game mode inspired by Might & Delight's 'Meadow', and online arena / story experience.<LINE><LINE>For the full credits see the workshop or the credits page in the Meadow menu.",

--- a/Online/Events/OnlineEvent.cs
+++ b/Online/Events/OnlineEvent.cs
@@ -39,6 +39,7 @@ namespace RainMeadow
             GenericResultError,
             GenericResultFail,
             RPCEvent,
+            SoftRPCEvent,
         }
 
         // there used to be a lot more stuff in here until I made everything into RPCs and state
@@ -60,6 +61,9 @@ namespace RainMeadow
                     break;
                 case EventTypeId.RPCEvent:
                     e = new RPCEvent();
+                    break;
+                case EventTypeId.SoftRPCEvent:
+                    e = new SoftRPCEvent();
                     break;
             }
             if (e is null) throw new InvalidOperationException("invalid event type: " + eventTypeId);

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -15,7 +15,7 @@ namespace RainMeadow
     [BepInPlugin("henpemaz.rainmeadow", "RainMeadow", MeadowVersionStr)]
     public partial class RainMeadow : BaseUnityPlugin
     {
-        public const string MeadowVersionStr = "0.1.2.1";
+        public const string MeadowVersionStr = "0.1.3.01";
         public static RainMeadow instance;
         private bool init;
         public bool fullyInit;


### PR DESCRIPTION
Sends a module GUI and ushort length that is used to skip the message body if the receiver does not have the module, takes a separate event index (we have plenty of those left). No changes to base RPCs other than ensuring that meadow ones are loaded first.