### PR TITLE
patch spears clipping in edge cases

### DIFF
--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -66,6 +66,8 @@ namespace RainMeadow
             public string currentGameMode;
             [OnlineField]
             public bool arenaItemSteal;
+            [OnlineField]
+            public bool weaponCollisionFix;
             public State() { }
             public State(ArenaLobbyData arenaLobbyData, OnlineResource onlineResource)
             {
@@ -96,6 +98,7 @@ namespace RainMeadow
                 disableMaul = arena.disableMaul;
                 disableArtiStun = arena.disableArtiStun;
                 arenaItemSteal = arena.itemSteal;
+                weaponCollisionFix = arena.weaponCollisionFix;
             }
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
@@ -127,6 +130,7 @@ namespace RainMeadow
                 (lobby.gameMode as ArenaOnlineGameMode).disableArtiStun = disableArtiStun;
                 (lobby.gameMode as ArenaOnlineGameMode).disableMaul = disableMaul;
                 (lobby.gameMode as ArenaOnlineGameMode).itemSteal = arenaItemSteal;
+                (lobby.gameMode as ArenaOnlineGameMode).weaponCollisionFix = weaponCollisionFix;
 
             }
 

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -30,6 +30,7 @@ public class RainMeadowOptions : OptionInterface
     public readonly Configurable<bool> WearingCape;
     public readonly Configurable<bool> StoryItemSteal;
     public readonly Configurable<bool> ArenaItemSteal;
+    public readonly Configurable<bool> WeaponCollisionFix;
 
 
     public readonly Configurable<float> ScrollSpeed;
@@ -83,6 +84,7 @@ public class RainMeadowOptions : OptionInterface
         PainCatLizard = config.Bind("PainCatLizard", true);
         BlockMaul = config.Bind("BlockMaul", false);
         BlockArtiStun = config.Bind("BlockArtiStun", false);
+        WeaponCollisionFix = config.Bind("WeaponCollisionFix", true);
         ShowPing = config.Bind("ShowPing", false);
         ShowPingLocation = config.Bind("ShowPingLocation", 0);
         ScrollSpeed = config.Bind("ScrollSpeed", 10f);

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -92,8 +92,12 @@ namespace RainMeadow
         // meant to fix spears going in between body chunks in arena mode, but could also be useful for other potential pvp-focused gamemodes
         public static SharedPhysics.CollisionResult SharedPhysics_TraceProjectileAgainstBodyChunks(On.SharedPhysics.orig_TraceProjectileAgainstBodyChunks orig, SharedPhysics.IProjectileTracer projTracer, Room room, Vector2 lastPos, ref Vector2 pos, float rad, int collisionLayer, PhysicalObject exemptObject, bool hitAppendages)
         {
+            if (OnlineManager.lobby == null || !(RainMeadow.isArenaMode(out var arena) ? arena.weaponCollisionFix : RainMeadow.rainMeadowOptions.WeaponCollisionFix.Value))
+            {
+                return orig(projTracer, room, lastPos, ref pos, rad, collisionLayer, exemptObject, hitAppendages);
+            }
             var result = orig(projTracer, room, lastPos, ref pos, rad, collisionLayer, exemptObject, hitAppendages);
-            if (OnlineManager.lobby != null && result.chunk == null && result.onAppendagePos == null && exemptObject is Player)
+            if (result.chunk == null && result.onAppendagePos == null && exemptObject is Player)
             {
                 // only need to check the collision layer that slugcats occupy
                 foreach (var obj in room.physicalObjects[1])
@@ -105,7 +109,6 @@ namespace RainMeadow
                         var chunk2 = obj.bodyChunks[1];
                         var p = Custom.LineIntersection(lastPos, pos, chunk1.pos, chunk2.pos);
                         if (Custom.DistLess(p, lastPos, Vector2.Distance(lastPos, pos)) && Custom.DistLess(p, pos, Vector2.Distance(lastPos, pos)) && Custom.DistLess(p, chunk1.pos, Vector2.Distance(chunk1.pos, chunk2.pos)) && Custom.DistLess(p, chunk2.pos, Vector2.Distance(chunk1.pos, chunk2.pos)))
-
                         {
                             if (Custom.Dist(chunk1.pos, pos) < Custom.Dist(chunk2.pos, pos))
                             {
@@ -124,7 +127,7 @@ namespace RainMeadow
 
         private static void Weapon_Thrown(On.Weapon.orig_Thrown orig, Weapon self, Creature thrownBy, Vector2 thrownPos, Vector2? firstFrameTraceFromPos, IntVector2 throwDir, float frc, bool eu)
         {
-            if (OnlineManager.lobby != null && thrownBy is Player && firstFrameTraceFromPos != null)
+            if (OnlineManager.lobby != null && (RainMeadow.isArenaMode(out var arena) ? arena.weaponCollisionFix : RainMeadow.rainMeadowOptions.WeaponCollisionFix.Value) && thrownBy is Player && firstFrameTraceFromPos != null)
             {
                 // move back last position, so that the spear traces starting from the throw chunk
                 self.firstChunk.lastPos = firstFrameTraceFromPos.Value;

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -32,6 +32,7 @@ namespace RainMeadow
         public bool disableMaul = RainMeadow.rainMeadowOptions.BlockMaul.Value;
         public bool disableArtiStun = RainMeadow.rainMeadowOptions.BlockArtiStun.Value;
         public bool itemSteal = RainMeadow.rainMeadowOptions.ArenaItemSteal.Value;
+        public bool weaponCollisionFix = RainMeadow.rainMeadowOptions.WeaponCollisionFix.Value;
 
         public string paincatName;
         public int lizardEvent;


### PR DESCRIPTION
note: this is a vanilla issue, which i planned on creating a separate mod to fix, but considering it's by far most noticeable in rain meadow (and meadow will probably be blamed for it), i thought it would fit here

patches the following edge cases (specifically for slugcat on slugcat violence, so as to minimize invasiveness), which would cause spears to inexplicably miss/'not register':
- weapons flying in between body chunk hitboxes, and subsequently missing (by snapping to the nearest body chunk if it goes in between)
- weapons missing from being thrown too close to a small body chunk, and starting on the other side (by making weapons start farther back)

i haven't done super thorough testing, but both patches function properly and the game doesn't immediately break
also it might be a little bit better if the SharedPhysics.TraceProjectileAgainstBodyChunks is an il hook, but i spent about two hours fumbling around with it and inexplicably being unable to