### PR TITLE
Prevent SaveToFile in ArenaOnlineLobbyMenu

### DIFF
--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -33,6 +33,7 @@ namespace RainMeadow
             IL.Menu.SlugcatSelectMenu.SlugcatPage.AddImage += SlugcatPage_AddImage;
 
             On.Menu.MenuScene.BuildScene += MenuScene_BuildScene;
+            On.Menu.MenuScene.SaveToFile += On_MenuScene_SaveToFile;
 
             On.Menu.SlugcatSelectMenu.SlugcatUnlocked += SlugcatSelectMenu_SlugcatUnlocked;
             On.Menu.SlugcatSelectMenu.StartGame += SlugcatSelectMenu_StartGame;
@@ -154,7 +155,15 @@ namespace RainMeadow
                 orig(self);
             }
         }
-
+        private void On_MenuScene_SaveToFile(On.Menu.MenuScene.orig_SaveToFile orig, MenuScene self)
+        {
+            if (self.menu is ArenaOnlineLobbyMenu && self.flatMode)
+            {
+                Debug("Prevented overriding positions.txt");
+                return;
+            }
+            orig(self);
+        }
         private void MenuScene_BuildScene(On.Menu.MenuScene.orig_BuildScene orig, MenuScene self)
         {
             orig(self);


### PR DESCRIPTION
Prevents MenuScene from overriding positions.txt by pressing b with dev tools enabled in ArenaOnlineLobbyMenu.

Highly likely was the leading cause of this bug due to how ArenaOnlineLobbyMenu's bg forcefully uses flatmode instead

This is actually a vanilla bug that can be replicated by going to options menu with dev tools, click on low/medium quality, pressing B and then reverting back to high quality. However this can be easily fixed via verify integrity

tho seems like people tend to have dev tools in arena and this bug has happened enough times to kinda be a concern to me

<img width="3200" height="1800" alt="image" src="https://github.com/user-attachments/assets/f683831d-6d78-4fac-9b18-21a8ec27a3c9" />

