### PR TITLE
conditionally serialize EntityID

### DIFF
--- a/Online/Entity/OnlineEntity.EntityId.cs
+++ b/Online/Entity/OnlineEntity.EntityId.cs
@@ -35,9 +35,17 @@
 
             public void CustomSerialize(Serializer serializer)
             {
-                serializer.Serialize(ref originalOwner);
                 serializer.Serialize(ref type);
-                serializer.Serialize(ref id);
+                serializer.Serialize(ref originalOwner);
+                switch ((byte)type)
+                {
+                case (byte)IdType.none:
+                case (byte)IdType.settings:
+                    break;
+                default:
+                    serializer.Serialize(ref id);
+                    break;
+                }
             }
 
             public override string ToString()


### PR DESCRIPTION
before:
ushort(2)+byte(1)+id(4)
reorg as id(4),ushort(2),(padding=1),byte(1)
4+2+1+1 = 8 (+8/16 of cli overhead)
serialized = 6

after:
uint = 4 (+8/16 of cli overhead)
serialized = 4

still managed but could easily be made into a struct if needed [w. bitpattern 0xffff_ffff as ad-hoc "nullable"?]