### PR TITLE
[wip] allow LAN and Steam players to play in same lobby

### DIFF
--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -37,6 +37,7 @@ public class RainMeadowOptions : OptionInterface
     public readonly Configurable<bool> DisableMeadowPauseAnimation;
     public readonly Configurable<bool> StopMovementWhileSpectateOverlayActive;
 
+	public readonly Configurable<bool> EnableLanInterface;
 
     public readonly Configurable<IntroRoll> PickedIntroRoll;
 

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -361,7 +361,7 @@ namespace RainMeadow
             var meadowButton = new SimpleButton(self, self.pages[0], self.Translate("MEADOW"), "MEADOW", Vector2.zero, new Vector2(Menu.MainMenu.GetButtonWidth(self.CurrLang), 30f));
             self.AddMainMenuButton(meadowButton, () =>
             {
-                if (!(OnlineManager.netIO is SteamNetIO) && !showed_no_steam_warning)
+                if (OnlineManager.steamNetIO == null && !showed_no_steam_warning)
                 {
                     showed_no_steam_warning = true;
                     self.manager.ShowDialog(new DialogNotify(self.Translate("Steam is not currently available. Some features of Rain Meadow have been disabled."), self.manager, 

--- a/Online/Matchmaking/LANMatchmakingManager.cs
+++ b/Online/Matchmaking/LANMatchmakingManager.cs
@@ -92,7 +92,7 @@ namespace RainMeadow {
             }
 
             public bool isLoopback() {
-                if (OnlineManager.GetLANNetIO() is LANNetIO netio) {
+                if (OnlineManager.netIO is LANNetIO netio) {
                     if (netio.manager.port != endPoint?.Port) return false;
                 }
 
@@ -109,7 +109,7 @@ namespace RainMeadow {
             }
         }
         public override void initializeMePlayer() {
-            if (OnlineManager.GetLANNetIO() is LANNetIO netio) {
+            if (OnlineManager.netIO is LANNetIO netio) {
                 OnlineManager.mePlayer = new OnlinePlayer(new LANPlayerId(new IPEndPoint(
                     UDPPeerManager.getInterfaceAddresses()[0], netio.manager.port))) { isMe = true };
                 if (RainMeadow.rainMeadowOptions.LanUserName.Value.Length > 0) {
@@ -126,7 +126,7 @@ namespace RainMeadow {
             // To create a proper list, we need to send a message to the broadcast endpoint.
             // and wait for responces from possible hosts.
             for (int i = 0; i < 8; i++) {
-                if (OnlineManager.GetLANNetIO() is LANNetIO lanentio) {
+                if (OnlineManager.netIO is LANNetIO lanentio) {
                     using (MemoryStream memoryStream = new())
                     using (BinaryWriter writer = new(memoryStream)) {
                         lanentio.SendBroadcast(new RequestLobbyPacket());
@@ -157,12 +157,12 @@ namespace RainMeadow {
 
         public void SendLobbyInfo(OnlinePlayer other) {
             if (OnlineManager.lobby != null && OnlineManager.lobby.isOwner) {
-                if (OnlineManager.GetLANNetIO() is LANNetIO lannetio) {
+                if (OnlineManager.netIO is LANNetIO lannetio) {
                     var packet = new InformLobbyPacket(
                         maxplayercount, Utils.Translate("LAN Lobby"), OnlineManager.lobby.hasPassword,
                         OnlineManager.lobby.gameModeType.value, OnlineManager.players.Count,
                         RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetRequiredMods()), RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetBannedMods()));
-                    OnlineManager.GetLANNetIO().SendP2P(other, packet, NetIO.SendType.Unreliable, true);
+                    OnlineManager.netIO.SendP2P(other, packet, NetIO.SendType.Unreliable, true);
                 }
             }
         }
@@ -180,7 +180,7 @@ namespace RainMeadow {
         public override void SendChatMessage(string message) {
             foreach (OnlinePlayer player in OnlineManager.players) {
                 if (player.isMe) continue;
-                OnlineManager.GetLANNetIO().SendP2P(player, new ChatMessagePacket(message), NetIO.SendType.Reliable);
+                OnlineManager.netIO.SendP2P(player, new ChatMessagePacket(message), NetIO.SendType.Reliable);
             }
 
             RecieveChatMessage(OnlineManager.mePlayer, message);
@@ -216,7 +216,7 @@ namespace RainMeadow {
             if (OnlineManager.players.Contains(joiningPlayer)) { return; }
             OnlineManager.players.Add(joiningPlayer);
             HandleJoin(joiningPlayer);
-            (OnlineManager.GetLANNetIO() as LANNetIO)?.SendAcknoledgement(joiningPlayer);
+            (OnlineManager.netIO as LANNetIO)?.SendAcknoledgement(joiningPlayer);
             RainMeadow.Debug($"Added {joiningPlayer} to the lobby matchmaking player list");
 
             if (OnlineManager.lobby != null && OnlineManager.lobby.isOwner)
@@ -228,12 +228,12 @@ namespace RainMeadow {
                     if (player.isMe || player == joiningPlayer)
                         continue;
 
-                    OnlineManager.GetLANNetIO().SendP2P(player, new ModifyPlayerListPacket(ModifyPlayerListPacket.Operation.Add, new OnlinePlayer[] { joiningPlayer }), 
+                    OnlineManager.netIO.SendP2P(player, new ModifyPlayerListPacket(ModifyPlayerListPacket.Operation.Add, new OnlinePlayer[] { joiningPlayer }), 
                         NetIO.SendType.Reliable);
                 }
 
                 // Tell joining peer to create everyone in the server
-                OnlineManager.GetLANNetIO().SendP2P(joiningPlayer, new ModifyPlayerListPacket(ModifyPlayerListPacket.Operation.Add, 
+                OnlineManager.netIO.SendP2P(joiningPlayer, new ModifyPlayerListPacket(ModifyPlayerListPacket.Operation.Add, 
                     OnlineManager.players.Append(OnlineManager.mePlayer).ToArray()), 
                     NetIO.SendType.Reliable);
             }
@@ -258,11 +258,11 @@ namespace RainMeadow {
                     if (player.isMe)
                         continue;
 
-                    OnlineManager.GetLANNetIO().SendP2P(player, new ModifyPlayerListPacket(ModifyPlayerListPacket.Operation.Remove, new OnlinePlayer[] { leavingPlayer }), 
+                    OnlineManager.netIO.SendP2P(player, new ModifyPlayerListPacket(ModifyPlayerListPacket.Operation.Remove, new OnlinePlayer[] { leavingPlayer }), 
                         NetIO.SendType.Reliable);
                 }
             }
-            OnlineManager.GetLANNetIO().ForgetPlayer(leavingPlayer);
+            OnlineManager.netIO.ForgetPlayer(leavingPlayer);
             OnPlayerListReceivedEvent(playerList.ToArray());
         }
         string lobbyPassword = "";
@@ -279,7 +279,7 @@ namespace RainMeadow {
                 }
                 
                 RainMeadow.Debug("Sending Request to join lobby...");
-                OnlineManager.GetLANNetIO().SendP2P(new OnlinePlayer(new LANPlayerId(lobbyInfo.endPoint)), 
+                OnlineManager.netIO.SendP2P(new OnlinePlayer(new LANPlayerId(lobbyInfo.endPoint)), 
                     new RequestJoinPacket(OnlineManager.mePlayer.id.name), NetIO.SendType.Reliable, true);
             } else {
                 RainMeadow.Error("Invalid lobby type");
@@ -316,13 +316,13 @@ namespace RainMeadow {
             if (OnlineManager.players is not null) {
                 if (OnlineManager.players.Count > 1) {
                     foreach (OnlinePlayer p in  OnlineManager.players) {
-                        OnlineManager.GetLANNetIO().SendP2P(p, 
+                        OnlineManager.netIO.SendP2P(p, 
                             new SessionEndPacket(), 
                                 NetIO.SendType.Reliable);
                     }
                 }
             }
-            OnlineManager.GetLANNetIO().ForgetEverything();
+            OnlineManager.netIO.ForgetEverything();
         }
 
         public override OnlinePlayer GetLobbyOwner() {

--- a/Online/Matchmaking/MatchmakingManager.cs
+++ b/Online/Matchmaking/MatchmakingManager.cs
@@ -60,7 +60,6 @@ namespace RainMeadow
                 instances.Add(MatchMakingDomain.Steam, new SteamMatchmakingManager());
                 supported_matchmakers.Add(MatchMakingDomain.Steam);
             }
-
             supported_matchmakers.Add(MatchMakingDomain.LAN); 
             instances.Add(MatchMakingDomain.LAN, new LANMatchmakingManager());
             currentDomain = supported_matchmakers[0];
@@ -198,6 +197,7 @@ namespace RainMeadow
             RainMeadow.Debug($"Actually removing player:{player}");
             OnlineManager.players.Remove(player);
             OnlineManager.netIO.ForgetPlayer(player);
+			OnlineManager.altNetIO?.ForgetPlayer(player);
 
             ChatLogManager.LogMessage(Utils.Translate("Rain Meadow"), (player.id.GetPersonaName()) + " " + Utils.Translate("left the game."));
         }

--- a/Online/Matchmaking/MatchmakingManager.cs
+++ b/Online/Matchmaking/MatchmakingManager.cs
@@ -56,7 +56,7 @@ namespace RainMeadow
             supported_matchmakers.Clear();
             instances.Clear();
 
-            if (OnlineManager.netIO is SteamNetIO) {
+            if (OnlineManager.steamNetIO != null) {
                 instances.Add(MatchMakingDomain.Steam, new SteamMatchmakingManager());
                 supported_matchmakers.Add(MatchMakingDomain.Steam);
             }
@@ -197,7 +197,7 @@ namespace RainMeadow
             RainMeadow.Debug($"Actually removing player:{player}");
             OnlineManager.players.Remove(player);
             OnlineManager.netIO.ForgetPlayer(player);
-			OnlineManager.altNetIO?.ForgetPlayer(player);
+			OnlineManager.steamNetIO?.ForgetPlayer(player);
 
             ChatLogManager.LogMessage(Utils.Translate("Rain Meadow"), (player.id.GetPersonaName()) + " " + Utils.Translate("left the game."));
         }

--- a/Online/Matchmaking/Packets/RequestJoinPacket.cs
+++ b/Online/Matchmaking/Packets/RequestJoinPacket.cs
@@ -29,7 +29,7 @@ namespace RainMeadow
                 matchmaker.AcknoledgeLANPlayer(processingPlayer);
 
                 // Tell them they are in
-                OnlineManager.GetLANNetIO().SendP2P(processingPlayer, new JoinLobbyPacket(
+                OnlineManager.netIO.SendP2P(processingPlayer, new JoinLobbyPacket(
                     matchmaker.maxplayercount,
                     "LAN Lobby",
                     OnlineManager.lobby.hasPassword,

--- a/Online/Matchmaking/Packets/RequestJoinPacket.cs
+++ b/Online/Matchmaking/Packets/RequestJoinPacket.cs
@@ -29,7 +29,7 @@ namespace RainMeadow
                 matchmaker.AcknoledgeLANPlayer(processingPlayer);
 
                 // Tell them they are in
-                OnlineManager.netIO.SendP2P(processingPlayer, new JoinLobbyPacket(
+                OnlineManager.GetLANNetIO().SendP2P(processingPlayer, new JoinLobbyPacket(
                     matchmaker.maxplayercount,
                     "LAN Lobby",
                     OnlineManager.lobby.hasPassword,
@@ -38,7 +38,6 @@ namespace RainMeadow
                     RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetRequiredMods()),
                     RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetBannedMods())
                 ), NetIO.SendType.Reliable);
-
             }
         }
 

--- a/Online/Matchmaking/Packets/SessionEndPacket.cs
+++ b/Online/Matchmaking/Packets/SessionEndPacket.cs
@@ -8,7 +8,7 @@ namespace RainMeadow
         {
             if (MatchmakingManager.currentDomain == MatchmakingManager.MatchMakingDomain.LAN)
 			{
-            	OnlineManager.GetLANNetIO().ForgetPlayer(processingPlayer);
+            	OnlineManager.netIO.ForgetPlayer(processingPlayer);
 			}
         }
     }

--- a/Online/Matchmaking/Packets/SessionEndPacket.cs
+++ b/Online/Matchmaking/Packets/SessionEndPacket.cs
@@ -6,8 +6,10 @@ namespace RainMeadow
 
         public override void Process()
         {
-            if (MatchmakingManager.currentDomain != MatchmakingManager.MatchMakingDomain.LAN) return;
-            OnlineManager.netIO.ForgetPlayer(processingPlayer);
+            if (MatchmakingManager.currentDomain == MatchmakingManager.MatchMakingDomain.LAN)
+			{
+            	OnlineManager.GetLANNetIO().ForgetPlayer(processingPlayer);
+			}
         }
     }
 }

--- a/Online/OnlineManager.cs
+++ b/Online/OnlineManager.cs
@@ -12,6 +12,8 @@ namespace RainMeadow
     public class OnlineManager : MainLoopProcess
     {
         public static NetIO netIO;
+        public static LANNetIO altNetIO;
+
         public static OnlineManager instance;
         public static Serializer serializer = new Serializer(65536);
         public static List<ResourceSubscription> subscriptions;
@@ -32,9 +34,12 @@ namespace RainMeadow
             if (SteamManager.Instance.m_bInitialized && SteamUser.BLoggedOn()) {
                 netIO = new SteamNetIO();
             }
-            
+            // if steam is not installed, default to LAN
+            // otherwise if we enable LAN interfaces, activate the alternative net interface
             if (netIO == null) {
                 netIO = new LANNetIO();
+            } else if (RainMeadow.rainMeadowOptions.EnableLanInterface.Value) {
+                altNetIO = new LANNetIO();
             }
 
             instance = this;
@@ -72,6 +77,7 @@ namespace RainMeadow
 
             MatchmakingManager.currentInstance.LeaveLobby();
             netIO?.ForgetEverything();
+            altNetIO?.ForgetEverything();
             lobby = null;
 
             subscriptions = new();
@@ -97,6 +103,7 @@ namespace RainMeadow
         {
             myTimeStacker += dt * (float)framesPerSecond;
             netIO?.Update(); // incoming data
+            altNetIO?.Update();
             lastReceive = UnityEngine.Time.realtimeSinceStartup;
 
             if (myTimeStacker >= 1f)
@@ -114,6 +121,7 @@ namespace RainMeadow
         public static void ForceLoadUpdate()
         {
             netIO?.Update();
+            altNetIO?.Update();
             lastReceive = UnityEngine.Time.realtimeSinceStartup;
 
             if (UnityEngine.Time.realtimeSinceStartup > lastSend + 1f / instance.framesPerSecond)
@@ -175,6 +183,7 @@ namespace RainMeadow
             if (toPlayer.needsAck || toPlayer.OutgoingEvents.Count > 0 || toPlayer.OutgoingStates.Count > 0)
             {
                 netIO?.SendSessionData(toPlayer);
+                altNetIO?.SendSessionData(toPlayer);
             }
         }
 
@@ -372,6 +381,14 @@ namespace RainMeadow
                 LeaveLobby();
                 throw new Exception(v);
             }
+        }
+
+        public static LANNetIO GetLANNetIO()
+        {
+            if (netIO != null && netIO is LANNetIO lanetio) {
+                return lanetio;
+            }
+            return altNetIO;
         }
     }
 }


### PR DESCRIPTION
idea:
- pop up an extra LAN interface for steam users (default = off, configurable toggle)
- from that interface other users can connect who are not using steam
- host could just "rewire" all p2p from all players to the LAN people
probably not the best way to do it i feel through