### PR TITLE
AFK sleep fixes

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1050,11 +1050,6 @@ public partial class RainMeadow
     }
 
     //Used to emulate having a new int in the Player class.
-    public static ConditionalWeakTable<Player, AbleToSleepTimer> playerAbleToSleep = new();
-    public class AbleToSleepTimer
-    {
-        public int timer = 0;
-    }
     private void Player_Update1(On.Player.orig_Update orig, Player self, bool eu)
     {
         if (OnlineManager.lobby != null && self.objectInStomach != null)
@@ -1150,30 +1145,28 @@ public partial class RainMeadow
         }
 
         //Sleeping when AFK
-        if (OnlineManager.lobby != null && self.IsLocal())
+        if (OnlineManager.lobby != null)
         {
-            var ableToSleep = playerAbleToSleep.GetOrCreateValue(self);
             if (self.sleepCounter == 0 && //Check we're not already sleeping in a shelter; otherwise waking up from a shelter can trigger AFK sleep instantly.
                 ( //Check if we can fit a sleeping animation.
                     (self.bodyMode == Player.BodyModeIndex.Stand && self.IsTileSolid(1, -1, -1) && self.IsTileSolid(1, 0, -1) && self.IsTileSolid(1, 1, -1)) ||
                     (self.bodyMode == Player.BodyModeIndex.Crawl && self.IsTileSolid(0, 0, -1) && self.IsTileSolid(1, 0, -1))
                 )
                )
-            {
-                ableToSleep.timer++;
-            }
+            {}
             else
             {
-                ableToSleep.timer = 0;
+                //Hack; this avoids needing an additional (synced) variable to track how long a player has been in a valid spot,
+                //at the cost of potentially disrupting anything expecting touchedNoInputCounter to be above 1000 (which nothing in vanilla or meadow comes close to).
+                self.touchedNoInputCounter = Math.Min(self.touchedNoInputCounter, 1000);
             }
-            if (self.touchedNoInputCounter > 1200 && ableToSleep.timer > 200)
+            if (self.touchedNoInputCounter > 1200)
             {
                 self.standing = false;
                 self.sleepCurlUp = Mathf.Max(wasSleepCurlUp, self.sleepCurlUp); // prevent decay
                 self.sleepCurlUp = Mathf.Min(1f, self.sleepCurlUp + 0.02f); // add up
             }
         }
-
     }
 
     private UnityEngine.Color Player_ShortCutColor(On.Player.orig_ShortCutColor orig, Player self)

--- a/Online/State/RealizedPlayerState.cs
+++ b/Online/State/RealizedPlayerState.cs
@@ -115,6 +115,8 @@ namespace RainMeadow
         private bool glowing;
         [OnlineFieldHalf]
         public float sleepCurlUp;
+        [OnlineField]
+        public int touchedNoInputCounter;
         [OnlineField(nullable = true)]
         private OnlineEntity.EntityId? spearOnBack;
         [OnlineField(nullable = true)]
@@ -160,6 +162,7 @@ namespace RainMeadow
             flipDirection = p.flipDirection > 0;
             glowing = p.glowing;
             sleepCurlUp = p.sleepCurlUp;
+            touchedNoInputCounter = p.touchedNoInputCounter;
             burstX = p.burstX;
             burstY = p.burstY;
             spearOnBack = (p.spearOnBack?.spear?.abstractPhysicalObject is AbstractPhysicalObject apo
@@ -268,6 +271,7 @@ namespace RainMeadow
             p.flipDirection = flipDirection ? 1 : -1;
             p.glowing = glowing;
             p.sleepCurlUp = sleepCurlUp;
+            p.touchedNoInputCounter = touchedNoInputCounter;
 
             if (p.spearOnBack != null)
                 p.spearOnBack.spear = (spearOnBack?.FindEntity() as OnlinePhysicalObject)?.apo?.realizedObject as Spear;


### PR DESCRIPTION
Fix for complete failure to sync AFK sleep on main. This version only requires 2 synced variables instead of the original 3; 2 is the absolute bare minimum without substantial and aggressive changes to vanilla sleep functionality.