### PR TITLE
prevent possible dupes at RWGAME creation

### DIFF
--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -72,6 +72,7 @@ namespace RainMeadow
             {
                 var c = new ILCursor(il);
                 var skip = il.DefineLabel();
+                // pole mimics are the last AbstractCreature to be created, whereas pink lizards are the first
                 ILLabel pmLoop = null;
                 c.GotoNext(moveType: MoveType.After,
                     i => i.MatchLdarg(0),
@@ -90,6 +91,7 @@ namespace RainMeadow
                     i => i.MatchCallOrCallvirt<RainWorldGame>("get_world"),
                     i => i.MatchLdstr("Pink Lizard")
                 );
+                // eligibility criteria; if we are not eligibile to create objects, we skip over the entire AbstractCreature creation process
                 c.Emit(OpCodes.Ldarg_0);
                 c.EmitDelegate((RainWorldGame self) => OnlineManager.lobby == null || (WorldSession.map.TryGetValue(self.world, out var ws) && ws.isOwner));
                 c.Emit(OpCodes.Brfalse, skip);

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -16,6 +16,7 @@ namespace RainMeadow
         {
             On.Futile.OnApplicationQuit += Futile_OnApplicationQuit;
             On.RainWorldGame.ctor += RainWorldGame_ctor;
+            IL.RainWorldGame.ctor += RainWorldGame_ctor2;
             On.StoryGameSession.ctor += StoryGameSession_ctor;
             On.RainWorldGame.RawUpdate += RainWorldGame_RawUpdate;
             On.RainWorldGame.ShutDownProcess += RainWorldGame_ShutDownProcess;
@@ -62,6 +63,40 @@ namespace RainMeadow
             if (OnlineManager.lobby != null)
             {
                 OnlineManager.lobby.gameMode.PostGameStart(self);
+            }
+        }
+
+        private void RainWorldGame_ctor2(ILContext il)
+        {
+            try
+            {
+                var c = new ILCursor(il);
+                var skip = il.DefineLabel();
+                ILLabel pmLoop = null;
+                c.GotoNext(moveType: MoveType.After,
+                    i => i.MatchLdarg(0),
+                    i => i.MatchCallOrCallvirt<RainWorldGame>("get_setupValues"),
+                    i => i.MatchLdfld<RainWorldGame.SetupValues>("poleMimics"),
+                    i => i.MatchBlt(out pmLoop)
+                );
+                c.MoveAfterLabels();
+                c.MarkLabel(skip);
+                c.GotoPrev(moveType: MoveType.Before,
+                    i => i.MatchLdarg(0),
+                    i => i.MatchCallOrCallvirt<RainWorldGame>("get_world"),
+                    i => i.MatchLdloc(0),
+                    i => i.MatchCallOrCallvirt<World>("GetAbstractRoom"),
+                    i => i.MatchLdarg(0),
+                    i => i.MatchCallOrCallvirt<RainWorldGame>("get_world"),
+                    i => i.MatchLdstr("Pink Lizard")
+                );
+                c.Emit(OpCodes.Ldarg_0);
+                c.EmitDelegate((RainWorldGame self) => OnlineManager.lobby == null || (WorldSession.map.TryGetValue(self.world, out var ws) && ws.isOwner));
+                c.Emit(OpCodes.Brfalse, skip);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e);
             }
         }
 


### PR DESCRIPTION
a solution to prevent duplicate toys in WAUA_TOYS is similar to this, so i asked myself: "Why not in RainWorldGame ctor", and then i did.
may be the wrong approach, does seem to work somewhat fine through (haven't seen dupe batfruits for exampleh)