### PR TITLE
Fix crash in arena menu

### DIFF
--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -50,6 +50,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
         if (backObject is SimplerButton btn) btn.description = Translate("Exit to Lobby Select");
         if (Arena.myArenaSetup == null) manager.arenaSetup = Arena.myArenaSetup = new ArenaOnlineSetup(manager); //loading it on game mode ctor loads the base setup prob due to lobby still being null
         Futile.atlasManager.LoadAtlas("illustrations/arena_ui_elements");
+        Futile.atlasManager.LoadAtlas("illustrations/ui_elements");
         if (Arena.currentGameMode == "" || Arena.currentGameMode == null)
             Arena.currentGameMode = FFA.FFAMode.value;
 


### PR DESCRIPTION
based on 
```
[Error  :RainMeadow] FutileException: Couldn't find element named 'Meadow_Menu_Ping'. 
Use Futile.atlasManager.LogAllElementNames() to see a list of all loaded elements names
  at FAtlasManager.GetElementWithName (System.String elementName) [0x000dd] in <0d3d3bd248b74a708fd84538ba1e82f5>:0 
  at FSprite..ctor (System.String elementName, System.Boolean quadType) [0x00000] in <0d3d3bd248b74a708fd84538ba1e82f5>:0 
  at RainMeadow.UI.Components.ArenaPlayerBox..ctor (Menu.Menu menu, Menu.MenuObject owner, RainMeadow.OnlinePlayer player, System.Boolean canKick, UnityEngine.Vector2 pos, UnityEngine.Vector2 size) [0x00074] in /Arena/ArenaPlayerBox.cs:45 
  at RainMeadow.UI.Pages.ArenaMainLobbyPage.GetPlayerButton (RainMeadow.UI.Components.PlayerDisplayer playerDisplay, System.Boolean isLargeDisplay, RainMeadow.OnlinePlayer player, UnityEngine.Vector2 pos) [0x00007] in /Menu/Pages/ArenaMainLobbyPage.cs:116 
  at RainMeadow.UI.Components.PlayerDisplayer.PopulatePlayerDisplays (RainMeadow.UI.Components.ButtonDisplayer buttonDisplayer, System.Boolean isLargeDisplay) [0x0004e] in /Menu/Components/PlayerDisplayer.cs:38 
```
just adds another method to load the desired atlas incase it doesnt get loaded earlier by LobbySelectMenu