### PR TITLE
Various fixes and improvements to afk sleep

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1157,7 +1157,7 @@ public partial class RainMeadow
             {
                 if (self.sleepCounter == 0 && //Check we're not already sleeping in a shelter; otherwise waking up from a shelter can trigger AFK sleep instantly.
                     self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong without a good way to fix).
-                    ( //Check if we can fit a sleeping animation.
+                    ( //Check if we can fit a sleeping animation (the animation checks double as consiousness check).
                         (self.bodyMode == Player.BodyModeIndex.Stand && self.IsTileSolid(1, -1, -1) && self.IsTileSolid(1, 0, -1) && self.IsTileSolid(1, 1, -1)) ||
                         (self.bodyMode == Player.BodyModeIndex.Crawl && self.IsTileSolid(0, 0, -1) && self.IsTileSolid(1, 0, -1))
                     )
@@ -1183,8 +1183,8 @@ public partial class RainMeadow
                 self.sleepCurlUp = 0f;
             }
             if (ModManager.MSC && self.SlugCatClass == MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Spear && extras.afkSleep && self.sleepCurlUp == 1f)
-            { //For reasons beyond my comprehension, Spearmaster specifically has a weirdly specific check to make them *not* close their eyes when sleepCurlUp but not sleepCounter.
-                self.Blink(2); //Naturally this breaks Spearmaster's AFK sleep animation, so I need an equally specific check to add the closed eyes back.
+            { //For reasons beyond my comprehension, PlayerBlink() has a weird, possibly unintended "else" that makes specifically Spearmaster *not* close their eyes during sleepCurlUp.
+                self.Blink(2); //Vanilla only avoids this issue because sleepCounter also closes eyes directly using Blink(). We're not using sleepCounter, so Spearmaster needs this insomnia cure.
             }
         }
     }

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1155,8 +1155,7 @@ public partial class RainMeadow
             var extras = playerExtras.GetOrCreateValue(self); 
             if (self.IsLocal())
             {
-                if (self.sleepCounter != 0 || //Reuse afk sleep to sync the shelter sleeping animation.
-                    !self.stillInStartShelter && //For some reason waking up from shelter sleep doesn't reset touchedNoInputCounter, so this prevents waking up immediately retriggering AFK sleep.
+                if (!self.stillInStartShelter && //For some reason waking up from shelter sleep doesn't reset touchedNoInputCounter, so this prevents waking up immediately retriggering AFK sleep.
                     self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong).
                     ( //Check if we can fit a sleeping animation (the animation checks double as a consiousness check).
                         (self.bodyMode == Player.BodyModeIndex.Stand && self.IsTileSolid(1, -1, -1) && self.IsTileSolid(1, 0, -1) && self.IsTileSolid(1, 1, -1)) ||

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1054,6 +1054,8 @@ public partial class RainMeadow
     {
         public bool afkSleep;
     }
+    public int afkSleepRequiredTime = 1200;
+    public int timeSinceShelterWakeup;
 
     private void Player_Update1(On.Player.orig_Update orig, Player self, bool eu)
     {
@@ -1152,16 +1154,21 @@ public partial class RainMeadow
         //Sleeping when AFK
         if (OnlineManager.lobby != null)
         {
-            var extras = playerExtras.GetOrCreateValue(self); 
+            var extras = playerExtras.GetOrCreateValue(self);
+            if (self.sleepCounter > 0)
+            { timeSinceShelterWakeup = 0; }
+            else
+            { timeSinceShelterWakeup++; }
+
             if (self.IsLocal())
             {
-                if (!self.stillInStartShelter && //For some reason waking up from shelter sleep doesn't reset touchedNoInputCounter, so this prevents waking up immediately retriggering AFK sleep.
+                if (timeSinceShelterWakeup > afkSleepRequiredTime && //Both touchedNoInputCounter and stillInStartShelter are bugged/unreliable, so congrats, you get your own variable. Now STOP FALLING ASLEEP WHEN WAKING UP.
                     self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong).
                     ( //Check if we can fit a sleeping animation (the animation checks double as a consiousness check).
                         (self.bodyMode == Player.BodyModeIndex.Stand && self.IsTileSolid(1, -1, -1) && self.IsTileSolid(1, 0, -1) && self.IsTileSolid(1, 1, -1)) ||
                         (self.bodyMode == Player.BodyModeIndex.Crawl && self.IsTileSolid(0, 0, -1) && self.IsTileSolid(1, 0, -1))
                     )
-                    && self.touchedNoInputCounter > 1200
+                    && self.touchedNoInputCounter > afkSleepRequiredTime
                 )
                 {
                     extras.afkSleep = true;

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1156,6 +1156,7 @@ public partial class RainMeadow
             if (self.IsLocal())
             {
                 if (self.sleepCounter == 0 && //Check we're not already sleeping in a shelter; otherwise waking up from a shelter can trigger AFK sleep instantly.
+                    self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong).
                     ( //Check if we can fit a sleeping animation.
                         (self.bodyMode == Player.BodyModeIndex.Stand && self.IsTileSolid(1, -1, -1) && self.IsTileSolid(1, 0, -1) && self.IsTileSolid(1, 1, -1)) ||
                         (self.bodyMode == Player.BodyModeIndex.Crawl && self.IsTileSolid(0, 0, -1) && self.IsTileSolid(1, 0, -1))
@@ -1176,8 +1177,9 @@ public partial class RainMeadow
                 self.sleepCurlUp = Mathf.Max(wasSleepCurlUp, self.sleepCurlUp); // prevent decay
                 self.sleepCurlUp = Mathf.Min(1f, self.sleepCurlUp + 0.02f); // add up
             }
-            if (self.sleepCurlUp > 0 && (self.dead || self.Stunned)) //When stunned or dead, the vanilla code stops decaying sleepCurlUp so we need to handle it ourselves. Technically this fixes an esoteric vanilla bug too.
+            if (self.sleepCurlUp > 0 && !self.Consious) //When stunned or dead, the vanilla code stops decaying sleepCurlUp so we need to handle it ourselves. Technically this fixes an esoteric vanilla bug too.
             {
+                //RainMeadow.Debug("Wake up and feel the PAIN, slugcat!");
                 self.sleepCurlUp = 0f;
             }
         }

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1155,14 +1155,15 @@ public partial class RainMeadow
             var extras = playerExtras.GetOrCreateValue(self); 
             if (self.IsLocal())
             {
-                if (self.sleepCounter == 0 && //Check we're not already sleeping in a shelter; otherwise waking up from a shelter can trigger AFK sleep instantly.
-                    self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong without a good way to fix).
-                    ( //Check if we can fit a sleeping animation (the animation checks double as consiousness check).
+                if (self.sleepCounter != 0 || //Reuse afk sleep to sync the shelter sleeping animation.
+                    !self.stillInStartShelter && //For some reason waking up from shelter sleep doesn't reset touchedNoInputCounter, so this prevents waking up immediately retriggering AFK sleep.
+                    self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong).
+                    ( //Check if we can fit a sleeping animation (the animation checks double as a consiousness check).
                         (self.bodyMode == Player.BodyModeIndex.Stand && self.IsTileSolid(1, -1, -1) && self.IsTileSolid(1, 0, -1) && self.IsTileSolid(1, 1, -1)) ||
                         (self.bodyMode == Player.BodyModeIndex.Crawl && self.IsTileSolid(0, 0, -1) && self.IsTileSolid(1, 0, -1))
                     )
                     && self.touchedNoInputCounter > 1200
-                   )
+                )
                 {
                     extras.afkSleep = true;
                 }

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1156,7 +1156,7 @@ public partial class RainMeadow
             if (self.IsLocal())
             {
                 if (self.sleepCounter == 0 && //Check we're not already sleeping in a shelter; otherwise waking up from a shelter can trigger AFK sleep instantly.
-                    self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong).
+                    self.onBack == null && //Check we're not piggybacking someone else (hilarious but looked very wrong without a good way to fix).
                     ( //Check if we can fit a sleeping animation.
                         (self.bodyMode == Player.BodyModeIndex.Stand && self.IsTileSolid(1, -1, -1) && self.IsTileSolid(1, 0, -1) && self.IsTileSolid(1, 1, -1)) ||
                         (self.bodyMode == Player.BodyModeIndex.Crawl && self.IsTileSolid(0, 0, -1) && self.IsTileSolid(1, 0, -1))
@@ -1179,8 +1179,12 @@ public partial class RainMeadow
             }
             if (self.sleepCurlUp > 0 && !self.Consious) //When stunned or dead, the vanilla code stops decaying sleepCurlUp so we need to handle it ourselves. Technically this fixes an esoteric vanilla bug too.
             {
-                //RainMeadow.Debug("Wake up and feel the PAIN, slugcat!");
+                //RainMeadow.Debug("Wake up and smell the PAIN, slugcat!");
                 self.sleepCurlUp = 0f;
+            }
+            if (ModManager.MSC && self.SlugCatClass == MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Spear && extras.afkSleep && self.sleepCurlUp == 1f)
+            { //For reasons beyond my comprehension, Spearmaster specifically has a weirdly specific check to make them *not* close their eyes when sleepCurlUp but not sleepCounter.
+                self.Blink(2); //Naturally this breaks Spearmaster's AFK sleep animation, so I need an equally specific check to add the closed eyes back.
             }
         }
     }

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1152,7 +1152,7 @@ public partial class RainMeadow
         //Sleeping when AFK
         if (OnlineManager.lobby != null)
         {
-            var extas = playerExtras.GetOrCreateValue(self); 
+            var extras = playerExtras.GetOrCreateValue(self); 
             if (self.IsLocal())
             {
                 if (self.sleepCounter == 0 && //Check we're not already sleeping in a shelter; otherwise waking up from a shelter can trigger AFK sleep instantly.
@@ -1163,18 +1163,22 @@ public partial class RainMeadow
                     && self.touchedNoInputCounter > 1200
                    )
                 {
-                    extas.afkSleep = true;
+                    extras.afkSleep = true;
                 }
                 else
                 {
-                    extas.afkSleep = false;
+                    extras.afkSleep = false;
                 }
             }
-            if (extas.afkSleep)
+            if (extras.afkSleep)
             {
                 self.standing = false;
                 self.sleepCurlUp = Mathf.Max(wasSleepCurlUp, self.sleepCurlUp); // prevent decay
                 self.sleepCurlUp = Mathf.Min(1f, self.sleepCurlUp + 0.02f); // add up
+            }
+            if (self.sleepCurlUp > 0 && (self.dead || self.Stunned)) //When stunned or dead, the vanilla code stops decaying sleepCurlUp so we need to handle it ourselves. Technically this fixes an esoteric vanilla bug too.
+            {
+                self.sleepCurlUp = 0f;
             }
         }
     }


### PR DESCRIPTION
- Afk sleep can now be triggered manually by holding exclusively down for 5 seconds without stopping.
- Fixed the sleeping animation not cancelling when stunned/killed (technically a vanilla bug, but not one you'd ever see).
- Fixed Spearmaster not closing their eyes during afk sleep.
- Fixed afk sleep rarely triggering when piggybacked onto someone else. I wanted to embrace this behavior but the animation has a lot of issues that'd take way too much effort to fix.
- Fixed the "Don't afk sleep when waking up" check not working (like 4 times).
- Fixed an oddity where shelters closing would cause afk sleep to stop.