### PR TITLE
foreign language name display

### DIFF
--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -66,7 +66,10 @@ namespace RainMeadow
 
         public ArenaOnlineGameMode(Lobby lobby) : base(lobby)
         {
-            avatarSettings = new SlugcatCustomization() { nickname = OnlineManager.mePlayer.id.name };
+            avatarSettings = new SlugcatCustomization() {
+                nickname = OnlineManager.mePlayer.id.name,
+                language = RWCustom.Custom.rainWorld.inGameTranslator.currentLanguage
+            };
             arenaClientSettings = new ArenaClientSettings();
             arenaClientSettings.playingAs = SlugcatStats.Name.White;
             playerResultColors = new Dictionary<string, int>();

--- a/GameModes/SlugcatCustomization.cs
+++ b/GameModes/SlugcatCustomization.cs
@@ -15,6 +15,7 @@ namespace RainMeadow
 
         public SlugcatStats.Name playingAs;
         public string nickname;
+        public InGameTranslator.LanguageID language; //used to select font for nickname display
 
         public SlugcatCustomization() { }
 
@@ -57,6 +58,8 @@ namespace RainMeadow
             public SlugcatStats.Name playingAs;
             [OnlineField]
             public string nickname;
+            [OnlineField]
+            public InGameTranslator.LanguageID language; //used to select font for nickname display
 
             public State() { }
             public State(SlugcatCustomization slugcatCustomization) : base()
@@ -64,6 +67,7 @@ namespace RainMeadow
                 customColors = slugcatCustomization.currentColors.ToArray();
                 playingAs = slugcatCustomization.playingAs;
                 nickname = slugcatCustomization.nickname;
+                language = slugcatCustomization.language;
             }
 
             public override void ReadTo(OnlineEntity.EntityData entityData, OnlineEntity onlineEntity)
@@ -72,6 +76,7 @@ namespace RainMeadow
                 slugcatCustomization.currentColors = customColors.ToList();
                 slugcatCustomization.playingAs = playingAs;
                 slugcatCustomization.nickname = nickname;
+                slugcatCustomization.language = language;
             }
 
             public override Type GetDataType() => typeof(SlugcatCustomization);

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -57,7 +57,10 @@ namespace RainMeadow
 
         public StoryGameMode(Lobby lobby) : base(lobby)
         {
-            avatarSettings = new SlugcatCustomization() { nickname = OnlineManager.mePlayer.id.name };
+            avatarSettings = new SlugcatCustomization() {
+                nickname = OnlineManager.mePlayer.id.name,
+                language = RWCustom.Custom.rainWorld.inGameTranslator.currentLanguage
+            };
         }
 
         public override ProcessManager.ProcessID MenuProcessId()

--- a/Menu/Objects/FForeignLanguageLabel.cs
+++ b/Menu/Objects/FForeignLanguageLabel.cs
@@ -1,0 +1,32 @@
+using Menu;
+using UnityEngine;
+using System;
+using Menu.Remix.MixedUI;
+using System.Collections;
+using MonoMod.RuntimeDetour;
+using System.Collections.Generic;
+using System.Reflection;
+using Mono.Cecil.Cil;
+
+namespace RainMeadow
+{
+    // Label that supports (1) foreign language
+    public class FForeignLanguageLabel : FLabel
+    {
+        public FForeignLanguageLabel(string fontName, string text) : this(fontName, text, new FTextParams())
+        {
+        }
+        
+        public FForeignLanguageLabel(string fontName, string text, FTextParams textParams) : base(fontName, text, textParams)
+        {
+        }
+
+        public void SetFont(string fontName)
+        {
+            this._fontName = fontName;
+            this._font = Futile.atlasManager.GetFontWithName(this._fontName);
+            this._doesTextNeedUpdate = true;
+            this._doesLocalPositionNeedUpdate = true;
+        }
+    }
+}

--- a/Menu/Objects/SlugcatCustomizationSelector.cs
+++ b/Menu/Objects/SlugcatCustomizationSelector.cs
@@ -50,12 +50,14 @@ namespace RainMeadow
         {
             RainMeadow.DebugMe();
             customization.nickname = value;
+            customization.language = RWCustom.Custom.rainWorld.inGameTranslator.currentLanguage;
         }
 
         private void NicknameBox_OnValueChanged(UIconfig config, string value, string oldValue)
         {
             RainMeadow.DebugMe();
             customization.nickname = value;
+            customization.language = RWCustom.Custom.rainWorld.inGameTranslator.currentLanguage;
         }
 
         private void SlugcatSelector_OnValueChanged(UIconfig config, string value, string oldValue)

--- a/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -11,7 +11,7 @@ namespace RainMeadow
     {
         public FSprite arrowSprite;
         public FSprite gradient;
-        public FLabel username;
+        public FForeignLanguageLabel username;
         public List<FLabel> messageLabels = new();
         public FLabel pingLabel;
         public FSprite slugIcon;
@@ -117,7 +117,7 @@ namespace RainMeadow
             this.slugIcon.color = lighter_color;
             this.blink = 1f;
 
-            this.username = new FLabel(Custom.GetFont(), customization.nickname);
+            this.username = new FForeignLanguageLabel(Utils.GetLanguageFont(customization.language), customization.nickname);
             owner.hud.fContainers[0].AddChild(this.username);
             this.username.alpha = 0f;
             this.username.x = -1000f;
@@ -248,6 +248,7 @@ namespace RainMeadow
 
             if (messageQueue.Count > 0)
             {
+                this.username.SetFont(Utils.GetLanguageFont(customization.language));
                 this.username.text = customization.nickname + ": ";
 
                 while (messageQueue.Count > messageLabels.Count) messageQueue.Dequeue();
@@ -278,6 +279,7 @@ namespace RainMeadow
             }
             else
             {
+                this.username.SetFont(Utils.GetLanguageFont(customization.language));
                 this.username.text = customization.nickname;
                 if (RainMeadow.rainMeadowOptions.ShowPingLocation.Value == 0)
                 {

--- a/Utils/Utils.cs
+++ b/Utils/Utils.cs
@@ -13,6 +13,20 @@ namespace RainMeadow
     {
         public static InGameTranslator Translator => Custom.rainWorld.inGameTranslator;
 
+        // Obtains a font but using the specified language font (as opposed to defualting the user one on GetFont())
+		public static string GetLanguageFont(InGameTranslator.LanguageID language)
+		{
+			if (ModManager.NonPrepackagedModsInstalled && ModManager.InitializationScreenFinished && Custom.rainWorld != null && (language == InGameTranslator.LanguageID.Korean || language == InGameTranslator.LanguageID.Japanese || language == InGameTranslator.LanguageID.Chinese))
+			{
+				return "font" + LocalizationTranslator.LangShort(language) + "Full";
+			}
+			if (!(Custom.rainWorld == null) && (!(language != InGameTranslator.LanguageID.Japanese) || !(language != InGameTranslator.LanguageID.Korean) || !(language != InGameTranslator.LanguageID.Chinese) || !(language != InGameTranslator.LanguageID.Russian)))
+			{
+				return "font" + LocalizationTranslator.LangShort(language);
+			}
+			return "font";
+		}
+
         public static string Translate(string text)
         {
             return Translator.Translate(text);


### PR DESCRIPTION
sometimes user have names like "ручка" and for non-russian it appears as "" which is bad (however if game is set to russian, name appears normally)
pr just makes it so the font used to display names is the one according to the language of the user
making "multilanguage FLabels" would involve lots of scary stuff like managing multiple fonts in the same run of text (scary)