### PR TITLE
meadow main menu button did not play sound

### DIFF
--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -426,6 +426,7 @@ namespace RainMeadow
 
                 OnlineManager.LeaveLobby();
                 self.manager.RequestMainProcessSwitch(Ext_ProcessID.LobbySelectMenu);
+                self.PlaySound(SoundID.MENU_Switch_Page_In);
             }, self.mainMenuButtons.Count - 2);
         }
     }


### PR DESCRIPTION
#852 except now it's not on my fork's main branch so it doesn't get deleted if I try to sync my fork