### PR TITLE
Add saving colors to Arena when exiting to lobby

### DIFF
--- a/Arena/ArenaLobbyMenu.cs
+++ b/Arena/ArenaLobbyMenu.cs
@@ -550,6 +550,7 @@ namespace RainMeadow
         public override void ShutDownProcess()
         {
             RainMeadow.DebugMe();
+            manager.rainWorld.progression.SaveProgression(true, true);
             if (manager.upcomingProcess != ProcessManager.ProcessID.Game)
             {
                 OnlineManager.LeaveLobby();


### PR DESCRIPTION
generally tested any save errors with story mode, so far it works fine, and colors last set by player gets loaded, should also save when playing a round in arena