### PR TITLE
use initstate instead of modifying seed directly

### DIFF
--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -103,7 +103,7 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null)
             {
-                UnityEngine.Random.seed = self.ID.RandomSeed;
+                UnityEngine.Random.InitState(self.ID.RandomSeed);
             }
             orig(self);
             if (OnlineManager.lobby != null && self.GetOnlineObject(out var oe))
@@ -133,7 +133,7 @@ namespace RainMeadow
         {
             if(OnlineManager.lobby != null)
             {
-                UnityEngine.Random.seed = self.ID.RandomSeed;
+                UnityEngine.Random.InitState(self.ID.RandomSeed);
             }
             var wasCreature = self.realizedCreature;
             orig(self);


### PR DESCRIPTION
https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Random.InitState.html

> The seed cannot be retrieved once set - the pseudorandomization algorithm stores its internal state in a more complex set of numbers. However, this state can be loaded and stored via the [state](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Random-state.html) property, which works with the opaque but serializable [State](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Random.State.html).

https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Random-state.html

> The values from step 5 and 6 will be equal to those from step 3 and 4 because the internal [state](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Random-state.html) of the generator was restored to what we saved in stateBeforeStep3. Also, the values from step 7 and 8 will be equal to those from step 1 and 2 because we are resetting the generator state with initialSeed via [InitState](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Random.InitState.html), which leaves the generator in the exact same state as right before step 1.
