### PR TITLE
6fears7-handle-nullBodyChunks

### DIFF
--- a/Online/State/BodyChunkRef.cs
+++ b/Online/State/BodyChunkRef.cs
@@ -16,13 +16,14 @@ namespace RainMeadow
             this.onlineOwner = owner.id;
             this.index = (byte)index;
         }
-
+        
         public static BodyChunkRef? FromBodyChunk(BodyChunk? bodyChunk)
         {
             if (bodyChunk is null) return null;
             if (!OnlinePhysicalObject.map.TryGetValue(bodyChunk.owner.abstractPhysicalObject, out var oe))
             {
-                throw new InvalidProgrammerException("body chunk owner doesn't exist in online space! " + bodyChunk.owner.abstractPhysicalObject);
+                RainMeadow.Error("body chunk owner doesn't exist in online space! " + bodyChunk.owner.abstractPhysicalObject);
+                return null;
             }
             return new BodyChunkRef(oe, bodyChunk.index);
         }


### PR DESCRIPTION
Handles scenarios where a player is unexpectedly unrealized (quits game with spear, gets derealized with spear embedded, eaten by wormgrass with attached objects). This currently throws the exception indefinitely and blocks networking from continuing.