### PR TITLE
Add arena color config

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -277,7 +277,7 @@ namespace RainMeadow
                 menuObject.nextSelectable[3] = (bottom ? bindWith : menuObject.nextSelectable[3]);
             }
         }
-        public static void TryMutualBind(this Menu.Menu? menu, MenuObject? first, MenuObject? second, bool leftRight = false, bool topDown = false)
+        public static void TryMutualBind(this Menu.Menu? menu, MenuObject? first, MenuObject? second, bool leftRight = false, bool bottomTop = false)
         {
             if (menu != null && first != null && second != null)
             {
@@ -285,7 +285,7 @@ namespace RainMeadow
                 {
                     menu.MutualHorizontalButtonBind(first, second);
                 }
-                if (topDown)
+                if (bottomTop)
                 {
                     menu.MutualVerticalButtonBind(first, second);
                 }

--- a/Menu/ColorHelpers.cs
+++ b/Menu/ColorHelpers.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Menu;
+using RWCustom;
+using UnityEngine;
+
+namespace RainMeadow
+{
+    public static class ColorHelpers
+    {
+        public static string SetHSLString(Vector3 hsl)
+        {
+            return $"{hsl.x},{hsl.y},{hsl.z}";
+        }
+        public static Vector3 GetMenuHSL(this Menu.Menu menu, SlugcatStats.Name id, int bodyIndex)
+        {
+            Vector3 color = Vector3.one;
+            if (bodyIndex >= 0 && menu.manager.rainWorld.progression.miscProgressionData.colorChoices.ContainsKey(id.value) && menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value].Count > bodyIndex && menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value][bodyIndex].Contains(","))
+            {
+                string[] hslArray = menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value][bodyIndex].Split(',');
+                color = new Vector3(float.Parse(hslArray[0], NumberStyles.Any, CultureInfo.InvariantCulture), float.Parse(hslArray[1], NumberStyles.Any, CultureInfo.InvariantCulture), float.Parse(hslArray[2], NumberStyles.Any, CultureInfo.InvariantCulture));
+            }
+            return color;
+        }
+        public static List<Vector3> GetMenuHSLs(this Menu.Menu menu, SlugcatStats.Name id)
+        {
+            List<Vector3> list = [];
+            if (menu.manager.rainWorld.progression.miscProgressionData.colorChoices.ContainsKey(id.value) && menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value] != null)
+            {
+                for (int i = 0; i < menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value].Count; i++)
+                {
+                    Vector3 hsl = Vector3.one;
+                    string hslString = menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value][i];
+                    if (hslString.Contains(","))
+                    {
+                        string[] hslArray = hslString.Split(',');
+                        hsl = new(float.Parse(hslArray[0], NumberStyles.Any, CultureInfo.InvariantCulture), float.Parse(hslArray[1], NumberStyles.Any, CultureInfo.InvariantCulture), float.Parse(hslArray[2], NumberStyles.Any, CultureInfo.InvariantCulture));
+                    }
+                    list.Add(hsl);
+                }
+            }
+            return list;
+        }
+        public static void SaveMenuHSL(this Menu.Menu menu, SlugcatStats.Name id, int bodyIndex, Vector3 hsl)
+        {
+            menu.SaveMenuHSL(id, bodyIndex, SetHSLString(hsl));
+        }
+        public static void SaveMenuHSL(this Menu.Menu menu, SlugcatStats.Name id, int bodyIndex, string hslString)
+        {
+            if (!menu.manager.rainWorld.progression.miscProgressionData.colorChoices.ContainsKey(id.value))
+            {
+                RainMeadow.Debug("WARNING! Failed to save color choices due to slugcat not saved");
+                return;
+            }
+            if (menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value].Count <= bodyIndex)
+            {
+                RainMeadow.Debug("WARNING! Failed to save color choices due to index being more than body count!");
+                return;
+            }
+            menu.manager.rainWorld.progression.miscProgressionData.colorChoices[id.value][bodyIndex] = hslString;
+        }
+        public static bool IsCustomColorEnabled(this Menu.Menu menu, SlugcatStats.Name id)
+        {
+            return menu.manager.rainWorld.progression.miscProgressionData.colorsEnabled != null && 
+                menu.manager.rainWorld.progression.miscProgressionData.colorsEnabled.ContainsKey(id.value) && 
+                menu.manager.rainWorld.progression.miscProgressionData.colorsEnabled[id.value];
+        }
+        public static Vector3 RWHSLRange(Vector3 hsl)
+        {
+            return new(Mathf.Clamp(hsl.x, 0, 0.99f), hsl.y, Mathf.Clamp(hsl.z, 0.01f, 1));
+        }
+        public static Color HSL2RGB(Vector3 hsl)
+        {
+            return Custom.HSL2RGB(hsl.x % 1, hsl.y, hsl.z);
+        }
+    }
+}

--- a/Menu/Dialogs/ColorSlugcatDialog.cs
+++ b/Menu/Dialogs/ColorSlugcatDialog.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using Menu;
+using RWCustom;
+using UnityEngine;
+using MoreSlugcats;
+using System.Linq;
+using System.Globalization;
+
+namespace RainMeadow
+{
+    public class ColorSlugcatDialog : DialogNotify, CheckBox.IOwnCheckBox //recommend remix on as it has translation and slider enums
+    {
+       
+        public static Slider.SliderID[] MMFHSLSLiderIDs => [MMFEnums.SliderID.Hue, MMFEnums.SliderID.Saturation, MMFEnums.SliderID.Lightness];
+        public float SizeXOfDefaultCol => CurrLang == InGameTranslator.LanguageID.Japanese || CurrLang == InGameTranslator.LanguageID.French ? 110 : 
+            CurrLang == InGameTranslator.LanguageID.Italian || CurrLang == InGameTranslator.LanguageID.Spanish ? 180 : 110;
+        public ColorSlugcatDialog(ProcessManager manager, SlugcatStats.Name name, Action onOK) : base("", Utils.Translate("Custom colors"), new(500f, 400f), manager, onOK)
+        {
+            SetUpSafeColorChoices();
+            id = name;
+            colorChooser = -1;
+            colorCheckbox = new(this, pages[0], this, new(size.x + 40, size.y + -40 * 5), 0, "", COLORCHECKBOXID);
+            pages[0].subObjects.Add(colorCheckbox);
+            this.TryMutualBind(colorCheckbox, okButton, true);
+            GetSaveColorEnabled();
+        }
+        public override void ShutDownProcess()
+        {
+            base.ShutDownProcess();
+            RemoveColorButtons();
+        }
+        public override void Update()
+        {
+            base.Update();
+
+        }
+        public override void Singal(MenuObject sender, string message)
+        {
+            base.Singal(sender, message);
+            if (message == "DEFAULTCOL")
+            {
+                PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
+                manager.rainWorld.progression.miscProgressionData.colorChoices[bodyInterface.slugcatID.value][colorChooser] = bodyInterface.defaultColors[colorChooser];
+            }
+            string openInterface = ColorSlugcatBodyButtons.OPENINTERFACESINGAL;
+            if (message.StartsWith(openInterface) && int.TryParse(message.Substring(openInterface.Length), NumberStyles.Any, CultureInfo.InvariantCulture, out int result))
+            {
+                AddOrRemoveColorInterface(result);
+            }
+        }
+        public override void SliderSetValue(Slider slider, float f)
+        {
+            if (slider?.ID != null && MMFHSLSLiderIDs.Contains(slider.ID))
+            {
+                Vector3 hsl = GetHSL();
+                hsl[MMFHSLSLiderIDs.IndexOf(slider.ID)] = f;
+                ApplyHSL(ColorHelpers.RWHSLRange(hsl));
+            }
+        }
+        public override float ValueOfSlider(Slider slider)
+        {
+            if (slider?.ID != null && MMFHSLSLiderIDs.Contains(slider.ID))
+            {
+                return GetHSL()[MMFHSLSLiderIDs.IndexOf(slider.ID)];
+
+            }
+            return 0;
+        }
+        public bool GetChecked(CheckBox box)
+        {
+            return box?.IDString == COLORCHECKBOXID && colorChecked;
+        }
+        public void SetChecked(CheckBox box, bool c)
+        {
+            if (box?.IDString == COLORCHECKBOXID)
+            {
+                SaveColorChoicesEnabled(c);
+            }
+        }
+        public void GetSaveColorEnabled()
+        {
+            SetUpSafeColorChoices();
+            if (!manager.rainWorld.progression.miscProgressionData.colorsEnabled.ContainsKey(id.value))
+            {
+                manager.rainWorld.progression.miscProgressionData.colorsEnabled.Add(id.value, colorChecked);
+                return;
+            }
+            colorCheckbox.Checked = manager.rainWorld.progression.miscProgressionData.colorsEnabled[id.value];
+
+        }
+        public void SaveColorChoicesEnabled(bool colorChecked)
+        {
+            if (!manager.rainWorld.progression.miscProgressionData.colorsEnabled.ContainsKey(id.value))
+            {
+                manager.rainWorld.progression.miscProgressionData.colorsEnabled.Add(id.value, colorChecked);
+            }
+            else
+            {
+                manager.rainWorld.progression.miscProgressionData.colorsEnabled[id.value] = colorChecked;
+            }
+            this.colorChecked = colorChecked;
+            ((Action)(colorChecked ? AddColorButtons : RemoveColorButtons)).Invoke();
+        }
+        public void SetUpSafeColorChoices()
+        {
+            manager.rainWorld.progression.miscProgressionData.colorChoices ??= [];
+            manager.rainWorld.progression.miscProgressionData.colorsEnabled ??= [];
+        }
+        public Vector3 GetHSL()
+        {
+            return this.GetMenuHSL(id, colorChooser);
+        }
+        public void ApplyHSL(Vector3 hsl)
+        {
+            this.SaveMenuHSL(id, colorChooser, hsl);
+        }
+        public void AddOrRemoveColorInterface(int num)
+        {
+            if (num == colorChooser)
+            {
+                RemoveColorInterface();
+                PlaySound(SoundID.MENU_Remove_Level);
+                return;
+            }
+            colorChooser = num;
+            AddColorInterface();
+            PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
+        }
+        public void AddColorButtons()
+        {
+            if (bodyInterface == null)
+            {
+                bodyInterface = GetColorInterface(id, new Vector2(size.x, size.y + 90f));
+                pages[0].subObjects.Add(bodyInterface);
+            }
+        }
+        public void AddColorInterface()
+        {
+            if (hueSlider == null)
+            {
+                hueSlider = new(this, pages[0], Translate("HUE"), new(size.x, size.y - 10), new(200, 30), MMFEnums.SliderID.Hue, false);
+                pages[0].subObjects.Add(hueSlider);
+            }
+            if (satSlider == null)
+            {
+                satSlider = new(this, pages[0], Translate("SAT"), hueSlider.pos + new Vector2(0, -40), hueSlider.size, MMFEnums.SliderID.Saturation, false);
+                pages[0].subObjects.Add(satSlider);
+            }
+            if (litSlider == null)
+            {
+                litSlider = new(this, pages[0], Translate("LIT"), satSlider.pos + new Vector2(0, -40), satSlider.size, MMFEnums.SliderID.Lightness, false);
+                pages[0].subObjects.Add(litSlider);
+            }
+            if (defaultColor == null)
+            {
+                defaultColor = new(this, pages[0], Translate("Restore Default"), "DEFAULTCOL", litSlider.pos + new Vector2(0, -40), new(SizeXOfDefaultCol, 30));
+                pages[0].subObjects.Add(defaultColor);
+            }
+            this.TryMutualBind(hueSlider, bodyInterface?.bodyButtons?.FirstOrDefault(), bottomTop: true);
+            MutualVerticalButtonBind(colorCheckbox, defaultColor);
+            this.TryMutualBind(okButton, defaultColor);
+        }
+        public void RemoveColorButtons()
+        {
+            RemoveColorInterface();
+            pages[0].ClearMenuObject(ref bodyInterface);
+        }
+        public void RemoveColorInterface()
+        {
+            for (int i = 0; i < bodyInterface?.bodyButtons?.Length; i++)
+            {
+                if (i == 0)
+                {
+                    MutualVerticalButtonBind(colorCheckbox, bodyInterface.bodyButtons[i]);
+                    continue;
+                }
+                bodyInterface.bodyButtons[i].TryBind(colorCheckbox, bottom: true);
+            }
+            pages[0].ClearMenuObject(ref hueSlider);
+            pages[0].ClearMenuObject(ref satSlider);
+            pages[0].ClearMenuObject(ref litSlider);
+            pages[0].ClearMenuObject(ref defaultColor);
+            colorChooser = -1;
+        }
+        public ColorSlugcatBodyButtons GetColorInterface(SlugcatStats.Name slugcatID, Vector2 pos)
+        {
+            List<string> list = PlayerGraphics.DefaultBodyPartColorHex(slugcatID);
+            for (int i = 0; i < list.Count; i++)
+            {
+                list[i] = ColorHelpers.SetHSLString(Custom.RGB2HSL(Custom.hexToColor(list[i])));
+            }
+            return new ColorSlugcatBodyButtons(this, pages[0], pos, slugcatID, PlayerGraphics.ColoredBodyPartList(slugcatID), list);
+        }
+
+        public const string COLORCHECKBOXID = "COLORCHECKED";
+        public int colorChooser;
+        public bool colorChecked;
+        public CheckBox colorCheckbox;
+        public SlugcatStats.Name id;
+        public SimpleButton? defaultColor;
+        public ColorSlugcatBodyButtons? bodyInterface;
+        public HorizontalSlider? hueSlider, satSlider, litSlider;
+    }
+}

--- a/Menu/Dialogs/ColorSlugcatDialog.cs
+++ b/Menu/Dialogs/ColorSlugcatDialog.cs
@@ -185,12 +185,7 @@ namespace RainMeadow
         }
         public ColorSlugcatBodyButtons GetColorInterface(SlugcatStats.Name slugcatID, Vector2 pos)
         {
-            List<string> list = PlayerGraphics.DefaultBodyPartColorHex(slugcatID);
-            for (int i = 0; i < list.Count; i++)
-            {
-                list[i] = ColorHelpers.SetHSLString(Custom.RGB2HSL(Custom.hexToColor(list[i])));
-            }
-            return new ColorSlugcatBodyButtons(this, pages[0], pos, slugcatID, PlayerGraphics.ColoredBodyPartList(slugcatID), list);
+             return new ColorSlugcatBodyButtons(this, pages[0], pos, slugcatID, PlayerGraphics.ColoredBodyPartList(slugcatID), [.. PlayerGraphics.DefaultBodyPartColorHex(slugcatID).Select(Custom.hexToColor).Select(Custom.RGB2HSL).Select(ColorHelpers.SetHSLString)]);
         }
 
         public const string COLORCHECKBOXID = "COLORCHECKED";

--- a/Menu/Objects/ColorSlugcatBodyButtons.cs
+++ b/Menu/Objects/ColorSlugcatBodyButtons.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using Menu;
+using RWCustom;
+using UnityEngine;
+
+namespace RainMeadow
+{
+    //supposed to follow saves
+    public class ColorSlugcatBodyButtons : PositionedMenuObject
+    {
+        public int PerPage { get => perPage; set => perPage = Mathf.Max(1, value); }
+        public int CurrentOffset { get => currentOffset; set => currentOffset = Mathf.Clamp(value, 0, (bodyNames?.Count > 0) ? (bodyNames.Count - 1 / PerPage) : 0); }
+        public bool PagesOn => bodyNames?.Count > PerPage;
+        public ColorSlugcatBodyButtons(Menu.Menu menu, MenuObject owner, Vector2 pos, SlugcatStats.Name slugcatID, List<string> names, List<string> defaultColors) : base(menu, owner, pos)
+        {
+            PerPage = 2;
+            CurrentOffset = 0;
+            bodyNames = names;
+            this.slugcatID = slugcatID;
+            this.defaultColors = defaultColors;
+            SafeSaveColor();
+            PopulatePage(CurrentOffset);
+            if (PagesOn)
+            {
+                ActivateButtons();
+            }
+        }
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+            bodyColors?.Do((illuIndex) =>
+            {
+                illuIndex.Key.color = ColorHelpers.HSL2RGB(menu.GetMenuHSL(slugcatID, illuIndex.Value));
+            });
+        }
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+            DeactivateButtons();
+            ClearInterface();
+        }
+        public override void Singal(MenuObject sender, string message)
+        {
+            base.Singal(sender, message);
+            if (message == PREVSINGAL)
+            {
+                PrevPage();
+            }
+            if (message == NEXTSINGAL)
+            {
+                NextPage();
+            }
+        }
+        public void PrevPage()
+        {
+            menu.PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
+            PopulatePage((CurrentOffset - 1 < 0) ? ((bodyNames != null && bodyNames.Count > 0) ? ((bodyNames.Count - 1) / PerPage) : 0) : (CurrentOffset - 1));
+        }
+        public void NextPage()
+        {
+            menu.PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
+            PopulatePage(bodyNames == null || bodyNames.Count == 0 || CurrentOffset + 1 > (bodyNames.Count - 1) / PerPage ? 0 : (CurrentOffset + 1));
+        }
+        public void PopulatePage(int offset)
+        {
+            ClearInterface(true);
+            List<SimpleButton> buttons = [];
+            List<RoundedRect> borders = [];
+            CurrentOffset = offset;
+            int num = CurrentOffset * PerPage;
+            while (num < bodyNames?.Count && num < (CurrentOffset + 1) * PerPage)
+            {
+                SimpleButton bodyButton = new(menu, this, menu.Translate(bodyNames[num]), OPENINTERFACESINGAL + num.ToString(CultureInfo.InvariantCulture), new Vector2(num % PerPage * 90, -50), new(80, 30));
+                RoundedRect bodyColorBorder = new(menu, this, new(bodyButton.pos.x + (bodyButton.size.x / 4), bodyButton.pos.y + 50), new(40, 40), false);
+                MenuIllustration bodyColor = new(menu, this, "", "square", bodyColorBorder.pos + new Vector2(2, 2), false, false);
+                subObjects.AddRange([bodyButton, bodyColorBorder, bodyColor]);
+                menu.TryMutualBind(buttons.GetValueOrDefault((num - 1) % PerPage), bodyButton, true);
+                buttons.Add(bodyButton);
+                borders.Add(bodyColorBorder);
+                bodyColors.Add(bodyColor, num);
+                num++;
+            }
+            menu.TryMutualBind(prevButton, bodyButtons.FirstOrDefault(), true);
+            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton);
+            bodyButtons = [.. buttons];
+            bodyColorBorders = [.. borders];
+            (menu as ColorSlugcatDialog)?.RemoveColorInterface();
+        }
+        public void SafeSaveColor()
+        {
+            if (!menu.manager.rainWorld.progression.miscProgressionData.colorChoices.ContainsKey(slugcatID.value))
+            {
+                menu.manager.rainWorld.progression.miscProgressionData.colorChoices.Add(slugcatID.value, []);
+            }
+            menu.manager.rainWorld.progression.miscProgressionData.colorChoices[slugcatID.value] ??= [];
+            while (menu.manager.rainWorld.progression.miscProgressionData.colorChoices[slugcatID.value].Count < bodyNames?.Count)
+            {
+                menu.manager.rainWorld.progression.miscProgressionData.colorChoices[slugcatID.value].Add(defaultColors[menu.manager.rainWorld.progression.miscProgressionData.colorChoices[slugcatID.value].Count]);
+            }
+        }
+        public void ActivateButtons()
+        {
+            if (prevButton == null)
+            {
+                prevButton = new(menu, this, "Menu_Symbol_Arrow", PREVSINGAL, new Vector2(-34f, -50f));
+                subObjects.Add(prevButton);
+                prevButton.symbolSprite.rotation = 270;
+            }
+            if (nextButton == null)
+            {
+                nextButton = new(menu, this, "Menu_Symbol_Arrow", NEXTSINGAL, new Vector2(prevButton.pos.x + 54 + (perPage * 80), prevButton.pos.y));
+                subObjects.Add(nextButton);
+                nextButton.symbolSprite.rotation = 90;
+            }
+            menu.MutualHorizontalButtonBind(prevButton, nextButton);
+            menu.TryMutualBind(prevButton, bodyButtons.FirstOrDefault(), true);
+            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton);
+        }
+        public void DeactivateButtons()
+        {
+            this.ClearMenuObject(ref prevButton);
+            this.ClearMenuObject(ref nextButton);
+        }
+        public void ClearInterface(bool refresh = false)
+        {
+            this.ClearMenuObjectIList(bodyButtons);
+            this.ClearMenuObjectIList(bodyColorBorders);
+            this.ClearMenuObjectIList(bodyColors?.Keys);
+            bodyButtons = refresh ? [] : default;
+            bodyColorBorders = refresh ? [] : default;
+            bodyColors = refresh ? [] : default;
+        }
+
+        protected int currentOffset, perPage;
+        public const string OPENINTERFACESINGAL = "COLORBODYBUTTONS_CUSTOMCOLOR", PREVSINGAL = "PrevPageColors_COLORBODYBUTTONS", NEXTSINGAL = "NextPageColors_COLORBODYBUTTONS";
+        public List<string> bodyNames;
+        public List<string> defaultColors;
+        public SlugcatStats.Name slugcatID;
+        public SimpleButton[]? bodyButtons;
+        public RoundedRect[]? bodyColorBorders;
+        public Dictionary<MenuIllustration, int>? bodyColors;
+        public SymbolButton? prevButton, nextButton;
+    }
+}

--- a/Menu/Objects/ColorSlugcatBodyButtons.cs
+++ b/Menu/Objects/ColorSlugcatBodyButtons.cs
@@ -87,7 +87,7 @@ namespace RainMeadow
                 num++;
             }
             menu.TryMutualBind(prevButton, bodyButtons.FirstOrDefault(), true);
-            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton);
+            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton, true);
             bodyButtons = [.. buttons];
             bodyColorBorders = [.. borders];
             (menu as ColorSlugcatDialog)?.RemoveColorInterface();
@@ -120,7 +120,7 @@ namespace RainMeadow
             }
             menu.MutualHorizontalButtonBind(prevButton, nextButton);
             menu.TryMutualBind(prevButton, bodyButtons.FirstOrDefault(), true);
-            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton);
+            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton, true);
         }
         public void DeactivateButtons()
         {


### PR DESCRIPTION
Added a color config which also replace getting colors from rain meadow options to getting colors from rw saves
this is how the color config looks now, uses remix sliders so the button to open it only appears when remix is on
![Screenshot (96)](https://github.com/user-attachments/assets/776eb19c-1c2d-449b-8d77-46c6b5874cd7)
colors in action
![Screenshot (97)](https://github.com/user-attachments/assets/0dd3128f-4c32-4f7b-9868-3595652faf22)
