### PR TITLE
Fix player not being able to select prev slugcat in story mode

### DIFF
--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -53,7 +53,7 @@ namespace RainMeadow
             }
             set
             {
-                playerSelectedSlugcat = value == slugcatColorOrder[slugcatPageIndex]? null : value;
+                playerSelectedSlugcat = value == storyGameMode.currentCampaign? null : value;
                 CurrentSlugcat = PlayerSelectedSlugcat;
             }
         }


### PR DESCRIPTION
Happens when you try and select the previous slugcat campaign you selected previously as a owner.