### PR TITLE
patch spears clipping in edge cases

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1087,11 +1087,6 @@ public partial class RainMeadow
             {
                 RainMeadow.Error("player entity not found for " + self + " " + self.abstractCreature);
             }
-            if (oe is not null)
-            {
-                slugcatStatsPerPlayer.Add(self, new SlugcatStats(self.SlugCatClass, self.slugcatStats.malnourished));
-                RainMeadow.Debug($"slugcatstats:{self.SlugCatClass} owner:{oe.owner}");
-            }
 
             // Allow glow for any non-watcher in watcher campaign
             if (ModManager.Watcher && self.room.game.session is StoryGameSession storyGameSession && self.rippleLevel > 0f && self.room != null && self.AI == null)
@@ -1119,6 +1114,8 @@ public partial class RainMeadow
                 {
                     RainMeadow.Debug("no SlugcatCustomization for " + oe);
                 }
+                slugcatStatsPerPlayer.Add(self, new SlugcatStats(self.SlugCatClass, self.slugcatStats.malnourished));
+                RainMeadow.Debug($"slugcatstats:{self.SlugCatClass} owner:{oe.owner}");
             }
             else
             {


### PR DESCRIPTION
note: this is a vanilla issue, which i planned on creating a separate mod to fix, but considering it's by far most noticeable in rain meadow (and meadow will probably be blamed for it), i thought it would fit here
patches the following edge cases (specifically for slugcat on slugcat violence, so as to minimize invasiveness), which would cause spears to inexplicably miss/'not register':
weapons flying in between body chunk hitboxes, and subsequently missing (by snapping to the nearest body chunk if it goes in between)
weapons missing from being thrown too close to a small body chunk, and starting on the other side (by making weapons start farther back)

i haven't done super thorough testing, but both patches function properly and the game doesn't immediately break