### PR TITLE
Slugcat Selection for owner in Story

### DIFF
--- a/Menu/ColorHelpers.cs
+++ b/Menu/ColorHelpers.cs
@@ -75,5 +75,9 @@ namespace RainMeadow
         {
             return Custom.HSL2RGB(hsl.x % 1, hsl.y, hsl.z);
         }
+        public static List<Color> GetCustomColors(this Menu.Menu menu, SlugcatStats.Name id)
+        {
+            return menu.IsCustomColorEnabled(id)? [..menu.GetMenuHSLs(id).Select(HSL2RGB)] : [..PlayerGraphics.DefaultBodyPartColorHex(id).Select(Custom.hexToColor)];
+        }
     }
 }

--- a/Menu/Objects/ButtonScroller.cs
+++ b/Menu/Objects/ButtonScroller.cs
@@ -27,8 +27,9 @@ namespace RainMeadow
             set
             {
                 scrollOffset = value;
-                ConstrainScroll();
+                DirectConstrainScroll();
                 scrollSliderValue = MaxDownScroll > 0 ? Mathf.InverseLerp(MaxDownScroll, 0, scrollOffset) : 1; //lower slider value means down, higher means up
+
             }
         }
         public float LowerBound => 0;
@@ -103,9 +104,13 @@ namespace RainMeadow
         {
             DownScrollOffset += addDir;
         }
-        public void ConstrainScroll()
+        public void ConstrainScroll() //for clamping scroll, also updating slider
         {
-            scrollOffset = Mathf.Clamp(scrollOffset, 0, MaxDownScroll);
+            DownScrollOffset = Mathf.Clamp(DownScrollOffset, 0, MaxDownScroll);
+        }
+        protected void DirectConstrainScroll() //for direct scroll clamp, like for DownScrollOffset set method, this doesnt not update slider value
+        {
+            scrollOffset =  Mathf.Clamp(scrollOffset, 0, MaxDownScroll);
         }
         public List<T> GetSpecificButtons<T>()
         {

--- a/Menu/Objects/ButtonSelector.cs
+++ b/Menu/Objects/ButtonSelector.cs
@@ -36,6 +36,14 @@ namespace RainMeadow
                 scroller.buttonSpacing = buttonSpacing;
             }
         }
+        public virtual void RefreshScrollerList()
+        {
+            if (scroller != null)
+            {
+                CloseList(false, false);
+                OpenList(false);
+            }
+        }
         public void OpenCloseList()
         {
             OpenCloseList(scroller == null, true, true);

--- a/Menu/Objects/ButtonSelector.cs
+++ b/Menu/Objects/ButtonSelector.cs
@@ -13,14 +13,13 @@ namespace RainMeadow
         public float ListPosOffset => downwardsList ? -(buttonSpacing + listDownUpYOffset) : OrigDistanceBetweenButtonYPos + listDownUpYOffset; //readds the additional button spacing lost
         public float OrigStart => downwardsList ? -ButtonScroller.CalculateHeightBasedOnAmtOfButtons(NumberOfButtonsToShow - 1, size.y, buttonSpacing) : size.y;
         public float StartingYPoint => OrigStart + ListPosOffset;
-
         public ButtonSelector(Menu.Menu menu, MenuObject owner, string displayText, Vector2 pos, Vector2 size, int amtOfButtonsView, float spacingOfButton, string description = "") : base(menu, owner, displayText, pos, size, description)
         {
             NumberOfButtonsToShow = amtOfButtonsView;
             buttonSpacing = spacingOfButton;
             OnClick += (_) =>
             {
-                OpenCloseList();
+                OpenCloseList(scroller == null, true, false);
             };
         }
         public override void RemoveSprites()
@@ -37,23 +36,50 @@ namespace RainMeadow
                 scroller.buttonSpacing = buttonSpacing;
             }
         }
-        public virtual void UpdateUponClosingList()
+        public void OpenCloseList()
         {
-            menu.PlaySound(SoundID.MENU_MultipleChoice_Clicked);
+            OpenCloseList(scroller == null, true, true);
         }
-        public virtual void OpenCloseList()
+        public virtual void OpenCloseList(bool open, bool playSound, bool playSelectedIfClose)
+        {
+            if (open)
+            {
+                OpenList(playSound);
+            }
+            else
+            {
+                CloseList(playSound, playSelectedIfClose);
+            }
+        }
+        public virtual void OpenList(bool playSound)
         {
             if (scroller == null)
             {
                 scroller = new(menu, this, new(0, StartingYPoint), NumberOfButtonsToShow - 1, size.x, size.y, buttonSpacing);
                 scroller.AddScrollObjects(populateList?.Invoke(this, scroller));
                 subObjects.Add(scroller);
-                return;
+                if (playSound)
+                {
+                    menu.PlaySound(SoundID.MENU_Checkbox_Check);
+                }
             }
-            this.ClearMenuObject(ref scroller);
-            UpdateUponClosingList();
         }
-
+        public virtual void CloseList(bool playSound, bool playSelected)
+        {
+            if (scroller != null)
+            {
+                if (playSound)
+                {
+                    menu.PlaySound(playSelected? SoundID.MENU_MultipleChoice_Clicked : SoundID.MENU_Checkbox_Uncheck);
+                }
+                this.ClearMenuObject(ref scroller);
+                UpdateUponClosingList();
+            }
+        }
+        public virtual void UpdateUponClosingList()
+        {
+           
+        }
         public bool downwardsList = true;
         public float listDownUpYOffset, buttonSpacing;
         private int amtOfButtonsToShow;

--- a/Menu/Objects/ButtonSelector.cs
+++ b/Menu/Objects/ButtonSelector.cs
@@ -40,8 +40,9 @@ namespace RainMeadow
         {
             if (scroller != null)
             {
-                CloseList(false, false);
-                OpenList(false);
+                scroller.RemoveAllButtons(false);
+                scroller.AddScrollObjects(populateList?.Invoke(this, scroller));
+                scroller.ConstrainScroll();
             }
         }
         public void OpenCloseList()

--- a/Menu/Objects/ColorSlugcatBodyButtons.cs
+++ b/Menu/Objects/ColorSlugcatBodyButtons.cs
@@ -86,10 +86,10 @@ namespace RainMeadow
                 bodyColors.Add(bodyColor, num);
                 num++;
             }
-            menu.TryMutualBind(prevButton, bodyButtons.FirstOrDefault(), true);
-            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton, true);
             bodyButtons = [.. buttons];
             bodyColorBorders = [.. borders];
+            menu.TryMutualBind(prevButton, bodyButtons.FirstOrDefault(), true);
+            menu.TryMutualBind(bodyButtons.LastOrDefault(), nextButton, true);
             (menu as ColorSlugcatDialog)?.RemoveColorInterface();
         }
         public void SafeSaveColor()

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -107,13 +107,13 @@ namespace RainMeadow
             On.HUD.TextPrompt.Update += TextPrompt_Update;
             On.HUD.TextPrompt.UpdateGameOverString += TextPrompt_UpdateGameOverString;
 
-            IL.Menu.SlugcatSelectMenu.ctor += SlugcatSelectMenu_ctor;
             IL.Menu.SlugcatSelectMenu.UpdateSelectedSlugcatInMiscProg += SlugcatSelectMenu_UpdateSelectedSlugcatInMiscProg;
 
             IL.Menu.SlugcatSelectMenu.SliderSetValue += SlugcatSelectMenu_SliderFix;
             IL.Menu.SlugcatSelectMenu.ValueOfSlider += SlugcatSelectMenu_SliderFix;
             IL.Menu.SlugcatSelectMenu.Singal +=  IL_SlugcatSelectMenu_SingalFix;
-
+            IL.Menu.SlugcatSelectMenu.SetChecked += IL_SlugcatSelectMenu_SetChecked;
+            On.Menu.SlugcatSelectMenu.UpdateSelectedSlugcatInMiscProg += On_SlugcatSelectMenu_UpdateSelectedSlugcatInMiscProg;
             On.Menu.SlugcatSelectMenu.SetChecked += SlugcatSelectMenu_SetChecked;
             On.Menu.SlugcatSelectMenu.GetChecked += SlugcatSelectMenu_GetChecked;
             On.Menu.SlugcatSelectMenu.SliderSetValue += SlugcatSelectMenu_SliderSetValue;
@@ -153,41 +153,18 @@ namespace RainMeadow
             }
         }
 
-        private void SlugcatSelectMenu_ctor(ILContext il)
-        {
-            try
-            {
-                // add colors checkbox regardless if remix disabled
-                var c = new ILCursor(il);
-                c.GotoNext(
-                    i => i.MatchStfld<Menu.SlugcatSelectMenu>("colorsCheckbox")
-                );
-                c.GotoPrev(MoveType.AfterLabel,
-                    i => i.MatchLdsfld<ModManager>("MMF"),
-                    i => i.MatchBrfalse(out _)
-                );
-                c.Index++;
-                c.Emit(OpCodes.Ldarg_0);
-                c.EmitDelegate((bool showColorsCheckbox, Menu.SlugcatSelectMenu self) => showColorsCheckbox || (isStoryMode(out _) && self is StoryOnlineMenu));
-            }
-            catch (Exception e)
-            {
-                Logger.LogError(e);
-            }
-        }
-
         private void SlugcatSelectMenu_UpdateSelectedSlugcatInMiscProg(ILContext il)
         {
             try
             {
                 var c = new ILCursor(il);
-                c.GotoNext(MoveType.AfterLabel,
+                /*c.GotoNext(MoveType.AfterLabel,
                     i => i.MatchLdsfld<ModManager>("MMF"),
                     i => i.MatchBrfalse(out _)
                 );
                 c.Index++;
                 c.Emit(OpCodes.Ldarg_0);
-                c.EmitDelegate((bool flag, Menu.SlugcatSelectMenu self) => flag || (isStoryMode(out _) && self is StoryOnlineMenu));
+                c.EmitDelegate((bool flag, Menu.SlugcatSelectMenu self) => flag || (isStoryMode(out _) && self is StoryOnlineMenu)); dont overload remix flag as makes slider ids null*/
 
             }
             catch (Exception e)
@@ -195,57 +172,59 @@ namespace RainMeadow
                 Logger.LogError(e);
             }
         }
-
+        private void On_SlugcatSelectMenu_UpdateSelectedSlugcatInMiscProg(On.Menu.SlugcatSelectMenu.orig_UpdateSelectedSlugcatInMiscProg orig, Menu.SlugcatSelectMenu self)
+        {
+            orig(self);
+            if (self is StoryOnlineMenu sOM)
+            {
+                if (self.colorsCheckbox != null)
+                {
+                    self.colorsCheckbox.Checked = self.IsCustomColorEnabled(sOM.CurrentSlugcat); //orig method doesnt change ifcolorson save, just adjust checkbox so this is fine
+                }
+            }
+        }
         private bool SlugcatSelectMenu_GetChecked(On.Menu.SlugcatSelectMenu.orig_GetChecked orig, Menu.SlugcatSelectMenu self, Menu.CheckBox box)
         {
-            if (isStoryMode(out var storyGameMode) && self is StoryOnlineMenu)
-            {
-                if (box.IDString == "CLIENTSAVERESET")
-                {
-                    return storyGameMode.saveToDisk;
-                }
-
-                if (box.IDString == "ONLINEFRIENDLYFIRE")
-                {
-                    return storyGameMode.friendlyFire;
-                }
-
-                if (box.IDString == "CAMPAIGNSLUGONLY")
-                {
-                    return storyGameMode.requireCampaignSlugcat;
-                }
-            }
-
-            return orig(self, box);
+            return (self as StoryOnlineMenu)?.GetOnlineChecked(box) ?? orig(self, box);
         }
-
         private void SlugcatSelectMenu_SetChecked(On.Menu.SlugcatSelectMenu.orig_SetChecked orig, Menu.SlugcatSelectMenu self, Menu.CheckBox box, bool c)
         {
-            if (isStoryMode(out var storyGameMode) && self is StoryOnlineMenu)
+            if (self is StoryOnlineMenu sOM && sOM.SetOnlineChecked(box, c))
             {
-                if (box.IDString == "CLIENTSAVERESET")
-                {
-                    storyGameMode.saveToDisk = c;
-                    return;
-                }
-
-                if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
-                {
-                    storyGameMode.friendlyFire = c;
-                    return;
-                }
-
-                if (box.IDString == "CAMPAIGNSLUGONLY")
-                {
-                    storyGameMode.requireCampaignSlugcat = c;
-                    return;
-                }
+                return;
             }
-
             orig(self, box, c);
         }
+        private void IL_SlugcatSelectMenu_SetChecked(ILContext il)
+        {
+            try
+            {
+                ILCursor cursor = new(il);
+                /*cursor.GotoNext(MoveType.After, x => x.MatchCall<Menu.SlugcatSelectMenu>("colorFromIndex"));
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate((SlugcatStats.Name slugcat, Menu.SlugcatSelectMenu self) =>
+                {
+                    return self is StoryOnlineMenu sOM ? sOM.CurrentSlugcat : slugcat;
+                }); not required now i suppose*/
+                cursor.GotoNext(MoveType.After, x => x.MatchLdfld<ExtEnumBase>(nameof(ExtEnumBase.value)));
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate((string value, Menu.SlugcatSelectMenu self) =>
+                {
+                    return self is StoryOnlineMenu sOM ? sOM.CurrentSlugcat.value : value;
+                });
+                cursor.GotoNext(MoveType.After, x => x.MatchLdfld<ExtEnumBase>(nameof(ExtEnumBase.value)));
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate((string value, Menu.SlugcatSelectMenu self) =>
+                {
+                    return self is StoryOnlineMenu sOM ? sOM.CurrentSlugcat.value : value;
+                });
 
-
+            }
+            catch (Exception ex)
+            {
+                RainMeadow.Error(ex);
+            }
+        }
         private void IL_SlugcatSelectMenu_SingalFix(ILContext il)
         {
             try

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -186,13 +186,42 @@ namespace RainMeadow
         }
         private bool SlugcatSelectMenu_GetChecked(On.Menu.SlugcatSelectMenu.orig_GetChecked orig, Menu.SlugcatSelectMenu self, Menu.CheckBox box)
         {
-            return (self as StoryOnlineMenu)?.GetOnlineChecked(box) ?? orig(self, box);
+            if (isStoryMode(out StoryGameMode storyGameMode) && self is StoryOnlineMenu)
+            {
+                if (box.IDString == "CLIENTSAVERESET")
+                {
+                    return storyGameMode.saveToDisk;
+                }
+                if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
+                {
+                    return storyGameMode.friendlyFire;
+                }
+                if (box.IDString == "CAMPAIGNSLUGONLY")
+                {
+                    return storyGameMode.requireCampaignSlugcat;
+                }
+            }
+            return orig(self, box);
         }
         private void SlugcatSelectMenu_SetChecked(On.Menu.SlugcatSelectMenu.orig_SetChecked orig, Menu.SlugcatSelectMenu self, Menu.CheckBox box, bool c)
         {
-            if (self is StoryOnlineMenu sOM && sOM.SetOnlineChecked(box, c))
+            if (isStoryMode(out StoryGameMode storyGameMode) && self is StoryOnlineMenu)
             {
-                return;
+                if (box.IDString == "CLIENTSAVERESET")
+                {
+                    storyGameMode.saveToDisk = c;
+                    return;
+                }
+                if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
+                {
+                    storyGameMode.friendlyFire = c;
+                    return;
+                }
+                if (box.IDString == "CAMPAIGNSLUGONLY")
+                {
+                    storyGameMode.requireCampaignSlugcat = c;
+                    return;
+                }
             }
             orig(self, box, c);
         }

--- a/Story/StoryMenuButtons.cs
+++ b/Story/StoryMenuButtons.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using HarmonyLib;
 using Menu;
 using UnityEngine;
 
@@ -49,13 +50,23 @@ namespace RainMeadow
     }
     public class StoryMenuSlugcatButton : ButtonScroller.ScrollerButton
     {
-        public StoryMenuSlugcatButton(Menu.Menu menu, MenuObject owner, SlugcatStats.Name slugcat, Action<SlugcatStats.Name> onReceieveSlugcat, Vector2 size = default) : base(menu, owner, menu.Translate(SlugcatStats.getSlugcatName(slugcat)), Vector2.zero, size == default? new(110, 30) : size)
+        public StoryMenuSlugcatButton(Menu.Menu menu, MenuObject owner, SlugcatStats.Name slugcat, Action<SlugcatStats.Name> onReceieveSlugcat, Vector2 size = default) : base(menu, owner, "", Vector2.zero, size == default? new(110, 30) : size)
         {
+            slug = slugcat;
             OnClick += (_) =>
             {
-                onReceieveSlugcat?.Invoke(slugcat);
+                onReceieveSlugcat?.Invoke(slug);
             };
         }
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+            if (menuLabel != null)
+            {
+                menuLabel.text = menu.Translate(SlugcatStats.getSlugcatName(slug));
+            }
+        }
+        public SlugcatStats.Name slug;
     }
     public class StoryMenuSlugcatSelector : ButtonSelector
     {
@@ -73,6 +84,21 @@ namespace RainMeadow
             if (menuLabel != null)
             {
                 menuLabel.text = menu.Translate(SlugcatStats.getSlugcatName(slug));
+            }
+        }
+        public SlugcatStats.Name Slug
+        {
+            get
+            {
+                return slug;
+            }
+            set
+            {
+                if (value != slug)
+                {
+                    slug = value;
+                    RefreshScrollerList();
+                }
             }
         }
         public SlugcatStats.Name slug;

--- a/Story/StoryMenuButtons.cs
+++ b/Story/StoryMenuButtons.cs
@@ -59,7 +59,7 @@ namespace RainMeadow
     }
     public class StoryMenuSlugcatSelector : ButtonSelector
     {
-        public StoryMenuSlugcatSelector(Menu.Menu menu, MenuObject owner, Vector2 pos, int amtOfScugsToShow, float spacing, SlugcatStats.Name currentSlugcat, Func<StoryMenuSlugcatSelector, ButtonScroller, StoryMenuSlugcatButton[]> populateSlugButtons) : base(menu, owner, "", pos, new(110, 30), amtOfScugsToShow, spacing)
+        public StoryMenuSlugcatSelector(Menu.Menu menu, MenuObject owner, Vector2 pos, int amtOfScugsToShow, float spacing, SlugcatStats.Name currentSlugcat, Func<StoryMenuSlugcatSelector, ButtonScroller, StoryMenuSlugcatButton[]> populateSlugButtons) : base(menu, owner, "", pos, new(110, 30), amtOfScugsToShow, spacing, menu.Translate("Press on the button to open/close the slugcat selection list"))
         {
             slug = currentSlugcat;
             populateList = (selector, scroller) =>

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -200,7 +200,7 @@ namespace RainMeadow
             if (storyGameMode.requireCampaignSlugcat)
             {
                 RemoveSlugcatList();
-                SelectedIndex = -1;
+                CurrentSlugcat = storyGameMode.currentCampaign;
             }
             else
             {
@@ -221,52 +221,12 @@ namespace RainMeadow
             {
                 OnlineManager.LeaveLobby();
             }
+            RainMeadow.rainMeadowOptions._SaveConfigFile(); //im just gonna allow this for now, since idk updates in slider set value
             base.ShutDownProcess();
         }
         public override string UpdateInfoText()
         {
             return selectedObject is IHaveADescription descObj ? descObj.Description : base.UpdateInfoText();
-        }
-        public bool? GetOnlineChecked(CheckBox box)
-        {
-            if (RainMeadow.isStoryMode(out StoryGameMode storyGameMode))
-            {
-                if (box.IDString == "CLIENTSAVERESET")
-                {
-                    return storyGameMode.saveToDisk;
-                }
-                if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
-                {
-                    return storyGameMode.friendlyFire;
-                }
-                if (box.IDString == "CAMPAIGNSLUGONLY")
-                {
-                    return storyGameMode.requireCampaignSlugcat;
-                }
-            }
-            return null; //get checked reutrns orig is bool is null :p
-        }
-        public bool SetOnlineChecked(CheckBox box, bool c)
-        {
-            if (RainMeadow.isStoryMode(out StoryGameMode storyGameMode))
-            {
-                if (box.IDString == "CLIENTSAVERESET")
-                {
-                    storyGameMode.saveToDisk = c;
-                    return true; //setchecked hook checks if it returns true, if true it returns else it calls orig
-                }
-                if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
-                {
-                    storyGameMode.friendlyFire = c;
-                    return true;
-                }
-                if (box.IDString == "CAMPAIGNSLUGONLY")
-                {
-                    storyGameMode.requireCampaignSlugcat = c;
-                    return true;
-                }
-            }
-            return false;
         }
         private void UpdatePlayerList()
         {
@@ -430,6 +390,11 @@ namespace RainMeadow
         }
         private void TryChangeSlugcatIndex(SlugcatStats.Name scug)
         {
+            if (scug == slugcatColorOrder[slugcatPageIndex])
+            {
+                SelectedIndex = -1;
+                return;
+            }
             for (int i = 0; i < SelectableSlugcats.Length; i++)
             {
                 if (SelectableSlugcats[i] == scug)

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -37,7 +37,7 @@ namespace RainMeadow
         {
             get
             {
-                return playerSelectedSlugcat ?? SelectableSlugcats[slugcatPageIndex];
+                return playerSelectedSlugcat ?? slugcatPages[slugcatPageIndex];
             }
             set
             {

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -75,7 +75,6 @@ namespace RainMeadow
 
             storyGameMode.Sanitize();
             storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
-            //removed setting SelectedIndex, it already gets current slugcat page without setting the num at the start
             restartCheckboxPos = restartCheckbox.pos;       
             RemoveExcessStoryObjects();
             ModifyExistingMenuItems();
@@ -126,9 +125,7 @@ namespace RainMeadow
             // * override singleplayer custom colours
             // * fix intro cutscenes messing with resource acquisition
             // ? how to deal with statistics screen (not supposed to continue, we should require wipe)
-            // Use the default colors for this slugcat when the checkbox is unchecked
-            // Use CustomColors when rw saves say its enabled regardless of remix, however dont open color config when remix isnt on since it contains enums and translations
-            personaSettings.currentColors = this.GetCustomColors(personaSettings.playingAs);
+            personaSettings.currentColors = this.GetCustomColors(personaSettings.playingAs); //abt colors, color config updates to campaign when required campaign is on. Client side, the host still needs to be in the menu to update it so they will notice the color config update
             manager.arenaSitting = null;
             if (restartChecked)
             {

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -195,12 +195,20 @@ namespace RainMeadow
                 {
                     onlineDifficultyLabel.text = GetCurrentCampaignName() + (string.IsNullOrEmpty(storyGameMode.region) ? Translate(" - New Game") : " - " + Translate(storyGameMode.region));
                 }
-
+                int campaignIndex = indexFromColor(storyGameMode.currentCampaign);
+                if (campaignIndex == -1)
+                {
+                    RainMeadow.Debug("WARNING! CAMPAIGN SLUGCAT is not found on list!! OWNER USING ANOTHER SLUGCAT?");
+                }
+                else
+                {
+                    slugcatPageIndex = campaignIndex;
+                }
             }
             if (storyGameMode.requireCampaignSlugcat)
             {
                 RemoveSlugcatList();
-                CurrentSlugcat = storyGameMode.currentCampaign;
+                SelectedIndex = -1;
             }
             else
             {
@@ -390,11 +398,6 @@ namespace RainMeadow
         }
         private void TryChangeSlugcatIndex(SlugcatStats.Name scug)
         {
-            if (scug == slugcatColorOrder[slugcatPageIndex])
-            {
-                SelectedIndex = -1;
-                return;
-            }
             for (int i = 0; i < SelectableSlugcats.Length; i++)
             {
                 if (SelectableSlugcats[i] == scug)

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -49,7 +49,7 @@ namespace RainMeadow
         {
             get
             {
-                return currentSlugcat ?? SelectableSlugcats[slugcatPageIndex];
+                return currentSlugcat ?? slugcatPages[slugcatPageIndex];
             }
             set
             {

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -37,7 +37,7 @@ namespace RainMeadow
         {
             get
             {
-                return playerSelectedSlugcat ?? SelectableSlugcats[slugcatPageIndex];
+                return playerSelectedSlugcat ?? slugcatColorOrder[slugcatPageIndex];
             }
             set
             {
@@ -49,7 +49,7 @@ namespace RainMeadow
         {
             get
             {
-                return currentSlugcat ?? SelectableSlugcats[slugcatPageIndex];
+                return currentSlugcat ?? slugcatColorOrder[slugcatPageIndex];
             }
             set
             {

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace RainMeadow
 {
-    public class StoryOnlineMenu : SlugcatSelectMenu, SelectOneButton.SelectOneButtonOwner
+    public class StoryOnlineMenu : SlugcatSelectMenu
     {
         CheckBox clientWantsToOverwriteSave;
         CheckBox friendlyFire;
@@ -20,13 +20,48 @@ namespace RainMeadow
         ButtonScroller? playerScrollBox;
         StoryMenuSlugcatSelector? slugcatSelector;
         SlugcatCustomization personaSettings;
-        public SlugcatStats.Name[] selectableSlugcats { get; private set; }
-
+        SlugcatStats.Name[] selectableSlugcats;
         StoryGameMode storyGameMode;
         MenuLabel onlineDifficultyLabel;
         Vector2 restartCheckboxPos;
-        public SlugcatStats.Name CurrentSlugcat { get => selectableSlugcats[SelectedIndex]; }
-        public int actualSelectedIndex = -1;
+        int actualSelectedIndex = -1, actualPlayerSelectedIndex = -1;
+        public SlugcatStats.Name[] SelectableSlugcats
+        {
+            get
+            {
+                SetupSelectableSlugcats();
+                return selectableSlugcats;
+            }
+        }
+        public SlugcatStats.Name PlayerSelectedSlugcat
+        {
+            get
+            {
+                return SelectableSlugcats[PlayerSelectedIndex];
+            }
+        }
+        public SlugcatStats.Name CurrentSlugcat
+        {
+            get
+            {
+                return SelectableSlugcats[SelectedIndex];
+            }
+            set
+            {
+                RecieveSlugcat(value);
+            }
+        }
+        protected int PlayerSelectedIndex //store's players original choice, slugcatpageindex check cuz maybe player wants change their slugcat with campaign selecting
+        {
+            get
+            {
+                return actualPlayerSelectedIndex < 0? slugcatPageIndex : actualPlayerSelectedIndex;
+            }
+            set
+            {
+                actualPlayerSelectedIndex = value >= 0 ? value != slugcatPageIndex? value: -1 :actualPlayerSelectedIndex;
+            }
+        }
         public int SelectedIndex
         {
             get
@@ -39,10 +74,8 @@ namespace RainMeadow
                 {
                     RemoveColorButtons();
                     actualSelectedIndex = value;
-                    if (colorChecked)
-                    {
-                        AddColorButtons();
-                    }
+                    PlayerSelectedIndex = actualSelectedIndex;
+                    UpdateUponChangingSlugcat(CurrentSlugcat);
                 }
             }
         }
@@ -54,6 +87,7 @@ namespace RainMeadow
 
         public StoryOnlineMenu(ProcessManager manager) : base(manager)
         {
+            SetupSelectableSlugcats();
             ID = OnlineManager.lobby.gameMode.MenuProcessId();
             storyGameMode = (StoryGameMode)OnlineManager.lobby.gameMode;
 
@@ -61,7 +95,6 @@ namespace RainMeadow
             storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
             //removed setting SelectedIndex, it already gets current slugcat page without setting the num at the start
             restartCheckboxPos = restartCheckbox.pos;       
-            SetupSelectableSlugcats();
             RemoveExcessStoryObjects();
             ModifyExistingMenuItems();
 
@@ -76,7 +109,8 @@ namespace RainMeadow
             }
 
             // HACK: force-register MMFEnums.SliderID because god is dead and we have killed them
-            MoreSlugcats.MMFEnums.SliderID.RegisterValues();
+            // turns out god not dead
+            //MoreSlugcats.MMFEnums.SliderID.RegisterValues();
 
             SetupOnlineCustomization();
 
@@ -102,44 +136,21 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby.isOwner)
             {
-                personaSettings.playingAs = storyGameMode.currentCampaign = storyGameCharacter;
+                storyGameMode.currentCampaign = storyGameCharacter;
             }
-            else
-            {
-                if (storyGameMode.requireCampaignSlugcat) // I'm a client and I want to match the host's
-                {
-                    personaSettings.playingAs = storyGameMode.currentCampaign;
-                }
-            }
+            storyGameMode.currentCampaign = OnlineManager.lobby.isOwner ? storyGameCharacter : storyGameMode.currentCampaign;
+            personaSettings.playingAs = storyGameMode.requireCampaignSlugcat ? storyGameMode.currentCampaign : PlayerSelectedSlugcat; //double check just incase
 
             // TODO: figure out how to reuse vanilla StartGame
             // * override singleplayer custom colours
             // * fix intro cutscenes messing with resource acquisition
             // ? how to deal with statistics screen (not supposed to continue, we should require wipe)
-           
-            if (colorChecked)
-            {
-                List<Color> val = new();
-                for (int i = 0; i < manager.rainWorld.progression.miscProgressionData.colorChoices[selectableSlugcats[SelectedIndex].value].Count; i++)
-                {
-                    Vector3 vector = new Vector3(1f, 1f, 1f);
-                    if (manager.rainWorld.progression.miscProgressionData.colorChoices[selectableSlugcats[SelectedIndex].value][i].Contains(","))
-                    {
-                        string[] array = manager.rainWorld.progression.miscProgressionData.colorChoices[selectableSlugcats[SelectedIndex].value][i].Split(new char[1] { ',' });
-                        vector = new Vector3(float.Parse(array[0], (NumberStyles)511, (IFormatProvider)(object)CultureInfo.InvariantCulture), float.Parse(array[1], (NumberStyles)511, (IFormatProvider)(object)CultureInfo.InvariantCulture), float.Parse(array[2], (NumberStyles)511, (IFormatProvider)(object)CultureInfo.InvariantCulture));
-                    }
-                    val.Add(Custom.HSL2RGB(vector[0], vector[1], vector[2]));
-                }
-
-                personaSettings.currentColors = val;
-            }
-            else
-            {
-                // Use the default colors for this slugcat when the checkbox is unchecked
-                personaSettings.currentColors = PlayerGraphics.DefaultBodyPartColorHex(selectableSlugcats[SelectedIndex]).Select(Custom.hexToColor).ToList();
-            }
+            // Use the default colors for this slugcat when the checkbox is unchecked
+            // Use CustomColors when rw saves say its enabled regardless of remix, however dont open color config when remix isnt on since it contains enums and translations
+            //safe check custom colors on for the player's playing as
+            personaSettings.currentColors = this.GetCustomColors(personaSettings.playingAs);
             manager.arenaSitting = null;
-            if (restartCheckbox != null && restartCheckbox.Checked)
+            if (restartChecked)
             {
                 manager.rainWorld.progression.WipeSaveState(storyGameMode.currentCampaign);
                 manager.menuSetup.startGameCondition = ProcessManager.MenuSetup.StoryGameInitCondition.New;
@@ -148,48 +159,7 @@ namespace RainMeadow
             {
                 manager.menuSetup.startGameCondition = ProcessManager.MenuSetup.StoryGameInitCondition.Load;
             }
-         
             manager.RequestMainProcessSwitch(ProcessManager.ProcessID.Game);
-        }
-
-        private static List<Color> GetSlugcatColorsFromMiscProg(SlugcatStats.Name id)
-        {
-            var miscProg = Custom.rainWorld.progression.miscProgressionData;
-
-            if (!miscProg.colorsEnabled.TryGetValue(id.value, out var colorsEnabled))
-            {
-                return [];
-            }
-
-            if (!colorsEnabled)
-            {
-                return [];
-            }
-
-            if (!miscProg.colorChoices.TryGetValue(id.value, out var partColorStrings))
-            {
-                return [];
-            }
-
-            var partColors = new List<Color>();
-
-            foreach (var partColorString in partColorStrings)
-            {
-                // Shouldn't happen, means that the color save data is malformed
-                if (!partColorString.Contains(","))
-                {
-                    partColors.Add(Color.magenta);
-                    continue;
-                }
-
-                var hslString = partColorString.Split([',']);
-                var hsl = new Vector3(float.Parse(hslString[0], NumberStyles.Any, CultureInfo.InvariantCulture), float.Parse(hslString[1], NumberStyles.Any, CultureInfo.InvariantCulture), float.Parse(hslString[2], NumberStyles.Any, CultureInfo.InvariantCulture));
-
-                var partColor = Custom.HSL2RGB(hsl[0], hsl[1], hsl[2]);
-                partColors.Add(partColor);
-            }
-
-            return partColors;
         }
 
         public override void Update()
@@ -206,9 +176,6 @@ namespace RainMeadow
                 {
                     startButton.buttonBehav.greyedOut = OnlineManager.lobby.clientSettings.Values.Any(cs => cs.inGame);
                 }
-                pages[0].ClearMenuObject(ref slugcatLabel); //added this just in case you suddenly become a host
-                pages[0].ClearMenuObject(ref slugcatSelector);
-                SelectedIndex = -1;
 
             }
             else
@@ -220,15 +187,6 @@ namespace RainMeadow
                     onlineDifficultyLabel.label.alpha = 0.5f;
                     pages[0].subObjects.Add(onlineDifficultyLabel);
                 }
-                if (storyGameMode.requireCampaignSlugcat)
-                {
-                    pages[0].ClearMenuObject(ref slugcatLabel);
-                    pages[0].ClearMenuObject(ref slugcatSelector);
-                }
-                else
-                {
-                    SetupSlugcatList();
-                }
                 if (startButton != null)
                 {
                     startButton.buttonBehav.greyedOut = !storyGameMode.canJoinGame;
@@ -238,6 +196,16 @@ namespace RainMeadow
                     onlineDifficultyLabel.text = GetCurrentCampaignName() + (string.IsNullOrEmpty(storyGameMode.region) ? Translate(" - New Game") : " - " + Translate(storyGameMode.region));
                 }
 
+            }
+            if (storyGameMode.requireCampaignSlugcat)
+            {
+                RemoveSlugcatList();
+                SelectedIndex = -1;
+            }
+            else
+            {
+                SetupSlugcatList();
+                SelectedIndex = PlayerSelectedIndex;
             }
             if (slugcatSelector != null)
             {
@@ -253,10 +221,53 @@ namespace RainMeadow
             {
                 OnlineManager.LeaveLobby();
             }
-            RainMeadow.rainMeadowOptions._SaveConfigFile(); // save colors
             base.ShutDownProcess();
         }
-
+        public override string UpdateInfoText()
+        {
+            return selectedObject is IHaveADescription descObj ? descObj.Description : base.UpdateInfoText();
+        }
+        public bool? GetOnlineChecked(CheckBox box)
+        {
+            if (RainMeadow.isStoryMode(out StoryGameMode storyGameMode))
+            {
+                if (box.IDString == "CLIENTSAVERESET")
+                {
+                    return storyGameMode.saveToDisk;
+                }
+                if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
+                {
+                    return storyGameMode.friendlyFire;
+                }
+                if (box.IDString == "CAMPAIGNSLUGONLY")
+                {
+                    return storyGameMode.requireCampaignSlugcat;
+                }
+            }
+            return null; //get checked reutrns orig is bool is null :p
+        }
+        public bool SetOnlineChecked(CheckBox box, bool c)
+        {
+            if (RainMeadow.isStoryMode(out StoryGameMode storyGameMode))
+            {
+                if (box.IDString == "CLIENTSAVERESET")
+                {
+                    storyGameMode.saveToDisk = c;
+                    return true; //setchecked hook checks if it returns true, if true it returns else it calls orig
+                }
+                if (box.IDString == "ONLINEFRIENDLYFIRE") // online dictionaries do not like updating over the wire and I dont have the energy to deal with that right now
+                {
+                    storyGameMode.friendlyFire = c;
+                    return true;
+                }
+                if (box.IDString == "CAMPAIGNSLUGONLY")
+                {
+                    storyGameMode.requireCampaignSlugcat = c;
+                    return true;
+                }
+            }
+            return false;
+        }
         private void UpdatePlayerList()
         {
             playerScrollBox?.RemoveAllButtons(false);
@@ -279,28 +290,6 @@ namespace RainMeadow
             if (RainMeadow.isStoryMode(out var _))
             {
                 UpdatePlayerList();
-            }
-        }
-
-
-        public int GetCurrentlySelectedOfSeries(string series) => series switch
-        {
-            "scugButtons" => !RainMeadow.rainMeadowOptions.SlugcatCustomToggle.Value ? -1 : SelectedIndex,
-            _ => -1,
-        };
-
-        public void SetCurrentlySelectedOfSeries(string series, int to)
-        {
-            switch (series)
-            {
-                case "scugButtons":
-                    SelectedIndex = to;
-                    if (to >= slugcatPages.Count) {
-                        to = 0;
-                    }
-
-                    slugcatPageIndex = to;
-                    return;
             }
         }
 
@@ -339,13 +328,15 @@ namespace RainMeadow
             }
 
         }
+        private void RemoveSlugcatList()
+        {
+            pages[0].ClearMenuObject(ref slugcatLabel);
+            pages[0].ClearMenuObject(ref slugcatSelector);
+        }
 
         private void SetupOnlineCustomization()
         {
             personaSettings = storyGameMode.avatarSettings;
-            personaSettings.playingAs = slugcatPages[slugcatPageIndex].slugcatNumber;
-            personaSettings.bodyColor = RainMeadow.rainMeadowOptions.BodyColor.Value.SafeColorRange();
-            personaSettings.eyeColor = RainMeadow.rainMeadowOptions.EyeColor.Value.SafeColorRange();
         }
 
         private void RemoveExcessStoryObjects()
@@ -416,42 +407,42 @@ namespace RainMeadow
         public StoryMenuSlugcatButton[] GetSlugcatSelectionButtons(StoryMenuSlugcatSelector slugcatSelector, ButtonScroller buttonScroller)
         {
             List<StoryMenuSlugcatButton> slugcatButtons = [];
-            for (int i = 0; i < selectableSlugcats.Length; i++)
+            for (int i = 0; i < SelectableSlugcats.Length; i++)
             {
-                if (selectableSlugcats[i] != slugcatSelector.slug)
+                if (SelectableSlugcats[i] != slugcatSelector.slug)
                 {
-                    StoryMenuSlugcatButton storyMenuSlugcatButton = new(this, buttonScroller, selectableSlugcats[i], (scug) =>
+                    StoryMenuSlugcatButton storyMenuSlugcatButton = new(this, buttonScroller, SelectableSlugcats[i], (scug) =>
                     {
-                        RecieveSlugcat(scug);
-                        slugcatSelector.slug = scug;
-                        slugcatSelector.OpenCloseList();
+                        CurrentSlugcat = scug;
+                        slugcatSelector.OpenCloseList(false, true, true);
                     });
                     slugcatButtons.Add(storyMenuSlugcatButton);
                 }
             }
             return [.. slugcatButtons];
         }
-        public void TryChangeSlugcatIndex(SlugcatStats.Name scug)
+        private void RecieveSlugcat(SlugcatStats.Name scug)
         {
-            for (int i = 0; i < selectableSlugcats.Length; i++)
+            if (scug != CurrentSlugcat)
             {
-                if (selectableSlugcats[i] == scug)
+                TryChangeSlugcatIndex(scug);
+            }
+        }
+        private void TryChangeSlugcatIndex(SlugcatStats.Name scug)
+        {
+            for (int i = 0; i < SelectableSlugcats.Length; i++)
+            {
+                if (SelectableSlugcats[i] == scug)
                 {
                     SelectedIndex = i;
-                    personaSettings.playingAs = scug;
                 }
             }
         }
-        public void RecieveSlugcat(SlugcatStats.Name scug)
-        {
-            TryChangeSlugcatIndex(scug);
-        }
-        public void UpdateUponChangingSlugcat(SlugcatStats.Name scug)
+        private void UpdateUponChangingSlugcat(SlugcatStats.Name scug)
         {
             if (colorsCheckbox != null)
             {
-                colorsCheckbox.Checked = manager.rainWorld.progression.miscProgressionData.colorsEnabled.ContainsKey(scug.value) && 
-                    manager.rainWorld.progression.miscProgressionData.colorsEnabled[scug.value]; //automatically opens color interface if enabled
+                colorsCheckbox.Checked = this.IsCustomColorEnabled(scug); //automatically opens color interface if enabled
             }
         }
     }

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -37,7 +37,7 @@ namespace RainMeadow
         {
             get
             {
-                return playerSelectedSlugcat ?? slugcatPages[slugcatPageIndex];
+                return playerSelectedSlugcat ?? SelectableSlugcats[slugcatPageIndex];
             }
             set
             {
@@ -49,7 +49,7 @@ namespace RainMeadow
         {
             get
             {
-                return currentSlugcat ?? slugcatPages[slugcatPageIndex];
+                return currentSlugcat ?? SelectableSlugcats[slugcatPageIndex];
             }
             set
             {
@@ -185,7 +185,7 @@ namespace RainMeadow
             }
             if (slugcatSelector != null)
             {
-                slugcatSelector.slug = CurrentSlugcat;
+                slugcatSelector.Slug = CurrentSlugcat;
             }
 
         }
@@ -345,7 +345,7 @@ namespace RainMeadow
             List<StoryMenuSlugcatButton> slugcatButtons = [];
             for (int i = 0; i < SelectableSlugcats.Length; i++)
             {
-                if (SelectableSlugcats[i] != slugcatSelector.slug)
+                if (SelectableSlugcats[i] != slugcatSelector.Slug)
                 {
                     StoryMenuSlugcatButton storyMenuSlugcatButton = new(this, buttonScroller, SelectableSlugcats[i], (scug) =>
                     {
@@ -361,7 +361,7 @@ namespace RainMeadow
         {
             if (colorsCheckbox != null)
             {
-                colorsCheckbox.Checked = this.IsCustomColorEnabled(scug); //automatically opens color interface if enabled
+                colorsCheckbox.Checked = colorChecked; //this.IsCustomColorEnabled(scug); //automatically opens color interface if enabled
             }
         }
     }


### PR DESCRIPTION
this pr also mainly includes

* Added a temporary save for player's original options for require campaign toggle, in case it turns on then off
* Update color checkbox to follow the current selected slugcat
* Remove forcing custom color config when remix is off, and now uses rw saves to determine whether or not to apply colors, cuz remix contains required enums and translations (follow the game original wishes now)
* Color config changes to campaign slugcat when require campaign button is checked, and changes back (using the temporary save)
* Fix applying colors to follow the player's color choices based on what they are playing as (prevent some body parts becoming pink sometimes)
* Readd text when hovering the slugcat selection button, since it was too subtle to some people 