### PR TITLE
remove buggy alt backspace

### DIFF
--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -66,7 +66,7 @@ namespace RainMeadow
             if (input == '\u007F') return;
             string msg = lastSentMessage;
             blockInput = false;
-            if ((input == '\b' || input == '\u0008') && !(Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt)))
+            if (input == '\b')
             {
                 if (cursorPos > 0 || selectionPos != -1)
                 {
@@ -142,15 +142,9 @@ namespace RainMeadow
                 // ctrl backspace stuff here instead of CaptureInputs, because ctrl + backspace doesn't always emit a capturable character on some operating systems
                 if (Input.GetKey(KeyCode.Backspace) && (cursorPos > 0 || selectionPos != -1))
                 {
-                    if ((Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt)) && backspaceHeld == 0)
-                    {
-                        lastSentMessage = "";
-                        menuLabel.text = lastSentMessage;
-                        cursorPos = 0;
-                        selectionPos = -1;
-                    }
+                    // no alt + backspace, because alt can be finnicky
                     // activates on either the first frame the key is held, or every other frame after it's been held down for half a second
-                    else if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) && (backspaceHeld == 0 || (backspaceHeld >= 30 && (backspaceHeld % 2 == 0))))
+                    if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) && (backspaceHeld == 0 || (backspaceHeld >= 30 && (backspaceHeld % 2 == 0))))
                     {
                         if (selectionPos != -1)
                         {


### PR DESCRIPTION
for whatever reason, alt will occasionally get stuck, causing regular backspace to clear the entire chat bar. it's happened with another mod of mine that uses alt, so i know it's not just the chat box.
seems like it's an issue with unity's input legacy module, maybe something to do with alt + tabbing. jank nonetheless