### PR TITLE
arena spawn location indicator

### DIFF
--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -80,7 +80,7 @@ namespace RainMeadow
             self.AddPart(new ArenaPrepTimer(self, self.fContainers[0], arena, session));
             self.AddPart(new OnlineHUD(self, session.game.cameras[0], arena));
             self.AddPart(new Pointing(self));
-
+            self.AddPart(new ArenaSpawnLocationIndicator(self, session.game.cameras[0]));
         }
         public virtual void ArenaCreatureSpawner_SpawnCreatures(ArenaOnlineGameMode arena, On.ArenaCreatureSpawner.orig_SpawnArenaCreatures orig, RainWorldGame game, ArenaSetup.GameTypeSetup.WildLifeSetting wildLifeSetting, ref List<AbstractCreature> availableCreatures, ref MultiplayerUnlocks unlocks)
         {

--- a/OnlineUIComponents/ArenaSpawnLocationIndicator.cs
+++ b/OnlineUIComponents/ArenaSpawnLocationIndicator.cs
@@ -1,0 +1,37 @@
+using HUD;
+using UnityEngine;
+
+namespace RainMeadow;
+
+public class ArenaSpawnLocationIndicator : HudPart
+{
+    private RoomCamera camera;
+    private int counter = 0;
+    private ClientSettings clientSettings;
+
+    public ArenaSpawnLocationIndicator(HUD.HUD hud, RoomCamera camera) : base(hud)
+    {
+        this.camera = camera;
+        if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arena)) RainMeadow.Error("ArenaSpawnPositionIndicator was constructed outside of an arena game");
+        clientSettings = arena.clientSettings;
+    }
+
+    public override void Update()
+    {
+        counter++;
+        if (counter != 30) return;
+
+        if (clientSettings.avatars.Count == 0
+            || clientSettings.avatars[0]?.FindEntity(true) is not OnlineCreature oc
+            || oc.realizedCreature is not Player player)
+        {
+            counter = 0;
+            return;
+        }
+
+        Vector2 pos = Vector2.Lerp(player.bodyChunks[0].pos, player.bodyChunks[1].pos, 0.33333334f) - camera.pos;
+        hud.fadeCircles.Add(new FadeCircle(this.hud, 20f, 30f, 0.94f, 60f, 4f, pos, this.hud.fContainers[1]) { alphaMultiply = 0.5f, fadeThickness = false });
+
+        slatedForDeletion = true;
+    }
+}


### PR DESCRIPTION
A circle similar to the one on a player's death now originates from your spawn location in arena mode to notify you of where you spawned.

Closes https://github.com/henpemaz/Rain-Meadow/issues/855