### PR TITLE
Fix ChatHud weird interactions

### DIFF
--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -56,13 +56,12 @@ namespace RainMeadow
             {
                 typingHandler.Unassign(this);
                 typingHandler.OnDestroy();
-
+                blockInput = false;
             }
         }
         private void CaptureInputs(char input)
         {
             // the "Delete" character, which is emitted by most - but not all - operating systems when ctrl and backspace are used together
-            if (isUnloading) return;
             if (input == '\u007F') return;
             string msg = lastSentMessage;
             blockInput = false;
@@ -107,7 +106,7 @@ namespace RainMeadow
                 lastSentMessage = "";
                 return;
             }
-            else
+            else if (!isUnloading)
             {
                 if(selectionPos != -1)
                 {
@@ -128,7 +127,7 @@ namespace RainMeadow
                     cursorPos++;
                 }
             }
-            blockInput = true;
+            if (!isUnloading) blockInput = true;
             menuLabel.text = lastSentMessage;
         }
 

--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -48,7 +48,6 @@ namespace RainMeadow
                 typingHandler.StartCoroutine(Unload(delay));
             }
         }
-
         private IEnumerator Unload(float delay)
         {
             yield return new WaitForSeconds(delay);
@@ -63,6 +62,7 @@ namespace RainMeadow
         private void CaptureInputs(char input)
         {
             // the "Delete" character, which is emitted by most - but not all - operating systems when ctrl and backspace are used together
+            if (isUnloading) return;
             if (input == '\u007F') return;
             string msg = lastSentMessage;
             blockInput = false;

--- a/OnlineUIComponents/ChatHud.cs
+++ b/OnlineUIComponents/ChatHud.cs
@@ -65,7 +65,7 @@ namespace RainMeadow
         public override void Draw(float timeStacker)
         {
             base.Draw(timeStacker);
-            if (chatInputOverlay is null && Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatLogKey.Value))
+            if (chatInputOverlay is null && Input.GetKeyUp(RainMeadow.rainMeadowOptions.ChatLogKey.Value))
             {
                 if (chatLogOverlay is not null)
                 {
@@ -81,14 +81,14 @@ namespace RainMeadow
                     isLogToggled = true;
                 }
             }
-            if (Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
+            if (Input.GetKeyUp(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
             {
-                if (chatInputOverlay is not null)
+                /*if (chatInputOverlay is not null) remove this cuz blockInput kinda makes this obsolete
                 {
                     ShutDownChatInput();
                     if (!showChatLog && chatLogOverlay is not null) ShutDownChatLog();
-                }
-                else if (!textPrompt.pausedMode && !ShouldForceCloseChat)
+                }*/
+                if (chatInputOverlay == null && !textPrompt.pausedMode && !ShouldForceCloseChat)
                 {
                     RainMeadow.Debug("creating input");
                     chatInputOverlay = new ChatInputOverlay(game.manager);
@@ -139,7 +139,6 @@ namespace RainMeadow
             {
                 chatInputOverlay.chat.DelayedUnload(0.1f);
                 chatInputOverlay.ShutDownProcess();
-                ChatTextBox.blockInput = false;
                 chatInputOverlay = null;
             }
         }

--- a/OnlineUIComponents/ChatHud.cs
+++ b/OnlineUIComponents/ChatHud.cs
@@ -83,11 +83,6 @@ namespace RainMeadow
             }
             if (Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
             {
-                if (chatInputOverlay is not null)
-                {
-                    ShutDownChatInput();
-                    if (!showChatLog && chatLogOverlay is not null) ShutDownChatLog();
-                }
                 if (chatInputOverlay == null && !textPrompt.pausedMode && !ShouldForceCloseChat)
                 {
                     RainMeadow.Debug("creating input");

--- a/OnlineUIComponents/ChatHud.cs
+++ b/OnlineUIComponents/ChatHud.cs
@@ -149,16 +149,22 @@ namespace RainMeadow
 
         public void Destroy()
         {
+            RainMeadow.DebugMe();
+            if (chatInputOverlay != null) ShutDownChatInput();
+            if (chatLogOverlay != null) ShutDownChatLog();
             ChatTextBox.OnShutDownRequest -= ShutDownChatInput;
             ChatLogManager.Unsubscribe(this);
         }
-
+        public override void ClearSprites()
+        {
+            base.ClearSprites();
+            Destroy();
+        }
         public override void Update()
         {
             base.Update();
 
-            if (slatedForDeletion) { Destroy(); return; }
-
+            if (slatedForDeletion) { return; }
             if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is MeadowGameMode) return;
 
             if (game.pauseMenu != null || camera.hud?.map?.visible is true || game.manager.upcomingProcess != null)

--- a/OnlineUIComponents/ChatHud.cs
+++ b/OnlineUIComponents/ChatHud.cs
@@ -65,69 +65,64 @@ namespace RainMeadow
         public override void Draw(float timeStacker)
         {
             base.Draw(timeStacker);
-            if (!ShouldForceCloseChat)
+            if (chatInputOverlay is null && Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatLogKey.Value))
             {
-                if (chatInputActive)
+                if (chatLogOverlay is not null)
                 {
-                    if (Input.GetKey(KeyCode.UpArrow))
-                    {
-                        if (currentLogIndex < chatLog.Count - 1)
-                        {
-                            currentLogIndex++;
-                            chatLogOverlay?.UpdateLogDisplay();
-                        }
-                    }
-
-                    if (Input.GetKey(KeyCode.DownArrow))
-                    {
-                        if (currentLogIndex > 0)
-                        {
-                            currentLogIndex--;
-                            chatLogOverlay?.UpdateLogDisplay();
-                        }
-                    }
+                    ShutDownChatLog();
+                    showChatLog = false;
+                    isLogToggled = false;
                 }
-
-                if (chatInputOverlay is null && Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatLogKey.Value))
+                else if (!textPrompt.pausedMode && !ShouldForceCloseChat)
                 {
-                    if (chatLogOverlay is not null)
-                    {
-                        ShutDownChatLog();
-                        showChatLog = false;
-                        isLogToggled = false;
-                    }
-                    else if (!textPrompt.pausedMode)
+                    RainMeadow.Debug("creating log");
+                    chatLogOverlay = new ChatLogOverlay(this, game.manager);
+                    showChatLog = true;
+                    isLogToggled = true;
+                }
+            }
+            if (Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
+            {
+                if (chatInputOverlay is not null)
+                {
+                    ShutDownChatInput();
+                    if (!showChatLog && chatLogOverlay is not null) ShutDownChatLog();
+                }
+                else if (!textPrompt.pausedMode && !ShouldForceCloseChat)
+                {
+                    RainMeadow.Debug("creating input");
+                    chatInputOverlay = new ChatInputOverlay(game.manager);
+                    if (chatLogOverlay is null)
                     {
                         RainMeadow.Debug("creating log");
                         chatLogOverlay = new ChatLogOverlay(this, game.manager);
-                        showChatLog = true;
-                        isLogToggled = true;
+                    }
+                }
+            }
+            if (chatInputActive)
+            {
+                if (Input.GetKey(KeyCode.UpArrow))
+                {
+                    if (currentLogIndex < chatLog.Count - 1)
+                    {
+                        currentLogIndex++;
+                        chatLogOverlay?.UpdateLogDisplay();
                     }
                 }
 
-                if (Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
+                if (Input.GetKey(KeyCode.DownArrow))
                 {
-                    if (chatInputOverlay is not null)
+                    if (currentLogIndex > 0)
                     {
-                        ShutDownChatInput();
-                        if (!showChatLog && chatLogOverlay is not null) ShutDownChatLog();
-                    }
-                    else if (!textPrompt.pausedMode)
-                    {
-                        RainMeadow.Debug("creating input");
-                        chatInputOverlay = new ChatInputOverlay(game.manager);
-                        if (chatLogOverlay is null)
-                        {
-                            RainMeadow.Debug("creating log");
-                            chatLogOverlay = new ChatLogOverlay(this, game.manager);
-                        }
+                        currentLogIndex--;
+                        chatLogOverlay?.UpdateLogDisplay();
                     }
                 }
             }
             chatLogOverlay?.GrafUpdate(timeStacker);
             chatInputOverlay?.GrafUpdate(timeStacker);
         }
-
+    
         public void ShutDownChatLog()
         {
             RainMeadow.DebugMe();

--- a/OnlineUIComponents/ChatHud.cs
+++ b/OnlineUIComponents/ChatHud.cs
@@ -65,7 +65,7 @@ namespace RainMeadow
         public override void Draw(float timeStacker)
         {
             base.Draw(timeStacker);
-            if (chatInputOverlay is null && Input.GetKeyUp(RainMeadow.rainMeadowOptions.ChatLogKey.Value))
+            if (chatInputOverlay is null && Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatLogKey.Value))
             {
                 if (chatLogOverlay is not null)
                 {
@@ -81,13 +81,13 @@ namespace RainMeadow
                     isLogToggled = true;
                 }
             }
-            if (Input.GetKeyUp(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
+            if (Input.GetKeyDown(RainMeadow.rainMeadowOptions.ChatButtonKey.Value))
             {
-                /*if (chatInputOverlay is not null) remove this cuz blockInput kinda makes this obsolete
+                if (chatInputOverlay is not null)
                 {
                     ShutDownChatInput();
                     if (!showChatLog && chatLogOverlay is not null) ShutDownChatLog();
-                }*/
+                }
                 if (chatInputOverlay == null && !textPrompt.pausedMode && !ShouldForceCloseChat)
                 {
                     RainMeadow.Debug("creating input");


### PR DESCRIPTION
Currently there are some bugs in chat hud

- spamming the chat button input multiple times can cause a bug where you can't move, pause or do anything at all (at anytime while chat hud is active)
- sometimes when toggling chat as the game unloads it can cause the chat sprites to then be visible throughout until you reopen rw
- spamming chat button input and sending messages also causes the chat to break and you can no longer open chat input (breaks very easily with '/' possibly with other typeable characters)

This pr is made to solve those issues

- [x] playtest every possible scenario to ensure there are no problems