### PR TITLE
Story: filter out dupe placed objects if we can while pending

### DIFF
--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -83,13 +83,16 @@ namespace RainMeadow
         {
             foreach (var item in room.roomSettings.placedObjects)
             {
-                if (!AllowedInMode(item))
+                if (item.active)
                 {
-                    item.active = false;
-                }
-                if (item.active && RoomSession.map.TryGetValue(room.abstractRoom, out var rs) && rs.isPending && avoidDupePlacedObjects.Contains(item.type))
-                {
-                    item.active = false;
+                    if (!AllowedInMode(item))
+                    {
+                        item.active = false;
+                    }
+                    if (RoomSession.map.TryGetValue(room.abstractRoom, out var rs) && rs.isPending && avoidDupePlacedObjects.Contains(item.type))
+                    {
+                        item.active = false;
+                    }
                 }
             }
 

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -69,8 +69,31 @@ namespace RainMeadow
         {
             PlacedObject.Type.SporePlant,  // crashes the game, ask Turtle
             PlacedObject.Type.HangingPearls,  // duplicates and needs to be synced, ask choc
-            DLCSharedEnums.PlacedObjectType.Stowaway //cause severe visual glitches and shaking when overlapped
+            DLCSharedEnums.PlacedObjectType.Stowaway, //cause severe visual glitches and shaking when overlapped
         };
+
+        public HashSet<PlacedObject.Type> avoidDupePlacedObjects = new()
+        {
+            PlacedObject.Type.DangleFruit,
+            PlacedObject.Type.StuckDaddy
+            // maybe adds stowaways
+        };
+
+        public override void FilterItems(Room room)
+        {
+            foreach (var item in room.roomSettings.placedObjects)
+            {
+                if (!AllowedInMode(item))
+                {
+                    item.active = false;
+                }
+                if (item.active && RoomSession.map.TryGetValue(room.abstractRoom, out var rs) && rs.isPending && avoidDupePlacedObjects.Contains(item.type))
+                {
+                    item.active = false;
+                }
+            }
+
+        }
 
         public override bool AllowedInMode(PlacedObject item)
         {
@@ -265,19 +288,25 @@ namespace RainMeadow
         }
     }
 
-    public static class StoryModeExtensions {
-        public static bool FriendlyFireSafetyCandidate(this PhysicalObject creature) {
-            if (creature is Player p) {
+    public static class StoryModeExtensions
+    {
+        public static bool FriendlyFireSafetyCandidate(this PhysicalObject creature)
+        {
+            if (creature is Player p)
+            {
                 if (p.isNPC) return false;
-            } else return false;
+            }
+            else return false;
 
-            if (RainMeadow.isStoryMode(out var story)) {
+            if (RainMeadow.isStoryMode(out var story))
+            {
                 return !story.friendlyFire;
             }
-            if (RainMeadow.isArenaMode(out var arena)) {
+            if (RainMeadow.isArenaMode(out var arena))
+            {
                 return arena.countdownInitiatedHoldFire;
             }
-            
+
             return false;
         }
     }


### PR DESCRIPTION
- [ ] Oddly, when doing a rs.IsOwner check by myself in LAN it returns false? Need to investigate this. Might need check for roomSession owner being null

Stowaways are found in the following rooms: [CC_SHAFT01x](https://rain-world-downpour-map.github.io/map.html?slugcat=spear&region=CC&room=CC_SHAFT01x), [CC_STRAINER01](https://rain-world-downpour-map.github.io/map.html?slugcat=red&region=CC&room=CC_STRAINER01), [CC_SUMP05](https://rain-world-downpour-map.github.io/map.html?slugcat=spear&region=CC&room=CC_SUMP05), [SB_A01](https://rain-world-downpour-map.github.io/map.html?slugcat=red&region=SB&room=SB_A01), [SB_C01](https://rain-world-downpour-map.github.io/map.html?slugcat=red&region=SB&room=SB_C01), [SB_E04](https://rain-world-downpour-map.github.io/map.html?slugcat=red&region=SB&room=SB_E04), [SB_H02](https://rain-world-downpour-map.github.io/map.html?slugcat=spear&region=SB&room=SB_H02), [SB_J01](https://rain-world-downpour-map.github.io/map.html?slugcat=red&region=SB&room=SB_J01), [VS_B17](https://rain-world-downpour-map.github.io/map.html?slugcat=red&region=VS&room=VS_B17), [VS_D03](https://rain-world-downpour-map.github.io/map.html?slugcat=red&region=VS&room=VS_D03), [OE_RUIN17](https://rain-world-downpour-map.github.io/map.html?slugcat=gourmand&region=OE&room=OE_RUIN17), [OE_TOWER14](https://rain-world-downpour-map.github.io/map.html?slugcat=gourmand&region=OE&room=OE_TOWER14), [UG_A02](https://rain-world-downpour-map.github.io/map.html?slugcat=saint&region=UG&room=UG_A02), [UG_C01](https://rain-world-downpour-map.github.io/map.html?slugcat=saint&region=UG&room=UG_C01), [UG_GUTTER01](https://rain-world-downpour-map.github.io/map.html?slugcat=saint&region=UG&room=UG_GUTTER01).