### PR TITLE
6fears7 story food bars

### DIFF
--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -30,6 +30,7 @@ public class RainMeadowOptions : OptionInterface
     public readonly Configurable<bool> WearingCape;
     public readonly Configurable<bool> StoryItemSteal;
     public readonly Configurable<bool> ArenaItemSteal;
+    public readonly Configurable<bool> StorySyncFoodBars;
 
 
     public readonly Configurable<float> ScrollSpeed;
@@ -90,6 +91,8 @@ public class RainMeadowOptions : OptionInterface
 
         StoryItemSteal = config.Bind("StoryItemSteal", false);
         ArenaItemSteal = config.Bind("ArenaItemSteal", false);
+
+        StorySyncFoodBars = config.Bind("StorySeparateFoodBars", true);
 
 
         PickedIntroRoll = config.Bind("PickedIntroRoll", IntroRoll.Meadow);
@@ -238,7 +241,7 @@ public class RainMeadowOptions : OptionInterface
 
             opTab.AddItems(GeneralUIArrPlayerOptions);
 
-            OnlineStorySettings = new UIelement[11]
+            OnlineStorySettings = new UIelement[13]
            {    new OpLabel(10f, 550f, Translate("Story"), bigText: true),
 
                 new OpLabel(10f, 500, Translate("Ready to shelter/gate"), bigText: false),
@@ -264,6 +267,13 @@ public class RainMeadowOptions : OptionInterface
                 new OpCheckBox(StoryItemSteal, new Vector2(10, 260)),
 
                 new OpLabel(40f, 260, RWCustom.Custom.ReplaceLineDelimeters(Translate("Steal items from other players in Story mode")))
+                {
+                    verticalAlignment = OpLabel.LabelVAlignment.Center
+                },
+
+                new OpCheckBox(StorySyncFoodBars, new Vector2(10, 170)),
+
+                new OpLabel(40f, 179, RWCustom.Custom.ReplaceLineDelimeters(Translate("Separate food bars")))
                 {
                     verticalAlignment = OpLabel.LabelVAlignment.Center
                 }

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -273,7 +273,7 @@ public class RainMeadowOptions : OptionInterface
 
                 new OpCheckBox(StorySyncFoodBars, new Vector2(10, 170)),
 
-                new OpLabel(40f, 179, RWCustom.Custom.ReplaceLineDelimeters(Translate("Separate food bars")))
+                new OpLabel(40f, 179, RWCustom.Custom.ReplaceLineDelimeters(Translate("Sync food bars")))
                 {
                     verticalAlignment = OpLabel.LabelVAlignment.Center
                 }

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -947,11 +947,9 @@ public partial class RainMeadow
         }
     }
 
-    public static bool sUpdateFood = true;
-
     private void Player_AddQuarterFood(On.Player.orig_AddQuarterFood orig, Player self)
     {
-        if (OnlineManager.lobby is null || !sUpdateFood)
+        if (OnlineManager.lobby is null || RainMeadow.rainMeadowOptions.StorySyncFoodBars.Value == false)
         {
             orig(self);
             return;
@@ -974,7 +972,7 @@ public partial class RainMeadow
 
     private void Player_AddFood(On.Player.orig_AddFood orig, Player self, int add)
     {
-        if (OnlineManager.lobby is null || !sUpdateFood)
+        if (OnlineManager.lobby is null || RainMeadow.rainMeadowOptions.StorySyncFoodBars.Value == false)
         {
             orig(self, add);
             return;
@@ -998,7 +996,7 @@ public partial class RainMeadow
 
     private void Player_SubtractFood(On.Player.orig_SubtractFood orig, Player self, int add)
     {
-        if (OnlineManager.lobby is null || !sUpdateFood)
+        if (OnlineManager.lobby is null || RainMeadow.rainMeadowOptions.StorySyncFoodBars.Value == false)
         {
             orig(self, add);
             return;

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -9,6 +9,7 @@ namespace RainMeadow
         public bool isInGame = false;
         public bool changedRegions = false;
         public bool readyForWin = false;
+        public bool syncFoodBars = RainMeadow.rainMeadowOptions.StorySyncFoodBars.Value;
         public enum ReadyForTransition : byte
         {
             Closed,

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -408,7 +408,7 @@ namespace RainMeadow
         private void Player_ctor_SynchronizeFoodBarForActualPlayers(On.Player.orig_ctor orig, Player self, AbstractCreature creature, World world)
         {
             orig(self, creature, world);
-            if (isStoryMode(out var storyGameMode) && !self.isNPC)
+            if (isStoryMode(out var storyGameMode) && !self.isNPC && storyGameMode.syncFoodBars)
             {
                 IntVector2 intVector = SlugcatStats.SlugcatFoodMeter(storyGameMode.currentCampaign);
                 self.slugcatStats.maxFood = intVector.x;

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -65,6 +65,7 @@ namespace RainMeadow
             public float minimumRippleLevel;
             [OnlineFieldHalf]
             public float maximumRippleLevel;
+            
 
             public State() { }
 
@@ -94,9 +95,11 @@ namespace RainMeadow
                     theGlow = storySession.saveState.theGlow;
                     reinforcedKarma = storySession.saveState.deathPersistentSaveData.reinforcedKarma;
                 }
-
-                food = (currentGameState?.Players[0].state as PlayerState)?.foodInStomach ?? 0;
-                quarterfood = (currentGameState?.Players[0].state as PlayerState)?.quarterFoodPoints ?? 0;
+                if (storyGameMode.syncFoodBars)
+                {
+                    food = (currentGameState?.Players[0].state as PlayerState)?.foodInStomach ?? 0;
+                    quarterfood = (currentGameState?.Players[0].state as PlayerState)?.quarterFoodPoints ?? 0;
+                }
                 mushroomCounter = (currentGameState?.Players[0].realizedCreature as Player)?.mushroomCounter ?? 0;
 
                 pups = new();
@@ -121,7 +124,7 @@ namespace RainMeadow
 
                 (lobby.gameMode as StoryGameMode).defaultDenPos = defaultDenPos;
 
-                if (playerstate != null)
+                if (playerstate != null && (lobby.gameMode as StoryGameMode).syncFoodBars)
                 {
                     playerstate.foodInStomach = food;
                     playerstate.quarterFoodPoints = quarterfood;

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -65,6 +65,8 @@ namespace RainMeadow
             public float minimumRippleLevel;
             [OnlineFieldHalf]
             public float maximumRippleLevel;
+            [OnlineField]
+            public bool syncFood;
             
 
             public State() { }
@@ -78,6 +80,7 @@ namespace RainMeadow
                 currentCampaign = storyGameMode.currentCampaign;
                 requireCampaignSlugcat = storyGameMode.requireCampaignSlugcat;
                 rippleLevel = storyGameMode.rippleLevel;
+                syncFood = storyGameMode.syncFoodBars;
 
                 isInGame = RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame && RWCustom.Custom.rainWorld.processManager.upcomingProcess is null;
                 changedRegions = storyGameMode.changedRegions;
@@ -95,7 +98,7 @@ namespace RainMeadow
                     theGlow = storySession.saveState.theGlow;
                     reinforcedKarma = storySession.saveState.deathPersistentSaveData.reinforcedKarma;
                 }
-                if (storyGameMode.syncFoodBars)
+                if (syncFood)
                 {
                     food = (currentGameState?.Players[0].state as PlayerState)?.foodInStomach ?? 0;
                     quarterfood = (currentGameState?.Players[0].state as PlayerState)?.quarterFoodPoints ?? 0;
@@ -121,10 +124,11 @@ namespace RainMeadow
                 var playerstate = (currentGameState?.Players[0].state as PlayerState);
                 var lobby = (resource as Lobby);
                 (lobby.gameMode as StoryGameMode).rippleLevel = rippleLevel;
+                (lobby.gameMode as StoryGameMode).syncFoodBars = syncFood;
 
                 (lobby.gameMode as StoryGameMode).defaultDenPos = defaultDenPos;
 
-                if (playerstate != null && (lobby.gameMode as StoryGameMode).syncFoodBars)
+                if (playerstate != null && syncFood)
                 {
                     playerstate.foodInStomach = food;
                     playerstate.quarterFoodPoints = quarterfood;


### PR DESCRIPTION
## Current Issues

- [ ] - Everyone starts with the same amount of food as the host has stored. This can either give everyone a lot of additional food, or remove a lot of food players would have had otherwise.,
- [ ] - If a non-host doesn't have sufficient food, it blocks shelters from closing even if the criteria for auto starve cycle are met. If the host doesn't have sufficient food, it works.,
- [ ] - Dead players' food bars are considered for determining starve cycle.,
- [ ] - If a starve cycle is initiated, the food bar shows it's a starve cycle for everyone, which is actually an improvement over current behavior. It doesn't fix an existing bug though where filling your food bar on a starve cycle will visually, but not mechanically remove starve debuff.,
- [ ] - If a starve cycle is initiated and someone joins the game during it, they don't get any starve effects, nor are they required to fill storage pips for the cycle to complete (this may be an existing bug).