### PR TITLE
fix: meadow main menu button did not play sound

### DIFF
--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -426,6 +426,7 @@ namespace RainMeadow
 
                 OnlineManager.LeaveLobby();
                 self.manager.RequestMainProcessSwitch(Ext_ProcessID.LobbySelectMenu);
+                self.PlaySound(SoundID.MENU_Switch_Page_In);
             }, self.mainMenuButtons.Count - 2);
         }
     }


### PR DESCRIPTION
@invalidunits the reason there's such a large git diff is cause there's mixed line endings. Using the Github web editor creates a diff of like 400 lines so the 40 line diff is as good as it's gonna get