### PR TITLE
Fix hidden emote wheel behavior

### DIFF
--- a/Meadow/MeadowEmoteHud.cs
+++ b/Meadow/MeadowEmoteHud.cs
@@ -351,8 +351,6 @@ namespace RainMeadow
                 hud.owner.PlayHUDSound(radialVisible ? SoundID.MENU_Checkbox_Check : SoundID.MENU_Checkbox_Uncheck);
             }
 
-            if (radialVisible || radialPickerActive) radialDisplayer.positionssss(initradialtime, fliptotheright);
-
             if (!toggleHidden && radialVisible && !radialPickerActive) // mouse input
             {
                 Vector2 offset = ((Vector2)Futile.mousePosition - this.mainWheelPos);
@@ -444,6 +442,8 @@ namespace RainMeadow
                     }
                 }
             }
+
+            if (radialVisible || radialPickerActive) radialDisplayer.positionssss(initradialtime, fliptotheright);
 
             if (radialPickerActive)
             {

--- a/Meadow/MeadowEmoteHud.cs
+++ b/Meadow/MeadowEmoteHud.cs
@@ -351,7 +351,7 @@ namespace RainMeadow
                 hud.owner.PlayHUDSound(radialVisible ? SoundID.MENU_Checkbox_Check : SoundID.MENU_Checkbox_Uncheck);
             }
 
-            if (radialVisible) radialDisplayer.positionssss(initradialtime, fliptotheright);
+            if (radialVisible || radialPickerActive) radialDisplayer.positionssss(initradialtime, fliptotheright);
 
             if (!toggleHidden && radialVisible && !radialPickerActive) // mouse input
             {
@@ -588,7 +588,7 @@ namespace RainMeadow
                 this.knobSprite.x = knobDrawPos.x * (mainWheelRad - 18f) + mainWheelPos.x;
                 this.knobSprite.y = knobDrawPos.y * (mainWheelRad - 18f) + mainWheelPos.y;
 
-                centerLabel.isVisible = true;
+                centerLabel.isVisible = radialDisplayer.isVisible;
             }
         }
 


### PR DESCRIPTION
Fixes two bugs related to the radial emote selector simultaneously being in "hidden" mode and having its hotkey pressed:
- The text "CANCEL" would get permanently stuck onscreen until the emote wheel was unhidden.
- Only the first hotkey press after hiding the wheel would render emotes onto the wheel.