### PR TITLE
add watcher fast travel to list of banned mods

### DIFF
--- a/Mod/RainMeadow.json
+++ b/Mod/RainMeadow.json
@@ -16,6 +16,7 @@
         "henpemaz_spawnmenu",
         "autodestruct",
         "DieButton",
+        "CuteFatalis.WacherFastTravel",
         "emeralds_features",
         "flirpy.rivuletunscammedlungcapacity",
         "Aureuix.Kaboom",


### PR DESCRIPTION
mainly to prevent sync issues with watcher campaigns, separate pr cuz also seems to affect normal(?)