### PR TITLE
OverworldSession Resource

### DIFF
--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -19,6 +19,7 @@ namespace RainMeadow
             On.RainWorldGame.ctor += RainWorldGame_ctor;
             IL.RainWorldGame.ctor += RainWorldGame_ctor2;
             On.StoryGameSession.ctor += StoryGameSession_ctor;
+            IL.OverWorld.ctor += Overworld_ctor; 
             On.RainWorldGame.RawUpdate += RainWorldGame_RawUpdate;
             On.RainWorldGame.ShutDownProcess += RainWorldGame_ShutDownProcess;
             IL.ShortcutHandler.SuckInCreature += ShortcutHandler_SuckInCreature;
@@ -56,8 +57,40 @@ namespace RainMeadow
         
             IL.Menu.SleepAndDeathScreen.GetDataFromGame += SleepAndDeathScreen_FixNullKarmaLadder;
         }
+        
+        private void Overworld_ctor(ILContext context)
+        {
+            try
+            {
+                ILCursor cursor = new(context);
+                cursor.GotoNext(MoveType.After,
+                    x => x.MatchStfld<OverWorld>(nameof(OverWorld.regions)));
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate((OverWorld self) =>
+                {
+                    if (OnlineManager.lobby != null)
+                    {
+                        if (OnlineManager.lobby.overworld.isActive) OnlineManager.lobby.overworld.Deactivate();
+                        
+                        OnlineManager.lobby.overworld.BindOverworld(self);
+                        OnlineManager.lobby.overworld.Needed();
+                        while (!OnlineManager.lobby.overworld.isAvailable)
+                        {
+                            OnlineManager.ForceLoadUpdate();
+                        }
 
-        private void SleepAndDeathScreen_FixNullKarmaLadder(ILContext il) {
+                        OnlineManager.lobby.overworld.Activate();
+                    }
+                });
+            }
+            catch (Exception except)
+            {
+                Logger.LogError(except);
+            }
+        }
+
+        private void SleepAndDeathScreen_FixNullKarmaLadder(ILContext il)
+        {
             try
             {
                 var c = new ILCursor(il);
@@ -416,13 +449,12 @@ namespace RainMeadow
 
                 OnlineManager.lobby.gameMode.GameShutDown(self);
 
-                if (!WorldSession.map.TryGetValue(self.world, out var ws)) return;
 
-                if (ws.isActive) ws.Deactivate();
-                ws.NotNeeded();
+                if (OnlineManager.lobby.overworld.isActive) OnlineManager.lobby.overworld.Deactivate();
+                OnlineManager.lobby.overworld.NotNeeded();
                 if (self.manager.upcomingProcess != ProcessManager.ProcessID.MainMenu) // quit directly, otherwise wait release
                 {
-                    while (ws.isAvailable)
+                    while (OnlineManager.lobby.overworld.isAvailable)
                     {
                         OnlineManager.ForceLoadUpdate();
                     }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
 namespace RainMeadow
 {
 
@@ -42,7 +45,7 @@ namespace RainMeadow
                     OnlinePlayer? currentName = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, player.playerNumber);
                     if (currentName != null)
                     {
-                       arena.ReadFromStats(player, currentName);
+                        arena.ReadFromStats(player, currentName);
                     }
                 }
 
@@ -294,18 +297,26 @@ namespace RainMeadow
                     if (isArenaMode(out var _))
                     {
                         RainMeadow.Debug("Arena: Setting up world session");
-
-                        ws = OnlineManager.lobby.worldSessions["arena"];
+                        ws = OnlineManager.lobby.overworld.worldSessions["arena"];
                     }
                     else
                     {
-                        ws = OnlineManager.lobby.worldSessions[region.name];
+                        ws = OnlineManager.lobby.overworld.worldSessions[region.name];
                     }
-                    ws.BindWorld(self, self.world);
+
+                    if (ws is null)
+                    {
+                        RainMeadow.Error($"Could not find world session for newly loaded World.");
+                    }
+                    else
+                    {
+                        ws.BindWorld(self, self.world);
+                    }
                 }
                 catch (System.NullReferenceException e) // happens in riv ending
                 {
-                    RainMeadow.Debug("NOTE: rivulet hackfix null ref exception is bad!");
+                    RainMeadow.Error(e);
+                    RainMeadow.Error("rivulet hackfix null ref exception is bad!");
                 }
             }
         }

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -627,7 +627,7 @@ namespace RainMeadow
         }
         public override bool PlayerCanOwnResource(OnlinePlayer from, OnlineResource onlineResource)
         {
-            if (onlineResource is WorldSession || onlineResource is RoomSession)
+            if (onlineResource is OverworldSession || onlineResource is WorldSession || onlineResource is RoomSession)
             {
                 return lobby.owner == from;
             }

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -170,7 +170,7 @@ namespace RainMeadow
 
         public override bool PlayerCanOwnResource(OnlinePlayer from, OnlineResource onlineResource)
         {
-            if (onlineResource is WorldSession)
+            if (onlineResource is OverworldSession || onlineResource is WorldSession)
             {
                 return lobby.owner == from;
             }

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -284,7 +284,7 @@ namespace RainMeadow
             }
             inWorldSession = inRoomSession.worldSession;
 
-            var worlds = OnlineManager.lobby.worldSessions.Values.ToList();
+            var worlds = OnlineManager.lobby.overworld.worldSessions.Values.ToList();
             worlds.Sort((x, y) => (x == inWorldSession ? -1 : 0) + (y == inWorldSession ? 1 : 0));
 
             int lastWorldLines = 0;

--- a/Online/OnlineManager.cs
+++ b/Online/OnlineManager.cs
@@ -340,28 +340,22 @@ namespace RainMeadow
         {
             if (lobby != null)
             {
+                if (rid == "@overworld") return lobby.overworld;
                 if (rid == ".") return lobby;
-
-                if (rid == "arena" && lobby.worldSessions.TryGetValue(rid, out var arenaRegionz)) return arenaRegionz;
-
-                if (rid.Contains("arena"))
+                if (lobby.overworld.isActive)
                 {
-                    string modifiedRid = rid.Replace("arena", "");
-
-                    if (lobby.worldSessions["arena"].roomSessions.TryGetValue(modifiedRid, out var roomSession))
+                    var split = rid.Split('.');
+                    if (lobby.overworld.worldSessions.TryGetValue(split[0], out var ws))
                     {
-                        return roomSession;
+                        if (split.Length >= 2 && ws.roomSessions.TryGetValue(split[1], out var rs))
+                            return rs;
+                        return ws;
                     }
                 }
 
-                var split = rid.Split('.');
-                if (lobby.worldSessions.TryGetValue(split[0], out var ws)) {
-                    if (split.Length >= 2 && ws.roomSessions.TryGetValue(split[1], out var rs))
-                        return rs;
-                    return ws;
-                }
             }
             RainMeadow.Error("resource not found : " + rid);
+            RainMeadow.Stacktrace();
             return null;
         }
 

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -11,7 +11,7 @@ namespace RainMeadow
     {
         public OnlineGameMode gameMode;
         public OnlineGameMode.OnlineGameModeType gameModeType;
-        public Dictionary<string, WorldSession> worldSessions = new();
+        public OverworldSession overworld;
         public Dictionary<OnlinePlayer, ClientSettings> clientSettings = new();
         public List<KeyValuePair<OnlinePlayer, OnlineEntity.EntityId>> playerAvatars = new(); // guess we can support multiple avatars per client
 
@@ -129,27 +129,8 @@ namespace RainMeadow
 
         protected override void ActivateImpl()
         {
-            if (RainMeadow.isArenaMode(out var _)) // Arena
-            {
-                Region arenaRegion = new Region("arena", 0, 0, RainMeadow.Ext_SlugcatStatsName.OnlineSessionPlayer);
-
-                var ws = new WorldSession(arenaRegion, this);
-                worldSessions.Add(arenaRegion.name, ws);
-                subresources.Add(ws);
-
-                RainMeadow.Debug(subresources.Count);
-            }
-            else
-            {
-                foreach (var r in Region.LoadAllRegions(RainMeadow.Ext_SlugcatStatsName.OnlineSessionPlayer))
-                {
-                    RainMeadow.Debug(r.name);
-                    var ws = new WorldSession(r, this);
-                    worldSessions.Add(r.name, ws);
-                    subresources.Add(ws);
-                }
-                RainMeadow.Debug(subresources.Count);
-            }
+            overworld = new OverworldSession(this);
+            subresources.Add(overworld);
         }
 
         protected override void AvailableImpl()

--- a/Online/Resource/OverworldSession.cs
+++ b/Online/Resource/OverworldSession.cs
@@ -1,0 +1,85 @@
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RainMeadow
+{
+    public partial class OverworldSession : OnlineResource
+    {
+        public OverWorld? overWorld = null;
+        public Dictionary<string, WorldSession> worldSessions = new();
+        public OverworldSession(Lobby lobby) : base(lobby) { }
+        public void BindOverworld(OverWorld overWorld)
+        {
+            RainMeadow.DebugMe();
+            if (this.overWorld is not null) RainMeadow.Error("overWorld is not null, Overriding...");
+            this.overWorld = overWorld;
+        }
+
+        protected override void AvailableImpl()
+        {
+
+        }
+
+        protected override void ActivateImpl()
+        {
+            if (overWorld is null) throw new InvalidProgrammerException("overWorld is null");
+            if (RainMeadow.isArenaMode(out var _)) // Arena
+            {
+                Region arenaRegion = new Region("arena", 0, 0, RainMeadow.Ext_SlugcatStatsName.OnlineSessionPlayer);
+
+                var ws = new WorldSession(arenaRegion, this);
+                worldSessions.Add(arenaRegion.name, ws);
+                subresources.Add(ws);
+
+                RainMeadow.Debug(subresources.Count);
+            }
+            else
+            {
+                foreach (var r in overWorld.regions)
+                {
+                    RainMeadow.Debug(r.name);
+                    var ws = new WorldSession(r, this);
+                    worldSessions.Add(r.name, ws);
+                    subresources.Add(ws);
+                }
+            }
+        }
+
+        protected override void DeactivateImpl()
+        {
+            overWorld = null;
+            worldSessions.Clear();
+            WorldSession.map = new();
+            RoomSession.map = new();
+            OnlinePhysicalObject.map = new();
+        }
+
+        protected override void UnavailableImpl()
+        {
+
+        }
+
+        public override string Id()
+        {
+            return "@overworld";
+        }
+
+        public override ushort ShortId() => (ushort)super.subresources.IndexOf(this);
+        public override OnlineResource SubresourceFromShortId(ushort shortId)
+        {
+            return worldSessions.Select(x => x.Value).FirstOrDefault(x => x.region.regionNumber == shortId);
+        }
+
+        protected override ResourceState MakeState(uint ts)
+        {
+            return new OverworldState(this, ts);
+        }
+
+        public class OverworldState : ResourceWithSubresourcesState
+        {
+            public OverworldState() : base() { }
+            public OverworldState(OverworldSession resource, uint ts) : base(resource, ts) { }
+        }
+    }
+}

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -14,7 +14,7 @@ namespace RainMeadow
         public Dictionary<string, RoomSession> roomSessions = new();
         public World World => world;
 
-        public WorldSession(Region region, Lobby lobby) : base(lobby)
+        public WorldSession(Region region, OverworldSession overworld) : base(overworld)
         {
             this.region = region;
         }
@@ -23,9 +23,9 @@ namespace RainMeadow
         {
             this.world = world;
             this.worldLoader = worldLoader;
-            if (RainMeadow.isArenaMode(out var _)) {
-
-                world.region = new Region("arena", 0, 0, SlugcatStats.SlugcatToTimeline(RainMeadow.Ext_SlugcatStatsName.OnlineSessionPlayer));
+            if (RainMeadow.isArenaMode(out var _))
+            {
+                world.region = this.region;
             }
             map.Add(world, this);
         }
@@ -71,6 +71,7 @@ namespace RainMeadow
         protected override void DeactivateImpl()
         {
             this.roomSessions.Clear();
+            if (world != null && map.TryGetValue(world, out var ws) && ws == this) map.Remove(world);
             world = null;
         }
 


### PR DESCRIPTION
I split off the management of WorldSessions from the Lobby into a new OverworldSession resource. 

- Allows players to manage there regions even when the host hasn't loaded in yet. (Meadow mode)
- Adds potential for downloading custom regions while inside the lobby.

This doesn't have to be merged immediately.  