### PR TITLE
Scrolling buttons adjustments

### DIFF
--- a/Menu/ButtonScroller.cs
+++ b/Menu/ButtonScroller.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Menu;
+using UnityEngine;
+using HarmonyLib;
+
+namespace RainMeadow
+{
+    //a scroller just for predetermined buttons, intended for buttons' owner to be ButtonScroller, rn has predetermined height and spacing
+    public class ButtonScroller : RectangularMenuObject, Slider.ISliderOwner
+    {
+        public static float CalculateHeightBasedOnAmtOfButtons(int amtOfButtonsView, float buttonHeight, float spacing)
+        {
+            //remember it goes by buttonsize + button spacing not the buttonSpacing + buttonsize. button size plus first as there will be not extra spacing
+            return buttonHeight + Mathf.Max(amtOfButtonsView - 1) * (buttonHeight + spacing);
+        }
+        public int ItemCount => buttons.Count;
+        public float MaxVisibleItemsShown => (UpperBound - LowerBound) / ButtonHeightAndSpacing;
+        public float MaxDownScroll => Mathf.Max(0, (ItemCount - MaxVisibleItemsShown) * ButtonHeightAndSpacing);
+        public float DownScrollOffset
+        {
+            get
+            {
+                return scrollOffset;
+            }
+            set
+            {
+                scrollOffset = value;
+                ConstrainScroll();
+                scrollSliderValue = MaxDownScroll > 0 ? Mathf.InverseLerp(MaxDownScroll, 0, scrollOffset) : 1; //lower slider value means down, higher means up
+            }
+        }
+        public float LowerBound => 0;
+        public float UpperBound => size.y;
+        public float ButtonHeightAndSpacing => buttonHeight + buttonSpacing;
+        public bool CanScrollUp => scrollOffset > 0;
+        public bool CanScrollDown => scrollOffset < MaxDownScroll;
+        public ButtonScroller(Menu.Menu menu, MenuObject owner, Vector2 pos, int amtOfButtonsToView, float listSizeX,float heightOfButton, float buttonSpacing) : this(menu, owner, pos, new(listSizeX, CalculateHeightBasedOnAmtOfButtons(amtOfButtonsToView, heightOfButton, buttonSpacing)))
+        {
+            buttonHeight = heightOfButton;
+            this.buttonSpacing = buttonSpacing;
+        }
+        public ButtonScroller(Menu.Menu menu, MenuObject owner, Vector2 pos, Vector2 size) : base(menu, owner, pos, size)
+        {
+            scrollOffset = 0;
+            scrollSliderValue = 1;
+            scrollSlider = new(menu, this, "Scroller", new(-30, 0), new Vector2(20, size.y), new("BUTTONSCROLLER_SCROLLSLIDER"), true);
+            subObjects.Add(scrollSlider);
+            ConstrainScroll();
+        }
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+            this.ClearMenuObject(ref scrollSlider);
+            RemoveAllButtons();
+        }
+        public override void Update()
+        {
+            base.Update();
+            if (MouseOver && menu.manager.menuesMouseMode)
+            {
+                ScrollingUpdate(menu.mouseScrollWheelMovement * buttons.Count / 2f);
+            }
+        }
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+            for (int i = 0; i < ItemCount; i++)
+            {
+                buttons[i].Alpha = GetAmountOfAlphaByCrossingBounds(buttons[i].Pos);
+                buttons[i].Size = new(buttons[i].Size.x, buttonHeight);
+                buttons[i].Pos = GetIdealPosWithScrollForButton(i);
+            }
+
+        }
+        public void SliderSetValue(Slider slider, float f)
+        {
+            if (slider?.ID?.value == "BUTTONSCROLLER_SCROLLSLIDER")
+            {
+                //scrollSliderValue is the entire scroll avaliblity combined into 0-1, better if could adjust the slider size
+                DownScrollOffset = Mathf.Lerp(MaxDownScroll, 0, f);
+            }
+        }
+        public float ValueOfSlider(Slider slider)
+        {
+            if (slider?.ID?.value == "BUTTONSCROLLER_SCROLLSLIDER")
+            {
+                return scrollSliderValue;
+            }
+            return 0;
+        }
+        public void ScrollingUpdate(float yInput)
+        {
+            if ((yInput < 0 && CanScrollUp) || (yInput > 0 && CanScrollDown))
+            {
+                //scrolling up -, scrolling down +
+                AddScroll(yInput);
+                menu.PlaySound(SoundID.MENU_Scroll_Tick);
+            }
+        }
+        public void AddScroll(float addDir)
+        {
+            DownScrollOffset += addDir;
+        }
+        public void ConstrainScroll()
+        {
+            scrollOffset = Mathf.Clamp(scrollOffset, 0, MaxDownScroll);
+        }
+        public List<T> GetSpecificButtons<T>()
+        {
+            return [..buttons.OfType<T>()];
+        }
+        public int IndexFromButton(IPartOfButtonScroller button)
+        {
+            for (int i = 0; i < buttons.Count; i++)
+            {
+                if (buttons[i] == button)
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+        public void RemoveButton(int index)
+        {
+            RemoveButton(index, true);
+        }
+        public void RemoveButton(int index, bool constrainScroll)
+        {
+            if (buttons.Count > index)
+            {
+                if (buttons[index] is MenuObject menuObj)
+                {
+                    this.ClearMenuObject(menuObj);
+                }
+                buttons.RemoveAt(index);
+            }
+            if (constrainScroll)
+            {
+                ConstrainScroll();
+            }
+        }
+        public void RemoveAllButtons()
+        {
+            RemoveAllButtons(true);
+        }
+        public void RemoveAllButtons(bool constrainScroll)
+        {
+            this.ClearMenuObjectIList(buttons.Where(x => x is MenuObject).Cast<MenuObject>());
+            buttons.Clear();
+            if (constrainScroll)
+            {
+                ConstrainScroll();
+            }
+        }
+        public void AddScrollObjects(params IPartOfButtonScroller[]? scrollBoxButtons)
+        {
+            AddScrollObjects(scrollBoxButtons, true, true);
+        }
+        public void AddScrollObjects(IPartOfButtonScroller[]? scrollBoxButtons, bool addToSubobjects, bool bindToSlider)
+        {
+            if (scrollBoxButtons != null)
+            {
+                List<IPartOfButtonScroller> newButtons = [.. scrollBoxButtons.Where(x => x != null)];
+                buttons.AddRange(newButtons);
+                if (addToSubobjects)
+                {
+                    subObjects.AddDistinctRange(newButtons.Where(x => x is MenuObject).Cast<MenuObject>());
+                }
+                if (bindToSlider)
+                {
+                    buttons.DoIf(x => x is MenuObject, x => (x as MenuObject).TryBind(scrollSlider, true));
+                }
+
+            }
+        }
+        public Vector2 GetIdealNormalPosForButton(int index)
+        {
+            return new(0, UpperBound - (buttonHeight + (index * (buttonSpacing + buttonHeight))));
+        }
+        public Vector2 GetIdealPosWithScrollForButton(int index)
+        {
+            Vector2 idealPos = GetIdealNormalPosForButton(index);
+            return new(idealPos.x, Math.Min(UpperBound + (ButtonHeightAndSpacing / 3), Mathf.Max(LowerBound - (ButtonHeightAndSpacing / 3), idealPos.y + scrollOffset)));
+        }
+        public float GetAmountOfAlphaByCrossingBounds(Vector2 combinedPos)
+        {
+            //if button starts crossing the bound, calculate the alpha else alpha = 1
+            float combinedPosY = combinedPos.y;
+            return combinedPosY < LowerBound ? Mathf.InverseLerp(LowerBound - (ButtonHeightAndSpacing / 3), LowerBound, combinedPosY) : combinedPosY + buttonHeight > UpperBound ? Mathf.InverseLerp(UpperBound + (ButtonHeightAndSpacing / 3), UpperBound, combinedPosY + buttonHeight) : 1;
+        }
+
+        private float scrollOffset;
+        public float scrollSliderValue, buttonSpacing, buttonHeight = 30;
+        public VerticalSlider? scrollSlider;
+        public List<IPartOfButtonScroller> buttons = [];
+        public class ScrollerButton(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size, string description = "") : SimplerButton(menu, owner, displayText, pos, size, description), IPartOfButtonScroller
+        {
+            public float Alpha { get => alpha; set => alpha = value; }
+            public Vector2 Pos { get => pos; set => pos = value; }
+            public Vector2 Size { get => size; set => size = value; }
+            public override bool CurrentlySelectableNonMouse => alpha >= 1 && base.CurrentlySelectableNonMouse;
+            public override bool CurrentlySelectableMouse => alpha >= 1 && base.CurrentlySelectableMouse;
+            public virtual void UpdateAlpha(float alpha)
+            {
+                this.alpha = alpha;
+                menuLabel.label.alpha = alpha;
+                for (int i = 0; i < roundedRect.sprites.Length; i++)
+                {
+                    roundedRect.sprites[i].alpha = alpha;
+                    roundedRect.fillAlpha = alpha / 2;
+                }
+                for (int i = 0; i < selectRect.sprites.Length; i++)
+                {
+                    selectRect.sprites[i].alpha = alpha;
+                }
+                GetButtonBehavior.greyedOut = alpha < 1;
+            }
+
+            public float alpha = 1;
+        }
+        public interface IPartOfButtonScroller //allows other derived objects to be part of the button scroller
+        {
+            public float Alpha { get; set; }
+            public Vector2 Pos { get; set; }
+            public Vector2 Size { get; set; }
+            public void UpdateAlpha(float alpha);
+        }
+    }
+}

--- a/Menu/Objects/ButtonScroller.cs
+++ b/Menu/Objects/ButtonScroller.cs
@@ -10,9 +10,14 @@ namespace RainMeadow
     //a scroller just for predetermined buttons, intended for buttons' owner to be ButtonScroller, rn has predetermined height and spacing
     public class ButtonScroller : RectangularMenuObject, Slider.ISliderOwner
     {
+        public static float CalculateHeightBasedOnAmtOfButtons(int amtOfButtonsView, float buttonHeight, float spacing)
+        {
+            //remember it goes by buttonsize + button spacing not the buttonSpacing + buttonsize. button size plus first as there will be not extra spacing
+            return buttonHeight + Mathf.Max(amtOfButtonsView - 1) * (buttonHeight + spacing);
+        }
         public int ItemCount => buttons.Count;
-        public float MaxVisibleItemsShown => (UpperBound - LowerBound) / (buttonHeight + buttonSpacing);
-        public float MaxDownScroll => Mathf.Max(0, (ItemCount - MaxVisibleItemsShown) * (buttonHeight + buttonSpacing));
+        public float MaxVisibleItemsShown => (UpperBound - LowerBound) / ButtonHeightAndSpacing;
+        public float MaxDownScroll => Mathf.Max(0, (ItemCount - MaxVisibleItemsShown) * ButtonHeightAndSpacing);
         public float DownScrollOffset
         {
             get
@@ -28,8 +33,14 @@ namespace RainMeadow
         }
         public float LowerBound => 0;
         public float UpperBound => size.y;
+        public float ButtonHeightAndSpacing => buttonHeight + buttonSpacing;
         public bool CanScrollUp => scrollOffset > 0;
         public bool CanScrollDown => scrollOffset < MaxDownScroll;
+        public ButtonScroller(Menu.Menu menu, MenuObject owner, Vector2 pos, int amtOfButtonsToView, float listSizeX,float heightOfButton, float buttonSpacing) : this(menu, owner, pos, new(listSizeX, CalculateHeightBasedOnAmtOfButtons(amtOfButtonsToView, heightOfButton, buttonSpacing)))
+        {
+            buttonHeight = heightOfButton;
+            this.buttonSpacing = buttonSpacing;
+        }
         public ButtonScroller(Menu.Menu menu, MenuObject owner, Vector2 pos, Vector2 size) : base(menu, owner, pos, size)
         {
             scrollOffset = 0;
@@ -49,7 +60,7 @@ namespace RainMeadow
             base.Update();
             if (MouseOver && menu.manager.menuesMouseMode)
             {
-                ScrollingUpdate(menu.mouseScrollWheelMovement * 1.2f);
+                ScrollingUpdate(menu.mouseScrollWheelMovement * buttons.Count / 2f);
             }
         }
         public override void GrafUpdate(float timeStacker)
@@ -85,6 +96,7 @@ namespace RainMeadow
             {
                 //scrolling up -, scrolling down +
                 AddScroll(yInput);
+                menu.PlaySound(SoundID.MENU_Scroll_Tick);
             }
         }
         public void AddScroll(float addDir)
@@ -151,20 +163,20 @@ namespace RainMeadow
         public Vector2 GetIdealPosWithScrollForButton(int index)
         {
             Vector2 idealPos = GetIdealNormalPosForButton(index);
-            return new(idealPos.x, Math.Min(UpperBound + (buttonHeight / 3), Mathf.Max(LowerBound - (buttonHeight / 3), idealPos.y + scrollOffset)));
+            return new(idealPos.x, Math.Min(UpperBound + (ButtonHeightAndSpacing / 3), Mathf.Max(LowerBound - (ButtonHeightAndSpacing / 3), idealPos.y + scrollOffset)));
         }
         public float GetAmountOfAlphaByCrossingBounds(Vector2 combinedPos)
         {
             //if button starts crossing the bound, calculate the alpha else alpha = 1
             float combinedPosY = combinedPos.y;
-            return combinedPosY < LowerBound ? Mathf.InverseLerp(LowerBound - (buttonHeight / 3), LowerBound, combinedPosY) : combinedPosY + buttonHeight > UpperBound ? Mathf.InverseLerp(UpperBound + (buttonHeight / 3), UpperBound, combinedPosY + buttonHeight) : 1;
+            return combinedPosY < LowerBound ? Mathf.InverseLerp(LowerBound - (ButtonHeightAndSpacing / 3), LowerBound, combinedPosY) : combinedPosY + buttonHeight > UpperBound ? Mathf.InverseLerp(UpperBound + (ButtonHeightAndSpacing / 3), UpperBound, combinedPosY + buttonHeight) : 1;
         }
 
         private float scrollOffset;
         public float scrollSliderValue, buttonSpacing, buttonHeight = 30;
         public VerticalSlider? scrollSlider;
         public List<IPartOfButtonScroller> buttons = [];
-        public class ScrollerButton(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size) : SimplerButton(menu, owner, displayText, pos, size), IPartOfButtonScroller
+        public class ScrollerButton(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size, string description = "") : SimplerButton(menu, owner, displayText, pos, size, description), IPartOfButtonScroller
         {
             public float Alpha { get => alpha; set => alpha = value; }
             public Vector2 Pos { get => pos; set => pos = value; }
@@ -184,6 +196,7 @@ namespace RainMeadow
                 {
                     selectRect.sprites[i].alpha = alpha;
                 }
+                GetButtonBehavior.greyedOut = alpha < 1;
             }
 
             public float alpha = 1;

--- a/Menu/Objects/ButtonSelector.cs
+++ b/Menu/Objects/ButtonSelector.cs
@@ -10,8 +10,8 @@ namespace RainMeadow
     {
         public int NumberOfButtonsToShow { get => amtOfButtonsToShow; set => amtOfButtonsToShow = Mathf.Max(value, 2); } //this includes the open list button itself
         public float OrigDistanceBetweenButtonYPos => size.y + buttonSpacing;
-        public float ListPosOffset => downwardsList ? -(OrigDistanceBetweenButtonYPos + buttonSpacing + listDownUpYOffset) : OrigDistanceBetweenButtonYPos + listDownUpYOffset; //readds the additional button spacing lost
-        public float OrigStart => downwardsList ? -ButtonScroller.CalculateHeightBasedOnAmtOfButtons(NumberOfButtonsToShow - 1, size.y, buttonSpacing) : size.y; //first removes an additional button spacing required
+        public float ListPosOffset => downwardsList ? -(buttonSpacing + listDownUpYOffset) : OrigDistanceBetweenButtonYPos + listDownUpYOffset; //readds the additional button spacing lost
+        public float OrigStart => downwardsList ? -ButtonScroller.CalculateHeightBasedOnAmtOfButtons(NumberOfButtonsToShow - 1, size.y, buttonSpacing) : size.y;
         public float StartingYPoint => OrigStart + ListPosOffset;
 
         public ButtonSelector(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size, int amtOfButtonsView, float spacingOfButton, string description = "") : base(menu, owner, displayText, pos, size, description)

--- a/Menu/Objects/ButtonSelector.cs
+++ b/Menu/Objects/ButtonSelector.cs
@@ -5,19 +5,18 @@ using UnityEngine;
 namespace RainMeadow
 {
     //now includes the first button as another button to view
+    //uses num of buttons to show now, the selector button is counted
     public class ButtonSelector : SimplerButton
     {
+        public int NumberOfButtonsToShow { get => amtOfButtonsToShow; set => amtOfButtonsToShow = Mathf.Max(value, 2); } //this includes the open list button itself
         public float OrigDistanceBetweenButtonYPos => size.y + buttonSpacing;
-        public float ListPosOffset => downwardsList ? -(OrigDistanceBetweenButtonYPos + listDownUpYOffset) : OrigDistanceBetweenButtonYPos + listDownUpYOffset;
-        public float OrigStart => downwardsList ? -sizeOfList : size.y;
-        public float StartingPoint => OrigStart + ListPosOffset;
-        public ButtonSelector(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size, int amtOfButtonsView, float spacingOfButton) : this(menu, owner, displayText, pos, size, (Mathf.Max(0, amtOfButtonsView - 1) * (size.y + spacingOfButton)), spacingOfButton)
+        public float ListPosOffset => downwardsList ? -(OrigDistanceBetweenButtonYPos + buttonSpacing + listDownUpYOffset) : OrigDistanceBetweenButtonYPos + listDownUpYOffset; //readds the additional button spacing lost
+        public float OrigStart => downwardsList ? -ButtonScroller.CalculateHeightBasedOnAmtOfButtons(NumberOfButtonsToShow - 1, size.y, buttonSpacing) : size.y; //first removes an additional button spacing required
+        public float StartingYPoint => OrigStart + ListPosOffset;
+
+        public ButtonSelector(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size, int amtOfButtonsView, float spacingOfButton, string description = "") : base(menu, owner, displayText, pos, size, description)
         {
-            //if you set it to one or less... why???
-        }
-        public ButtonSelector(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size, float listSize, float spacingOfButton) : base(menu, owner, displayText, pos, size, "Press the button to open a list to select")
-        {
-            sizeOfList = listSize;
+            NumberOfButtonsToShow = amtOfButtonsView;
             buttonSpacing = spacingOfButton;
             OnClick += (_) =>
             {
@@ -40,13 +39,13 @@ namespace RainMeadow
         }
         public virtual void UpdateUponClosingList()
         {
-
+            menu.PlaySound(SoundID.MENU_MultipleChoice_Clicked);
         }
         public virtual void OpenCloseList()
         {
             if (scroller == null)
             {
-                scroller = new(menu, this, new(0, StartingPoint), new(size.x, sizeOfList));
+                scroller = new(menu, this, new(0, StartingYPoint), NumberOfButtonsToShow - 1, size.x, size.y, buttonSpacing);
                 scroller.AddScrollObjects(populateList?.Invoke(this, scroller));
                 subObjects.Add(scroller);
                 return;
@@ -56,8 +55,8 @@ namespace RainMeadow
         }
 
         public bool downwardsList = true;
-        public float listDownUpYOffset;
-        public float sizeOfList, buttonSpacing;
+        public float listDownUpYOffset, buttonSpacing;
+        private int amtOfButtonsToShow;
         public ButtonScroller? scroller;
         public Func<ButtonSelector,ButtonScroller, ButtonScroller.IPartOfButtonScroller[]>? populateList;
     }

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -59,7 +59,6 @@ namespace RainMeadow
                 }
             }       
             orig(self);
-            return;
         }
 
         private bool SlugcatSelectMenu_SlugcatUnlocked(On.Menu.SlugcatSelectMenu.orig_SlugcatUnlocked orig, SlugcatSelectMenu self, SlugcatStats.Name i)

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -36,6 +36,11 @@ namespace RainMeadow
 
             On.Menu.SlugcatSelectMenu.AddColorButtons += SlugcatSelectMenu_AddColorButtons;
             On.Menu.MenuObject.GrafUpdate += On_MenuObject_GrafUpdate;
+            On.Menu.Menu.UpdateInfoText += On_Menu_UpdateInfoText;
+        }
+        string On_Menu_UpdateInfoText(On.Menu.Menu.orig_UpdateInfoText orig, Menu.Menu self)
+        {
+            return self.selectedObject != null && self.selectedObject is IHaveADescription descripObj ? descripObj.Description : orig(self);
         }
         void On_MenuObject_GrafUpdate(On.Menu.MenuObject.orig_GrafUpdate orig, MenuObject self, float timestacker)
         {
@@ -45,21 +50,19 @@ namespace RainMeadow
                 buttonScroll.UpdateAlpha(buttonScroll.Alpha);
             }
         }
-        void SlugcatSelectMenu_AddColorButtons(On.Menu.SlugcatSelectMenu.orig_AddColorButtons orig, global::Menu.SlugcatSelectMenu self) {
-            if (isStoryMode(out _)) {
-                var storymenu = self as StoryOnlineMenu;
-                if (storymenu == null) {
-                    Error("self was not a StoryOnlineMenu.");
-                } else if (storymenu.colorInterface == null) {
-                    storymenu.SetupSelectableSlugcats();
-                    Vector2 pos = new Vector2(1000f - (1366f - storymenu.manager.rainWorld.options.ScreenSize.x) / 2f, storymenu.manager.rainWorld.options.ScreenSize.y - 100f);
-                    self.colorInterface = self.GetColorInterfaceForSlugcat(storymenu.selectableSlugcats[storymenu.SelectedIndex], pos);
+        void SlugcatSelectMenu_AddColorButtons(On.Menu.SlugcatSelectMenu.orig_AddColorButtons orig, SlugcatSelectMenu self) 
+        {
+            if (self is StoryOnlineMenu sOM)
+            {
+                if (sOM.colorInterface == null)
+                {
+                    sOM.SetupSelectableSlugcats();
+                    Vector2 pos = new(1000f - (1366f - sOM.manager.rainWorld.options.ScreenSize.x) / 2f, sOM.manager.rainWorld.options.ScreenSize.y - 100f);
+                    self.colorInterface = self.GetColorInterfaceForSlugcat(sOM.CurrentSlugcat, pos);
                     self.pages[0].subObjects.Add(self.colorInterface);
-                    return;
+                    //return; removed return due to the orig making a new the color interface if it is null, so unnecessary
                 }
-            }
-            
-
+            }       
             orig(self);
             return;
         }

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -36,11 +36,6 @@ namespace RainMeadow
 
             On.Menu.SlugcatSelectMenu.AddColorButtons += SlugcatSelectMenu_AddColorButtons;
             On.Menu.MenuObject.GrafUpdate += On_MenuObject_GrafUpdate;
-            On.Menu.Menu.UpdateInfoText += On_Menu_UpdateInfoText;
-        }
-        string On_Menu_UpdateInfoText(On.Menu.Menu.orig_UpdateInfoText orig, Menu.Menu self)
-        {
-            return self.selectedObject != null && self.selectedObject is IHaveADescription descripObj ? descripObj.Description : orig(self);
         }
         void On_MenuObject_GrafUpdate(On.Menu.MenuObject.orig_GrafUpdate orig, MenuObject self, float timestacker)
         {

--- a/Story/StoryMenuButtons.cs
+++ b/Story/StoryMenuButtons.cs
@@ -10,7 +10,7 @@ namespace RainMeadow
 {
     public class StoryMenuPlayerButton : ButtonScroller.ScrollerButton
     {
-        public StoryMenuPlayerButton(Menu.Menu menu, MenuObject owner,OnlinePlayer oP, bool canKick) : base(menu, owner, oP.id.name, Vector2.zero, new(110, 30))
+        public StoryMenuPlayerButton(Menu.Menu menu, MenuObject owner, OnlinePlayer oP, bool canKick, Vector2 size = default) : base(menu, owner, oP.id.name, Vector2.zero, size == default ? new(110, 30) : size)
         {
             OnClick += (_) => 
             { 
@@ -31,17 +31,18 @@ namespace RainMeadow
             base.RemoveSprites();
             this.ClearMenuObject(ref kickButton);
         }
-        public override void UpdateAlpha(float fade)
+        public override void UpdateAlpha(float alpha)
         {
-            base.UpdateAlpha(fade);
+            base.UpdateAlpha(alpha);
             if (kickButton != null)
             {
-                kickButton.symbolSprite.alpha = fade;
+                kickButton.symbolSprite.alpha = alpha;
                 for (int i = 0; i < kickButton.roundedRect.sprites.Length; i++)
                 {
-                    kickButton.roundedRect.sprites[i].alpha = fade;
-                    kickButton.roundedRect.fillAlpha = fade / 2;
+                    kickButton.roundedRect.sprites[i].alpha = alpha;
+                    kickButton.roundedRect.fillAlpha = alpha / 2;
                 }
+                kickButton.GetButtonBehavior.greyedOut = alpha < 1;
             }    
         }
         public SimplerSymbolButton? kickButton;
@@ -71,7 +72,7 @@ namespace RainMeadow
             base.GrafUpdate(timeStacker);
             if (menuLabel != null)
             {
-                menuLabel.text = SlugcatStats.getSlugcatName(slug);
+                menuLabel.text = menu.Translate(SlugcatStats.getSlugcatName(slug));
             }
         }
         public SlugcatStats.Name slug;

--- a/Story/StoryMenuButtons.cs
+++ b/Story/StoryMenuButtons.cs
@@ -18,7 +18,7 @@ namespace RainMeadow
             };
             if (canKick)
             {
-                kickButton = new(menu, this, "Menu_Symbol_Clear_All", "KICKPLAYER", new(size.x + 15, 0));
+                kickButton = new(menu, this, "Menu_Symbol_Clear_All", "KICKPLAYER", new(this.size.x + 15, 0));
                 kickButton.OnClick += (_) =>
                 {
                     BanHammer.BanUser(oP);

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -39,7 +39,10 @@ namespace RainMeadow
                 {
                     RemoveColorButtons();
                     actualSelectedIndex = value;
-                    UpdateUponChangingSlugcat(CurrentSlugcat);
+                    if (colorChecked)
+                    {
+                        AddColorButtons();
+                    }
                 }
             }
         }

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -207,6 +207,7 @@ namespace RainMeadow
 
             }
 
+
             if (OnlineManager.lobby.isOwner)
             {
                 storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
@@ -233,19 +234,6 @@ namespace RainMeadow
             }
 
         }
-        public override void Singal(MenuObject sender, string message)
-        {
-            if (message == "DEFAULTCOL")
-            {
-                manager.rainWorld.progression.miscProgressionData.colorChoices[selectableSlugcats[SelectedIndex].value] = colorInterface.defaultColors;
-                hueSlider.floatValue = hueSlider.floatValue;
-                satSlider.floatValue = satSlider.floatValue;
-                litSlider.floatValue = litSlider.floatValue;
-                PlaySound(SoundID.MENU_Remove_Level);
-                return;
-            }
-            base.Singal(sender, message);
-        }
 
         public override void ShutDownProcess()
         {
@@ -263,7 +251,7 @@ namespace RainMeadow
             playerScrollBox?.RemoveAllButtons();
             if (playerScrollBox == null)
             {
-                playerScrollBox = new(this, pages[0], new(194,  553 - ((MaxVisibleOnList + 1) * ButtonSizeWithSpacing)), new(200, MaxVisibleOnList * ButtonSizeWithSpacing))
+                playerScrollBox = new(this, pages[0], new(194,  553 - 30 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, ButtonSize, ButtonSpacingOffset)
                 {
                     buttonSpacing = ButtonSpacingOffset
                 };
@@ -338,8 +326,8 @@ namespace RainMeadow
             }
             if (slugcatSelector == null)
             {
-                //first player button is 30 pos below size of list. and list is 38 below the title. Plus
-                slugcatSelector = new(this, pages[0], new(pos.x, pos.y - ButtonSizeWithSpacing - ButtonSize), MaxVisibleOnList - 1, ButtonSpacingOffset, CurrentSlugcat, GetSlugcatSelectionButtons);
+                //first player button is 30 pos below size of list. and list top part is 30 below the title. Plus
+                slugcatSelector = new(this, pages[0], new(pos.x, pos.y - (ButtonSize * 2)), MaxVisibleOnList, ButtonSpacingOffset, CurrentSlugcat, GetSlugcatSelectionButtons);
                 pages[0].subObjects.Add(slugcatSelector);
             }
 

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -260,7 +260,6 @@ namespace RainMeadow
             {
                 StoryMenuPlayerButton playerButton = new(this, playerScrollBox, player, OnlineManager.lobby.isOwner && player != OnlineManager.lobby.owner);
                 playerScrollBox.AddScrollObjects(playerButton);
-                playerButton.TryBind(playerScrollBox.scrollSlider, true);
             }
             playerScrollBox.ConstrainScroll();
 

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -25,11 +25,16 @@ namespace RainMeadow
         StoryGameMode storyGameMode;
         MenuLabel onlineDifficultyLabel;
         Vector2 restartCheckboxPos;
-        public SlugcatStats.Name CurrentSlugcat { get => selectableSlugcats[actualSelectedIndex]; }
+        public SlugcatStats.Name CurrentSlugcat { get => selectableSlugcats[SelectedIndex]; }
         public int actualSelectedIndex = -1;
-        public int SelectedIndex { get => (actualSelectedIndex < 0 || (OnlineManager.lobby?.isOwner ?? false))? slugcatPageIndex : actualSelectedIndex;   private set {
-            actualSelectedIndex = value;
-        } }
+        public int SelectedIndex
+        {
+            get => (actualSelectedIndex < 0 || (OnlineManager.lobby?.isOwner ?? false)) ? slugcatPageIndex : actualSelectedIndex;
+            private set
+            {
+                actualSelectedIndex = value;
+            }
+        }
         public static int MaxVisibleOnList => 8;
         public static float ButtonSpacingOffset => 8;
         public static float ButtonSizeWithSpacing => ButtonSize + ButtonSpacingOffset;
@@ -41,13 +46,10 @@ namespace RainMeadow
             ID = OnlineManager.lobby.gameMode.MenuProcessId();
             storyGameMode = (StoryGameMode)OnlineManager.lobby.gameMode;
 
-            SelectedIndex = slugcatPageIndex;
             storyGameMode.Sanitize();
             storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
-
-            restartCheckboxPos = restartCheckbox.pos;
-            
-
+            //removed setting SelectedIndex, it already gets current slugcat page without setting the num at the start
+            restartCheckboxPos = restartCheckbox.pos;       
             SetupSelectableSlugcats();
             RemoveExcessStoryObjects();
             ModifyExistingMenuItems();
@@ -81,7 +83,6 @@ namespace RainMeadow
                         SelectableSlugcatsEnumerable = SelectableSlugcatsEnumerable.Append(MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Slugpup);
                     }
                 }
-
                 selectableSlugcats = SelectableSlugcatsEnumerable.ToArray();
             }
         }   
@@ -204,21 +205,6 @@ namespace RainMeadow
                 {
                     SetupSlugcatList();
                 }
-
-            }
-
-
-            if (OnlineManager.lobby.isOwner)
-            {
-                storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
-                storyGameMode.region = CurrentRegion();
-                if (startButton != null)
-                {
-                    startButton.buttonBehav.greyedOut = OnlineManager.lobby.clientSettings.Values.Any(cs => cs.inGame);
-                }
-            }
-            else
-            {
                 if (startButton != null)
                 {
                     startButton.buttonBehav.greyedOut = !storyGameMode.canJoinGame;
@@ -227,6 +213,19 @@ namespace RainMeadow
                 {
                     onlineDifficultyLabel.text = GetCurrentCampaignName() + (string.IsNullOrEmpty(storyGameMode.region) ? Translate(" - New Game") : " - " + Translate(storyGameMode.region));
                 }
+
+            }
+            else
+            {
+                storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
+                storyGameMode.region = CurrentRegion();
+                if (startButton != null)
+                {
+                    startButton.buttonBehav.greyedOut = OnlineManager.lobby.clientSettings.Values.Any(cs => cs.inGame);
+                }
+                pages[0].ClearMenuObject(ref slugcatLabel); //added this just in case you suddenly become a host
+                pages[0].ClearMenuObject(ref slugcatSelector);
+
             }
             if (slugcatSelector != null)
             {
@@ -437,10 +436,10 @@ namespace RainMeadow
         }
         public void RecieveSlugcat(SlugcatStats.Name scug)
         {
-            TryChangeSlugcatIndex(scug); //fix slugcat not matching
+            RemoveColorButtons(); //remove out of range error from value of slider midway when slugcat changes but index acceeds new scug color bound
+            TryChangeSlugcatIndex(scug);
             if (colorChecked)
             {
-                RemoveColorButtons();
                 AddColorButtons();
             }
         }

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -39,10 +39,7 @@ namespace RainMeadow
                 {
                     RemoveColorButtons();
                     actualSelectedIndex = value;
-                    if (colorChecked)
-                    {
-                        AddColorButtons();
-                    }
+                    UpdateUponChangingSlugcat(CurrentSlugcat);
                 }
             }
         }
@@ -262,10 +259,7 @@ namespace RainMeadow
             playerScrollBox?.RemoveAllButtons();
             if (playerScrollBox == null)
             {
-                playerScrollBox = new(this, pages[0], new(194,  553 - 30 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, ButtonSize, ButtonSpacingOffset)
-                {
-                    buttonSpacing = ButtonSpacingOffset
-                };
+                playerScrollBox = new(this, pages[0], new(194, 553 - 30 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, ButtonSize, ButtonSpacingOffset);
                 pages[0].subObjects.Add(playerScrollBox);
             }
             foreach (OnlinePlayer player in OnlineManager.players)
@@ -448,6 +442,14 @@ namespace RainMeadow
         public void RecieveSlugcat(SlugcatStats.Name scug)
         {
             TryChangeSlugcatIndex(scug);
+        }
+        public void UpdateUponChangingSlugcat(SlugcatStats.Name scug)
+        {
+            if (colorsCheckbox != null)
+            {
+                colorsCheckbox.Checked = manager.rainWorld.progression.miscProgressionData.colorsEnabled.ContainsKey(scug.value) && 
+                    manager.rainWorld.progression.miscProgressionData.colorsEnabled[scug.value]; //automatically opens color interface if enabled
+            }
         }
     }
 }

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -259,7 +259,7 @@ namespace RainMeadow
 
         private void UpdatePlayerList()
         {
-            playerScrollBox?.RemoveAllButtons();
+            playerScrollBox?.RemoveAllButtons(false);
             if (playerScrollBox == null)
             {
                 playerScrollBox = new(this, pages[0], new(194, 553 - 30 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, ButtonSize, ButtonSpacingOffset);


### PR DESCRIPTION
**Button scroller, selector**
- Made button scroller mouse scroll speed faster
- Added another constructor in button scroller to get amt of buttons to view
- Made it easier to get the height of button scroller with using number of buttons to view for positioning purposes without making a instance first
- Added sound as well when scrolling
- Forced Selector ctor to use num of buttons to view cuz no one likes to make weird size
- Selector makes a sound indicator when closing list

 **Story Menu**
- Added so that it removes slugcat selector for if they suddenly become the owner midway for now
- Lowered the position offset of player list and slugcat selector from their respective titles from 38 to 30
- Removed some unnecessary stuff from story menu hooks