### PR TITLE
SSOracles dont need absolute syncing

### DIFF
--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -140,6 +140,7 @@ namespace RainMeadow
         public override bool ShouldSyncAPOInRoom(RoomSession rs, AbstractPhysicalObject apo)
         {
             if (unsyncedAbstractObjectTypes.Contains(apo.type)) return false;
+            if (apo.type == AbstractPhysicalObject.AbstractObjectType.SSOracleSwarmer) return false;
             return true;
         }
 


### PR DESCRIPTION
This doesn't fix all of the pain in 5P, but it's a start. Not added to unsycnedAPOObjectTypes because that completely removes them from clients games.

- [x] Review what happens if I add this code to SyncAPOInWorld, might be able to skirt a ton of RPCs.