### PR TITLE
fix compression making stuff bigger (just dont send the bigger stuff)

### DIFF
--- a/Online/Serialization/Serializer.cs
+++ b/Online/Serialization/Serializer.cs
@@ -126,7 +126,14 @@ namespace RainMeadow
             var pos = (int)scratchpad.Position;
             scratchpad.stream.Seek(0, SeekOrigin.Begin);
             var zippedState = new DeflateState(scratchpad.stream, pos);
-            RainMeadow.Debug($"zipping state {state}, was {pos} became ~{zippedState.bytes.Length}");
+            var zippedSize = zippedState.bytes.Length;
+            RainMeadow.Debug($"zipping state {state}, was {pos} became ~{zippedSize}");
+            if (zippedSize >= pos)
+            {
+                RainMeadow.Debug($"cancelling zipping of {state}");
+                scratchpad.stream.Seek(pos, SeekOrigin.Begin); //restore position
+                return false;
+            }
             return WriteState(zippedState);
         }
 


### PR DESCRIPTION
separate pr because lz4 pr tackles the "faster compr algo" problem, whereas this just tackles the general issue where bigger things are sent when they should just not