### PR TITLE
Fix default colors OutOfRange exception in story menu

### DIFF
--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -112,6 +112,7 @@ namespace RainMeadow
 
             IL.Menu.SlugcatSelectMenu.SliderSetValue += SlugcatSelectMenu_SliderFix;
             IL.Menu.SlugcatSelectMenu.ValueOfSlider += SlugcatSelectMenu_SliderFix;
+            IL.Menu.SlugatSelectMenu.Singal +=  IL_SlugcatSelectMenu_SingalFix;
 
             On.Menu.SlugcatSelectMenu.SetChecked += SlugcatSelectMenu_SetChecked;
             On.Menu.SlugcatSelectMenu.GetChecked += SlugcatSelectMenu_GetChecked;

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -242,7 +242,29 @@ namespace RainMeadow
 
             orig(self, box, c);
         }
+	    
+	private void IL_SlugcatSelectMenu_SingalFix(ILContext il)
+        {
+            try
+            {
+                /*SlugcatStats.Name name = this.slugcatColorOrder[this.slugcatPageIndex]; <- patch this
+		  int index = this.activeColorChooser;
+		 this.manager.rainWorld.progression.miscProgressionData.colorChoices[name.value][index] = this.colorInterface.defaultColors[this.activeColorChooser];*/
 
+                ILCursor cursor = new(il);
+                cursor.GotoNext(MoveType.After, x => x.MatchStloc(0));
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.Emit(OpCodes.Ldloca, 0);
+                cursor.EmitDelegate((Menu.SlugcatSelectMenu ssM, ref SlugcatStats.Name name) =>
+                {
+                    name = ssM is StoryOnlineMenu? ssM.colorInterface.slugcatID : name;
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+            }
+        }
 
         private void SlugcatSelectMenu_SliderFix(ILContext context)
         {

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -112,7 +112,7 @@ namespace RainMeadow
 
             IL.Menu.SlugcatSelectMenu.SliderSetValue += SlugcatSelectMenu_SliderFix;
             IL.Menu.SlugcatSelectMenu.ValueOfSlider += SlugcatSelectMenu_SliderFix;
-            IL.Menu.SlugatSelectMenu.Singal +=  IL_SlugcatSelectMenu_SingalFix;
+            IL.Menu.SlugcatSelectMenu.Singal +=  IL_SlugcatSelectMenu_SingalFix;
 
             On.Menu.SlugcatSelectMenu.SetChecked += SlugcatSelectMenu_SetChecked;
             On.Menu.SlugcatSelectMenu.GetChecked += SlugcatSelectMenu_GetChecked;


### PR DESCRIPTION

error when setting default colors in config when testing 1.3.0

ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
System.ThrowHelper.ThrowArgumentOutOfRangeException (System.ExceptionArgument argument, System.ExceptionResource resource) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.ThrowHelper.ThrowArgumentOutOfRangeException () (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Collections.Generic.List`1[T].set_Item (System.Int32 index, T value) (at <695d1cc93cca45069c528c15c9fdd749>:0)
Menu.SlugcatSelectMenu.Singal (Menu.MenuObject sender, System.String message) (at <1ce43d89235949a5ba90dc605b43f579>:0)
