### PR TITLE
Engine: don't update weapon state if transferring

### DIFF
--- a/Online/State/RealizedSpearState.cs
+++ b/Online/State/RealizedSpearState.cs
@@ -1,4 +1,5 @@
 using RWCustom;
+using Steamworks;
 using System;
 using UnityEngine;
 
@@ -32,6 +33,7 @@ namespace RainMeadow
             needleActive = spear.spearmasterNeedle_hasConnection;
             spearDamageBonus = spear.spearDamageBonus;
 
+
             if (spear.stuckInObject != null)
             {
                 stuckInChunk = BodyChunkRef.FromBodyChunk(spear.stuckInChunk);
@@ -48,8 +50,8 @@ namespace RainMeadow
             spear.stuckInWall = stuckInWall;
             spear.abstractSpear.stuckInWallCycles = stuckInWallCycles;
             spear.spearDamageBonus = spearDamageBonus;
-            if (!stuckInWall.HasValue)
-                spear.addPoles = false;
+            spear.addPoles = stuckInWall.HasValue;
+
             spear.spearmasterNeedle_hasConnection = needleActive;
 
             if (stuckInChunk is not null)
@@ -72,13 +74,15 @@ namespace RainMeadow
                 RainMeadow.Error("Stuck in creature but no creature");
                 spear.ChangeMode(Weapon.Mode.Free);
             }
+
         }
 
         override public bool ShouldPosBeLenient(PhysicalObject po)
         {
             if (po is not Spear p) { RainMeadow.Error("target is wrong type: " + po); return false; }
             if (p.onPlayerBack) return true;
-            return false;
+            if (p.stuckInObject != null) return true;
+            return base.ShouldPosBeLenient(po);
         }
     }
 

--- a/Online/State/RealizedSpearState.cs
+++ b/Online/State/RealizedSpearState.cs
@@ -1,5 +1,4 @@
 using RWCustom;
-using Steamworks;
 using System;
 using UnityEngine;
 
@@ -82,8 +81,7 @@ namespace RainMeadow
             if (po is not Spear p) { RainMeadow.Error("target is wrong type: " + po); return false; }
             if (p.onPlayerBack) return true;
             if (p.stuckInObject != null) return true;
-            return base.ShouldPosBeLenient(po);
-        }
+            return false;        }
     }
 
     public class AppendageRef : Serializer.ICustomSerializable, IEquatable<AppendageRef>

--- a/Online/State/RealizedSpearState.cs
+++ b/Online/State/RealizedSpearState.cs
@@ -80,7 +80,6 @@ namespace RainMeadow
         {
             if (po is not Spear p) { RainMeadow.Error("target is wrong type: " + po); return false; }
             if (p.onPlayerBack) return true;
-            if (p.stuckInObject != null) return true;
             return false;        }
     }
 

--- a/Online/State/RealizedWeaponState.cs
+++ b/Online/State/RealizedWeaponState.cs
@@ -1,4 +1,5 @@
 using RWCustom;
+using System.Numerics;
 using UnityEngine;
 
 namespace RainMeadow
@@ -31,19 +32,30 @@ namespace RainMeadow
         public override void ReadTo(OnlineEntity onlineEntity)
         {
             base.ReadTo(onlineEntity);
-            var weapon = (Weapon)((OnlinePhysicalObject)onlineEntity).apo.realizedObject;
-            var newMode = mode;
-            if (weapon.room != null && weapon.mode != newMode)
+            if (onlineEntity.isTransfering)
             {
-                RainMeadow.Debug($"{onlineEntity} new mode : {newMode}");
-                weapon.ChangeMode(newMode);
-                weapon.throwModeFrames = -1; // not synched, behaves as "infinite"
+                RainMeadow.Debug($"Transferring {onlineEntity}, not updating state!");
+                return;
             }
+
+            var weapon = (Weapon)((OnlinePhysicalObject)onlineEntity).apo.realizedObject;
+            //RainMeadow.Debug(onlineEntity.isTransfering);
+            weapon.mode = mode;
+            //var newMode = mode;
+            RainMeadow.Debug(weapon.mode);
+            RainMeadow.Debug(mode);
+            //if (weapon.room != null && weapon.mode != newMode)
+            //{
+            //    RainMeadow.Debug($"{onlineEntity} new mode : {newMode}");
+            //    weapon.ChangeMode(newMode);
+            //    weapon.throwModeFrames = -1; // not synched, behaves as "infinite"
+            //}
+
             weapon.thrownBy = thrownBy?.realizedCreature;
             if (weapon.grabbedBy != null && weapon.grabbedBy.Count > 0) { RainMeadow.Trace($"Skipping state because grabbed"); return; }
             weapon.rotation = Custom.DegToVec(rotation);
             weapon.rotationSpeed = rotationSpeed;
-            weapon.throwDir = new IntVector2((throwDir & 0b01)!=0 ? 0 : (throwDir & 0b10)!=0 ? -1 : 1, (throwDir & 0b01)==0 ? 0 : (throwDir & 0b10)!=0 ? -1 : 1);
+            weapon.throwDir = new IntVector2((throwDir & 0b01) != 0 ? 0 : (throwDir & 0b10) != 0 ? -1 : 1, (throwDir & 0b01) == 0 ? 0 : (throwDir & 0b10) != 0 ? -1 : 1);
         }
     }
 }

--- a/Online/State/RealizedWeaponState.cs
+++ b/Online/State/RealizedWeaponState.cs
@@ -39,17 +39,17 @@ namespace RainMeadow
             }
 
             var weapon = (Weapon)((OnlinePhysicalObject)onlineEntity).apo.realizedObject;
-            //RainMeadow.Debug(onlineEntity.isTransfering);
+            
             weapon.mode = mode;
-            //var newMode = mode;
+            var newMode = mode;
             RainMeadow.Debug(weapon.mode);
             RainMeadow.Debug(mode);
-            //if (weapon.room != null && weapon.mode != newMode)
-            //{
-            //    RainMeadow.Debug($"{onlineEntity} new mode : {newMode}");
-            //    weapon.ChangeMode(newMode);
-            //    weapon.throwModeFrames = -1; // not synched, behaves as "infinite"
-            //}
+            if (weapon.room != null && weapon.mode != newMode)
+            {
+                RainMeadow.Debug($"{onlineEntity} new mode : {newMode}");
+                weapon.ChangeMode(newMode);
+                weapon.throwModeFrames = -1; // not synched, behaves as "infinite"
+            }
 
             weapon.thrownBy = thrownBy?.realizedCreature;
             if (weapon.grabbedBy != null && weapon.grabbedBy.Count > 0) { RainMeadow.Trace($"Skipping state because grabbed"); return; }

--- a/Online/State/RealizedWeaponState.cs
+++ b/Online/State/RealizedWeaponState.cs
@@ -1,5 +1,4 @@
 using RWCustom;
-using System.Numerics;
 using UnityEngine;
 
 namespace RainMeadow
@@ -39,7 +38,6 @@ namespace RainMeadow
             }
 
             var weapon = (Weapon)((OnlinePhysicalObject)onlineEntity).apo.realizedObject;
-            
             weapon.mode = mode;
             var newMode = mode;
             

--- a/Online/State/RealizedWeaponState.cs
+++ b/Online/State/RealizedWeaponState.cs
@@ -38,7 +38,6 @@ namespace RainMeadow
             }
 
             var weapon = (Weapon)((OnlinePhysicalObject)onlineEntity).apo.realizedObject;
-            weapon.mode = mode;
             var newMode = mode;
             
             if (weapon.room != null && weapon.mode != newMode)

--- a/Online/State/RealizedWeaponState.cs
+++ b/Online/State/RealizedWeaponState.cs
@@ -42,8 +42,7 @@ namespace RainMeadow
             
             weapon.mode = mode;
             var newMode = mode;
-            RainMeadow.Debug(weapon.mode);
-            RainMeadow.Debug(mode);
+            
             if (weapon.room != null && weapon.mode != newMode)
             {
                 RainMeadow.Debug($"{onlineEntity} new mode : {newMode}");


### PR DESCRIPTION
Problem: Weapon states are being updated while new owners are in the middle of using the weapon. 

Example: Spears thrown in Arena by Player 2 that were owned by Player 1 receive a "Free" Weapon.Mode in the middle of the player 2 throwing the Spear, denying a kill and updating the Mode erroneously. 

Solution: Don't update State if we're transferring.