### PR TITLE
Better Controller UI navigation

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -334,5 +334,30 @@ namespace RainMeadow
                 }
             }
         }
+        ///<summary>Directionally binds a list of UI elements to a target element. For example, with fromObjects[A,B,C] and ToObject D, Bind A→D, B→D, and C→D.</summary>
+        public static void TryMassBind(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
+        {
+            foreach (MenuObject fromObject in fromObjects)
+            {
+                TryBind(fromObject, toObject, left, right, top, bottom);
+            }
+        }
+        ///<summary>Chains MutualBinds together from a list. For example, with menuObjects[A,B,C,D], MutualBind A↔B, B↔C, C↔D, and optionally D↔A. Rain World handles MutualBinds from BOTTOM TO TOP, or left to right. Use reverseList if you need.</summary>
+        public static void TryMassMutualBind(this Menu.Menu menu, List<MenuObject> menuObjects, bool leftRight = false, bool bottomTop = false, bool loopLastIndex = false, bool reverseList = false)
+        {
+            List<MenuObject> WorkingObjects = menuObjects.Where(MenuObject => MenuObject != null).ToList(); //If our input list contains null entries (such as uninitialized), just remove them and continue gracefully.
+            if (reverseList)
+            {
+                WorkingObjects.Reverse();
+            }
+            for (int i = 0; i < WorkingObjects.Count - 1; i++)
+            {
+                TryMutualBind(menu, WorkingObjects[i], WorkingObjects[i+1], leftRight, bottomTop);
+            }
+            if (loopLastIndex)
+            {
+                TryMutualBind(menu, WorkingObjects[WorkingObjects.Count - 1], WorkingObjects[0], leftRight, bottomTop);
+            }
+        }
     }
 }

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -419,7 +419,6 @@ namespace RainMeadow
                 TargetStep -= (ListA.Count - 1);
             }
             //Find which direction we need to bind, then bind. Referencing the index of a division is conceptually sketchy, but the math checks out and has been throughly tested. Worst-case scenario it's integer division anyway.
-            RainMeadow.Debug(ListA.Count + " " + ListB.Count + " " + ListAStepper + " " + ListBStepper + " " + TargetStep);
             TryBind(
                 ListA[ListAStepper / Math.Max(1, ListB.Count - 1)],
                 ListB[TargetStep   / Math.Max(1, ListA.Count - 1)],

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -336,9 +336,17 @@ namespace RainMeadow
         }
         //I've been told these could go in Menu/MenuHelpers.cs, but separating them from the functions they're based off of seems wrong. If someone else wants to though, go for it.
         ///<summary>Directionally binds a list of UI elements to a target element. For example, with fromObjects[A,B,C] and ToObject D, Bind A→D, B→D, and C→D.</summary>
-        public static void TryMassBind(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
+        public static void TryMassBindTo(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
         {
             foreach (MenuObject fromObject in fromObjects)
+            {
+                TryBind(fromObject, toObject, left, right, top, bottom);
+            }
+        }
+        ///<summary>Directionally binds a UI element to a list of target elements. For example, with fromObject A and ToObjects[B,C,D], Bind A→B, A→C, and A→D.</summary>
+        public static void TryMassBindFrom(MenuObject fromObject, List<MenuObject> toObjects, bool left = false, bool right = false, bool top = false, bool bottom = false)
+        {
+            foreach (MenuObject toObject in toObjects)
             {
                 TryBind(fromObject, toObject, left, right, top, bottom);
             }
@@ -347,6 +355,11 @@ namespace RainMeadow
         public static void TryMassMutualBind(this Menu.Menu menu, List<MenuObject> menuObjects, bool leftRight = false, bool bottomTop = false, bool loopLastIndex = false, bool reverseList = false)
         {
             List<MenuObject> WorkingObjects = menuObjects.Where(MenuObject => MenuObject != null).ToList(); //If our input list contains null entries (such as uninitialized), just remove them and continue gracefully.
+            if (WorkingObjects.Count < 2)
+            {
+                RainMeadow.Warn(" Tried to keybind less than two UI elements to each other, skipping. Is the list not populated?");
+                return;
+            }
             if (reverseList)
             {
                 WorkingObjects.Reverse();

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -338,25 +338,25 @@ namespace RainMeadow
         ///<summary>Directionally binds a list of UI elements to a target element. For example, with fromObjects[A,B,C] and ToObject D, Bind A→D, B→D, and C→D.</summary>
         public static void TryMassBind(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
         {
-            foreach (MenuObject fromObject in fromObjects)
+            foreach (MenuObject FromObject in fromObjects)
             {
-                TryBind(fromObject, toObject, left, right, top, bottom);
+                TryBind(FromObject, toObject, left, right, top, bottom);
             }
         }
         ///<summary>Chains MutualBinds together from a list. For example, with menuObjects[A,B,C,D], MutualBind A↔B, B↔C, C↔D, and optionally D↔A. Rain World handles MutualBinds from BOTTOM TO TOP, or left to right. Use reverseList if you need.</summary>
-        public static void TryMassMutualBind(this Menu.Menu menu, List<MenuObject> menuObjects, bool leftRight = false, bool bottomTop = false, bool loopLastIndex = false, bool reverseList = false)
+        public static void TrySequentialMutualBind(this Menu.Menu menu, List<MenuObject> menuObjects, bool leftRight = false, bool bottomTop = false, bool loopLastIndex = false, bool reverseList = false)
         {
             List<MenuObject> WorkingObjects = menuObjects.Where(MenuObject => MenuObject != null).ToList(); //If our input list contains null entries (such as uninitialized), just remove them and continue gracefully.
             if (WorkingObjects.Count < 2)
             {
-                RainMeadow.Warn(" Tried to keybind less than two UI elements to each other, skipping. Is the list not populated?");
+                RainMeadow.Warn(" Tried to keybind " + WorkingObjects.Count + " UI element(s) to each other, cancelling operation. Is the list not yet populated?");
                 return;
             }
             if (reverseList)
             {
                 WorkingObjects.Reverse();
             }
-            for (int i = 0; i < WorkingObjects.Count - 1; i++)
+            for (int i=0; i < WorkingObjects.Count - 1; i++)
             {
                 TryMutualBind(menu, WorkingObjects[i], WorkingObjects[i+1], leftRight, bottomTop);
             }
@@ -364,6 +364,80 @@ namespace RainMeadow
             {
                 TryMutualBind(menu, WorkingObjects[WorkingObjects.Count - 1], WorkingObjects[0], leftRight, bottomTop);
             }
+        }
+        /// <summary>Mutually binds two different lists of elements together based on their UI position, designed for handling parallel rows or columns with potentially-unequal length.</summary>
+        public static void TryParallelStitchBind(List<MenuObject> objectsListA, List<MenuObject> objectsListB, bool areRows = false, bool areColumns = false, bool reverseFromList = false, bool reverseToList = false)
+        {
+            List<MenuObject> ListA = objectsListA.Where(MenuObject => MenuObject != null).ToList(); //If our input lists contain null entries (such as uninitialized), just remove them and continue as if they don't exist.
+            List<MenuObject> ListB = objectsListB.Where(MenuObject => MenuObject != null).ToList();
+            if (ListA.Count < 1) { RainMeadow.Warn(" Tried to keybind to an empty or null fromObjects, cancelling operation. Is the list not yet populated?"); return; }
+            if (ListB.Count < 1) { RainMeadow.Warn(" Tried to keybind to an empty or null toObjects, cancelling operation. Is the list not yet populated?");   return; }
+            if (reverseFromList) { ListA.Reverse(); }
+            if (reverseToList  ) { ListB.Reverse(); }
+
+
+
+
+
+
+            //int NotSoLeastCommonMultiple = ListA.Count * ListB.Count;
+            //int ListAStepper = 0;
+            //int ListBStepper = 0;
+            //RainMeadow.Debug(ListAStepper + " " + ListBStepper + " - " + NotSoLeastCommonMultiple);
+            //while (ListAStepper < NotSoLeastCommonMultiple || ListBStepper < NotSoLeastCommonMultiple)
+            //{
+            //    if (ListAStepper <= ListBStepper)
+            //    {
+            //        ListAStepper += ListB.Count;
+            //    }
+            //    else
+            //    {
+            //        ListBStepper += ListA.Count;
+            //    }
+            //    RainMeadow.Debug(ListAStepper + " " + ListBStepper);
+            //}
+
+            //if ((ListBStepper - ListAStepper) <= ((ListBStepper + ListB.Count) - ListAStepper))
+            //{
+            //    RainMeadow.Debug("Binding 0[" + ListAStepper / ListA.Count + "] to 1[" + ListBStepper / ListB.Count + "]");
+            //    //TryBind(ListA[ListAStepper / ListA.Count], ListB[ListBStepper / ListB.Count]);
+            //}
+            //else
+            //{
+            //    RainMeadow.Debug("Binding 0[" + ListAStepper / ListA.Count + "] to 1[" + (ListBStepper / ListB.Count) + 1 + "]");
+            //    //TryBind(fromObjects[ListAStepper / ListA.Count], ListB[(ListBStepper / ListB.Count)+1]);
+            //}
+
+            //if ((ListAStepper - ListBStepper) <= ((ListAStepper + ListA.Count) - ListBStepper))
+            //{
+            //    RainMeadow.Debug("Binding 1[" + ListBStepper / ListB.Count + "] to 0[" + ListAStepper / ListA.Count + "]");
+            //    //TryBind(ListB[ListBStepper / ListB.Count], ListA[ListAStepper / ListA.Count]);
+            //}
+            //else
+            //{
+            //    RainMeadow.Debug("Binding 1[" + ListBStepper / ListB.Count + "] to 0[" + (ListAStepper / ListA.Count) + 1 + "]");
+            //    //TryBind(ListB[ListBStepper / ListB.Count], ListA[(ListAStepper / ListA.Count)+1]);
+            //}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            //int BestTargetID = 0;
+            //float BestTargetVector = float.PositiveInfinity;
+            //foreach (MenuObject CurrentObject in ListA)
+            //{
+            //    RainMeadow.Debug(CurrentObject.Container.GetPosition());
+            //}
         }
     }
 }

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -335,12 +335,28 @@ namespace RainMeadow
             }
         }
         //I've been told these could go in Menu/MenuHelpers.cs, but separating them from the functions they're based off of seems wrong. If someone else wants to though, go for it.
+        ///<summary>Effectively deletes a UI element's directional keybind(s) by binding the button to itself.</summary>
+        public static void TryDeleteBind(MenuObject menuObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
+        {
+            menuObject.nextSelectable[0] = (left ? menuObject : menuObject.nextSelectable[0]);
+            menuObject.nextSelectable[1] = (top ? menuObject : menuObject.nextSelectable[1]);
+            menuObject.nextSelectable[2] = (right ? menuObject : menuObject.nextSelectable[2]);
+            menuObject.nextSelectable[3] = (bottom ? menuObject : menuObject.nextSelectable[3]);
+        }
         ///<summary>Directionally binds a list of UI elements to a target element. For example, with fromObjects[A,B,C] and ToObject D, Bind A→D, B→D, and C→D.</summary>
         public static void TryMassBind(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
         {
             foreach (MenuObject FromObject in fromObjects)
             {
                 TryBind(FromObject, toObject, left, right, top, bottom);
+            }
+        }
+        ///<summary>Effectively deletes a UI list of elements' directional keybind(s) by binding each button to itself.</summary>
+        public static void TryMassDeleteBind(List<MenuObject> objects, bool left = false, bool right = false, bool top = false, bool bottom = false)
+        {
+            foreach (MenuObject Object in objects)
+            {
+                TryDeleteBind(Object, left, right, top, bottom);
             }
         }
         ///<summary>Chains MutualBinds together from a list. For example, with menuObjects[A,B,C,D], MutualBind A↔B, B↔C, C↔D, and optionally D↔A. Rain World handles MutualBinds from BOTTOM TO TOP, or left to right. Use reverseList if you need.</summary>

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -336,17 +336,9 @@ namespace RainMeadow
         }
         //I've been told these could go in Menu/MenuHelpers.cs, but separating them from the functions they're based off of seems wrong. If someone else wants to though, go for it.
         ///<summary>Directionally binds a list of UI elements to a target element. For example, with fromObjects[A,B,C] and ToObject D, Bind A→D, B→D, and C→D.</summary>
-        public static void TryMassBindTo(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
+        public static void TryMassBind(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
         {
             foreach (MenuObject fromObject in fromObjects)
-            {
-                TryBind(fromObject, toObject, left, right, top, bottom);
-            }
-        }
-        ///<summary>Directionally binds a UI element to a list of target elements. For example, with fromObject A and ToObjects[B,C,D], Bind A→B, A→C, and A→D.</summary>
-        public static void TryMassBindFrom(MenuObject fromObject, List<MenuObject> toObjects, bool left = false, bool right = false, bool top = false, bool bottom = false)
-        {
-            foreach (MenuObject toObject in toObjects)
             {
                 TryBind(fromObject, toObject, left, right, top, bottom);
             }

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -334,6 +334,7 @@ namespace RainMeadow
                 }
             }
         }
+        //I've been told these could go in Menu/MenuHelpers.cs, but separating them from the functions they're based off of seems wrong. If someone else wants to though, go for it.
         ///<summary>Directionally binds a list of UI elements to a target element. For example, with fromObjects[A,B,C] and ToObject D, Bind A→D, B→D, and C→D.</summary>
         public static void TryMassBind(List<MenuObject> fromObjects, MenuObject toObject, bool left = false, bool right = false, bool top = false, bool bottom = false)
         {

--- a/Meadow/MeadowPauseMenu.cs
+++ b/Meadow/MeadowPauseMenu.cs
@@ -220,13 +220,14 @@ namespace RainMeadow
         }
         public void CreateElementBinds()
         {
+            //Group up elements
             List<MenuObject> PauseElements = pages[0].subObjects.Where(MenuObject => MenuObject.GetType() == typeof(SimplerButton)).ToList();
             PauseElements.Add(hubVolumeSlider.subObjects[0]); //oh you special little snowflake
             PauseElements.AddRange(pages[0].subObjects.Where(MenuObject => MenuObject.GetType() == typeof(CheckBox)).ToList());
-
+            //Apply new binds
             Extensions.TryMassDeleteBind(PauseElements, left: true, right: true); //Fix left/right causing nonsense by just removing left/right.
             Extensions.TrySequentialMutualBind(this, PauseElements, bottomTop: true, loopLastIndex: true, reverseList: true); //Fix the up/down binds not linking properly.
-            Extensions.TryBind(continueButton, exitButton, top: true); //When pressing up at Continue, move to Quit instead of the collision checkbox.
+            Extensions.TryBind(continueButton, exitButton, top: true); //When pressing up at Continue, move to Quit instead of the collision checkbox, so Quit is easier to get to.
         }
     }
 }

--- a/Meadow/MeadowPauseMenu.cs
+++ b/Meadow/MeadowPauseMenu.cs
@@ -2,6 +2,7 @@
 using Menu;
 using RWCustom;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -13,6 +14,8 @@ namespace RainMeadow
         private Creature avatarCreature;
         private int targetHub;
         private int suco4;
+
+        private HorizontalSlider2 hubVolumeSlider;
         
         public static Slider.SliderID HubVolume = new Slider.SliderID("Thingy", true);
         public MeadowPauseMenu(ProcessManager manager, RainWorldGame game, MeadowGameMode mgm) : base(manager, game)
@@ -89,9 +92,9 @@ namespace RainMeadow
             pos.y -= 40f;
 
             pos.y -= (buttonCount) * 40f;
-            var slider = new HorizontalSlider2(this, pages[0], this.Translate("Hub zone volume"), pos, new Vector2(60f, 10f), HubVolume, false);
-            slider.subObjects.Add(new Floater(this, slider, new Vector2(750f, 0f), new Vector2(3f, 2.75f), new Vector2(0f, 1f)));
-            pages[0].subObjects.Add(slider);
+            hubVolumeSlider = new HorizontalSlider2(this, pages[0], this.Translate("Hub zone volume"), pos, new Vector2(60f, 10f), HubVolume, false);
+            hubVolumeSlider.subObjects.Add(new Floater(this, hubVolumeSlider, new Vector2(750f, 0f), new Vector2(3f, 2.75f), new Vector2(0f, 1f)));
+            pages[0].subObjects.Add(hubVolumeSlider);
 
             pos.y -= 40f;
             var namesCb = new CheckBox(this, pages[0], this, pos, 70f, this.Translate("Display names"), "NAMES", true);
@@ -107,6 +110,8 @@ namespace RainMeadow
             this.controlMap.RemoveSprites();
             this.pages[0].subObjects.Remove(this.controlMap);
             //this.blackSprite.scaleX = manager.rainWorld.options.ScreenSize.x / 4f;
+
+            CreateElementBinds();
         }
 
         public override void SliderSetValue(Slider slider, float f)
@@ -212,6 +217,16 @@ namespace RainMeadow
                 MeadowProgression.progressionData.collisionOn = c;
                 avatarCreature.ChangeCollisionLayer(MeadowProgression.progressionData.collisionOn ? 1 : 0);
             }
+        }
+        public void CreateElementBinds()
+        {
+            List<MenuObject> PauseElements = pages[0].subObjects.Where(MenuObject => MenuObject.GetType() == typeof(SimplerButton)).ToList();
+            PauseElements.Add(hubVolumeSlider.subObjects[0]); //oh you special little snowflake
+            PauseElements.AddRange(pages[0].subObjects.Where(MenuObject => MenuObject.GetType() == typeof(CheckBox)).ToList());
+
+            Extensions.TryMassDeleteBind(PauseElements, left: true, right: true); //Fix left/right causing nonsense by just removing left/right.
+            Extensions.TrySequentialMutualBind(this, PauseElements, bottomTop: true, loopLastIndex: true, reverseList: true); //Fix the up/down binds not linking properly.
+            Extensions.TryBind(continueButton, exitButton, top: true); //When pressing up at Continue, move to Quit instead of the collision checkbox.
         }
     }
 }

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -278,6 +278,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     public override void Init()
     {
         base.Init();
+        UpdateElementBindings();
         selectedObject = arenaMainLobbyPage.readyButton;
     }
     public override void Update()
@@ -300,7 +301,6 @@ public class ArenaOnlineLobbyMenu : SmartMenu
                 infoLabelFade = 1;
         }
         UpdateOnlineUI();
-        UpdateElementBindings();
         if (!RainMeadow.isArenaMode(out _)) return;
         if (Arena.currentLobbyOwner != OnlineManager.lobby.owner)
         {

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -448,6 +448,9 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     {
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton };
         Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
+
+        //Extensions.TryBind(arenaMainLobbyPage.chatMenuBox.messageScroller.scrollSlider, arenaMainLobbyPage.tabContainer.activeTab, right: true);
+        //Extensions.TryBind(arenaMainLobbyPage.levelSelector.selectedLevelsPlaylist.scrollSlider, arenaMainLobbyPage.tabContainer.activeTab, left: true);
     }
     public void RemoveAndAddNewExtGameModeTab(ExternalArenaGameMode? gameMode)
     {

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -446,18 +446,21 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     }
     public void UpdateElementBindings()
     {
+        //Primary page
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton };
         Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
 
-        List<MenuObject> RepeatRoomsSubElements = new List<MenuObject>() { backObject, backObject };
-        List<MenuObject> RainTimerSubElements = new List<MenuObject>() { backObject, backObject, backObject, backObject, backObject };
-        //Extensions.TryParallelStitchBind(RainTimerSubElements, RepeatRoomsSubElements);
-
-        //Extensions.TryBind(arenaMainLobbyPage.chatMenuBox.messageScroller.scrollSlider, arenaMainLobbyPage.tabContainer.activeTab, right: true);
-        //Extensions.TryBind(arenaMainLobbyPage.levelSelector.selectedLevelsPlaylist.scrollSlider, arenaMainLobbyPage.tabContainer.activeTab, left: true);
-
-        //arenaSettingsInterface
-        //slugcatAbilitiesInterface
+        //Match Settings submenu
+        List<MenuObject> MatchSettingsRow1Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.spearsHitCheckbox, arenaMainLobbyPage.arenaSettingsInterface.evilAICheckBox};
+        List<MenuObject> MatchSettingsRow2Elements = arenaMainLobbyPage.arenaSettingsInterface.roomRepeatArray.buttons.Cast<MenuObject>().ToList();
+        List<MenuObject> MatchSettingsRow3Elements = arenaMainLobbyPage.arenaSettingsInterface.rainTimerArray.buttons.Cast<MenuObject>().ToList();
+        List<MenuObject> MatchSettingsRow4Elements = arenaMainLobbyPage.arenaSettingsInterface.wildlifeArray.buttons.Cast<MenuObject>().ToList();
+        List<MenuObject> MatchSettingsRow5Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.stealItemCheckBox, arenaMainLobbyPage.arenaSettingsInterface.allowMidGameJoinCheckbox};
+        List<MenuObject> MatchSettingsRow6Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.piggyBackCheckbox, arenaMainLobbyPage.arenaSettingsInterface.weaponCollisionCheckBox};
+        List<MenuObject> MatchSettingsRow7Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.countdownTimerTextBox.wrapper};
+        List<MenuObject> MatchSettingsRow8Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.arenaGameModeComboBox.wrapper};
+        List<List<MenuObject>> MatchSettingsElementRowList = new List<List<MenuObject>>() { MatchSettingsRow1Elements, MatchSettingsRow2Elements, MatchSettingsRow3Elements, MatchSettingsRow4Elements, MatchSettingsRow5Elements, MatchSettingsRow6Elements, MatchSettingsRow7Elements, MatchSettingsRow8Elements };
+        Extensions.TrySequentialParallelStitchBind(MatchSettingsElementRowList, areRows: true, loopLastIndex: true, reverseListList: true);
     }
     public void RemoveAndAddNewExtGameModeTab(ExternalArenaGameMode? gameMode)
     {

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -278,7 +278,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     public override void Init()
     {
         base.Init();
-        UpdateElementBindings();
+        CreateAndUpdateElementBindings();
         selectedObject = arenaMainLobbyPage.readyButton;
     }
     public override void Update()
@@ -444,23 +444,27 @@ public class ArenaOnlineLobbyMenu : SmartMenu
             lastCountdownSoundPlayed = Arena.lobbyCountDown;
         }
     }
+    public void CreateAndUpdateElementBindings()
+    {
+        //Match Settings submenu
+        List<MenuObject> MatchSettingsRow1Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.spearsHitCheckbox, arenaMainLobbyPage.arenaSettingsInterface.evilAICheckBox };
+        List<MenuObject> MatchSettingsRow2Elements = arenaMainLobbyPage.arenaSettingsInterface.roomRepeatArray.buttons.Cast<MenuObject>().ToList();
+        List<MenuObject> MatchSettingsRow3Elements = arenaMainLobbyPage.arenaSettingsInterface.rainTimerArray.buttons.Cast<MenuObject>().ToList();
+        List<MenuObject> MatchSettingsRow4Elements = arenaMainLobbyPage.arenaSettingsInterface.wildlifeArray.buttons.Cast<MenuObject>().ToList();
+        List<MenuObject> MatchSettingsRow5Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.stealItemCheckBox, arenaMainLobbyPage.arenaSettingsInterface.allowMidGameJoinCheckbox };
+        List<MenuObject> MatchSettingsRow6Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.piggyBackCheckbox, arenaMainLobbyPage.arenaSettingsInterface.weaponCollisionCheckBox };
+        List<MenuObject> MatchSettingsRow7Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.countdownTimerTextBox.wrapper };
+        List<MenuObject> MatchSettingsRow8Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.arenaGameModeComboBox.wrapper };
+        List<List<MenuObject>> MatchSettingsElementRowList = new List<List<MenuObject>>() { MatchSettingsRow1Elements, MatchSettingsRow2Elements, MatchSettingsRow3Elements, MatchSettingsRow4Elements, MatchSettingsRow5Elements, MatchSettingsRow6Elements, MatchSettingsRow7Elements, MatchSettingsRow8Elements };
+        Extensions.TrySequentialParallelStitchBind(MatchSettingsElementRowList, areRows: true, loopLastIndex: true, reverseListList: true);
+
+        UpdateElementBindings();
+    }
     public void UpdateElementBindings()
     {
         //Primary page
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton };
         Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
-
-        //Match Settings submenu
-        List<MenuObject> MatchSettingsRow1Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.spearsHitCheckbox, arenaMainLobbyPage.arenaSettingsInterface.evilAICheckBox};
-        List<MenuObject> MatchSettingsRow2Elements = arenaMainLobbyPage.arenaSettingsInterface.roomRepeatArray.buttons.Cast<MenuObject>().ToList();
-        List<MenuObject> MatchSettingsRow3Elements = arenaMainLobbyPage.arenaSettingsInterface.rainTimerArray.buttons.Cast<MenuObject>().ToList();
-        List<MenuObject> MatchSettingsRow4Elements = arenaMainLobbyPage.arenaSettingsInterface.wildlifeArray.buttons.Cast<MenuObject>().ToList();
-        List<MenuObject> MatchSettingsRow5Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.stealItemCheckBox, arenaMainLobbyPage.arenaSettingsInterface.allowMidGameJoinCheckbox};
-        List<MenuObject> MatchSettingsRow6Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.piggyBackCheckbox, arenaMainLobbyPage.arenaSettingsInterface.weaponCollisionCheckBox};
-        List<MenuObject> MatchSettingsRow7Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.countdownTimerTextBox.wrapper};
-        List<MenuObject> MatchSettingsRow8Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.arenaGameModeComboBox.wrapper};
-        List<List<MenuObject>> MatchSettingsElementRowList = new List<List<MenuObject>>() { MatchSettingsRow1Elements, MatchSettingsRow2Elements, MatchSettingsRow3Elements, MatchSettingsRow4Elements, MatchSettingsRow5Elements, MatchSettingsRow6Elements, MatchSettingsRow7Elements, MatchSettingsRow8Elements };
-        Extensions.TrySequentialParallelStitchBind(MatchSettingsElementRowList, areRows: true, loopLastIndex: true, reverseListList: true);
     }
     public void RemoveAndAddNewExtGameModeTab(ExternalArenaGameMode? gameMode)
     {

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -278,7 +278,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     public override void Init()
     {
         base.Init();
-        selectedObject = arenaMainLobbyPage.chatMenuBox.chatTypingBox;
+        selectedObject = arenaMainLobbyPage.readyButton;
     }
     public override void Update()
     {
@@ -446,8 +446,14 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     }
     public void UpdateElementBindings()
     {
-        MutualHorizontalButtonBind(backObject, arenaMainLobbyPage.readyButton);
         MutualHorizontalButtonBind(arenaMainLobbyPage.chatMenuBox.chatTypingBox, arenaMainLobbyPage.chatMenuBox.messageScroller.scrollSlider);
+        //MutualHorizonalButtonBind freaks out if you put things in a loop, so we've got to do it manually.
+        Extensions.TryBind(backObject, arenaMainLobbyPage.readyButton, left: true);
+        Extensions.TryBind(backObject, arenaMainLobbyPage.startButton, right: true);
+        Extensions.TryBind(arenaMainLobbyPage.startButton, backObject, left: true);
+        Extensions.TryBind(arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, right: true);
+        Extensions.TryBind(arenaMainLobbyPage.readyButton, arenaMainLobbyPage.startButton, left: true);
+        Extensions.TryBind(arenaMainLobbyPage.readyButton, backObject, right: true);
     }
     public void RemoveAndAddNewExtGameModeTab(ExternalArenaGameMode? gameMode)
     {

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -447,10 +447,17 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     public void UpdateElementBindings()
     {
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton };
-        Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
+        Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
+
+        List<MenuObject> RepeatRoomsSubElements = new List<MenuObject>() { backObject, backObject };
+        List<MenuObject> RainTimerSubElements = new List<MenuObject>() { backObject, backObject, backObject, backObject, backObject };
+        //Extensions.TryParallelStitchBind(RainTimerSubElements, RepeatRoomsSubElements);
 
         //Extensions.TryBind(arenaMainLobbyPage.chatMenuBox.messageScroller.scrollSlider, arenaMainLobbyPage.tabContainer.activeTab, right: true);
         //Extensions.TryBind(arenaMainLobbyPage.levelSelector.selectedLevelsPlaylist.scrollSlider, arenaMainLobbyPage.tabContainer.activeTab, left: true);
+
+        //arenaSettingsInterface
+        //slugcatAbilitiesInterface
     }
     public void RemoveAndAddNewExtGameModeTab(ExternalArenaGameMode? gameMode)
     {

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -446,7 +446,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     }
     public void CreateAndUpdateElementBindings()
     {
-        //Match Settings submenu
+        //Set up for and fix the match settings submenu. This is not exactly the cleanest-looking implementation, but it's the friendliest to modification.
         List<MenuObject> MatchSettingsRow1Elements = new List<MenuObject>() { arenaMainLobbyPage.arenaSettingsInterface.spearsHitCheckbox, arenaMainLobbyPage.arenaSettingsInterface.evilAICheckBox };
         List<MenuObject> MatchSettingsRow2Elements = arenaMainLobbyPage.arenaSettingsInterface.roomRepeatArray.buttons.Cast<MenuObject>().ToList();
         List<MenuObject> MatchSettingsRow3Elements = arenaMainLobbyPage.arenaSettingsInterface.rainTimerArray.buttons.Cast<MenuObject>().ToList();
@@ -462,7 +462,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     }
     public void UpdateElementBindings()
     {
-        //Primary page
+        //Enforce the bottom row's element order. Wow was this broken. TrySequentualMutualBind has a built-in per-entry null check, so if startButton doesn't exist, it will gracefully rebind around it.
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton };
         Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
     }

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -446,8 +446,6 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     }
     public void UpdateElementBindings()
     {
-        MutualHorizontalButtonBind(arenaMainLobbyPage.chatMenuBox.chatTypingBox, arenaMainLobbyPage.chatMenuBox.messageScroller.scrollSlider);
-
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton };
         Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
     }

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -447,13 +447,14 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     public void UpdateElementBindings()
     {
         MutualHorizontalButtonBind(arenaMainLobbyPage.chatMenuBox.chatTypingBox, arenaMainLobbyPage.chatMenuBox.messageScroller.scrollSlider);
-        //MutualHorizonalButtonBind freaks out if you put things in a loop, so we've got to do it manually.
-        Extensions.TryBind(backObject, arenaMainLobbyPage.readyButton, left: true);
-        Extensions.TryBind(backObject, arenaMainLobbyPage.startButton, right: true);
-        Extensions.TryBind(arenaMainLobbyPage.startButton, backObject, left: true);
-        Extensions.TryBind(arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, right: true);
-        Extensions.TryBind(arenaMainLobbyPage.readyButton, arenaMainLobbyPage.startButton, left: true);
-        Extensions.TryBind(arenaMainLobbyPage.readyButton, backObject, right: true);
+        Extensions.TryMutualBind(this, backObject, arenaMainLobbyPage.startButton, leftRight: true);
+        Extensions.TryMutualBind(this, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, leftRight: true);
+        Extensions.TryMutualBind(this, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton, leftRight: true);
+        Extensions.TryMutualBind(this, arenaMainLobbyPage.arenaGameStatsButton, backObject, leftRight: true);
+        if (arenaMainLobbyPage.startButton == null)
+        {
+            Extensions.TryMutualBind(this, backObject, arenaMainLobbyPage.readyButton, leftRight: true);
+        }
     }
     public void RemoveAndAddNewExtGameModeTab(ExternalArenaGameMode? gameMode)
     {

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -447,14 +447,9 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     public void UpdateElementBindings()
     {
         MutualHorizontalButtonBind(arenaMainLobbyPage.chatMenuBox.chatTypingBox, arenaMainLobbyPage.chatMenuBox.messageScroller.scrollSlider);
-        Extensions.TryMutualBind(this, backObject, arenaMainLobbyPage.startButton, leftRight: true);
-        Extensions.TryMutualBind(this, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, leftRight: true);
-        Extensions.TryMutualBind(this, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton, leftRight: true);
-        Extensions.TryMutualBind(this, arenaMainLobbyPage.arenaGameStatsButton, backObject, leftRight: true);
-        if (arenaMainLobbyPage.startButton == null)
-        {
-            Extensions.TryMutualBind(this, backObject, arenaMainLobbyPage.readyButton, leftRight: true);
-        }
+
+        List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, arenaMainLobbyPage.startButton, arenaMainLobbyPage.readyButton, arenaMainLobbyPage.arenaGameStatsButton };
+        Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
     }
     public void RemoveAndAddNewExtGameModeTab(ExternalArenaGameMode? gameMode)
     {

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -113,16 +113,16 @@ public class LobbyCreateMenu : SmartMenu
     public void CreateElementBindings()
     {
         List<MenuObject> VerticalElements = new List<MenuObject>() { modeDropDown.wrapper, visibilityDropDown.wrapper, passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper };
-        Extensions.TryMassBindTo(VerticalElements, backObject, left:true);
-        Extensions.TryMassBindTo(VerticalElements, createButton, right:true);
+        Extensions.TryMassBind(VerticalElements, backObject, left:true);
+        Extensions.TryMassBind(VerticalElements, createButton, right:true);
         Extensions.TryMassMutualBind(this, VerticalElements, bottomTop:true, loopLastIndex:true, reverseList:true);
 
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, createButton };
-        Extensions.TryMassBindTo(BottomRowElements, lobbyLimitNumberTextBox.wrapper, top:true);
-        Extensions.TryMassBindTo(BottomRowElements, modeDropDown.wrapper, bottom:true);
+        Extensions.TryMassBind(BottomRowElements, lobbyLimitNumberTextBox.wrapper, top:true);
+        Extensions.TryMassBind(BottomRowElements, modeDropDown.wrapper, bottom:true);
         Extensions.TryMutualBind(this, backObject, createButton, leftRight: true);
 
-        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, bottom:true);
+        //Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, bottom:true);
     }
 
     private void CreateLobby(SimplerButton obj)

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -112,17 +112,16 @@ public class LobbyCreateMenu : SmartMenu
     }
     public void CreateElementBindings()
     {
+        //Column; enforce element order, and fix/adjust left/right binds.
         List<MenuObject> VerticalElements = new List<MenuObject>() { modeDropDown.wrapper, visibilityDropDown.wrapper, passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper };
         Extensions.TrySequentialMutualBind(this, VerticalElements, bottomTop: true, loopLastIndex: true, reverseList: true);
         Extensions.TryMassBind(VerticalElements, backObject, left:true);
         Extensions.TryMassBind(VerticalElements, createButton, right:true);
-
+        //Bottom row; enforce element order and fix/adjust up/down binds.
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, createButton };
         Extensions.TryMassBind(BottomRowElements, lobbyLimitNumberTextBox.wrapper, top:true);
         Extensions.TryMassBind(BottomRowElements, modeDropDown.wrapper, bottom:true);
         Extensions.TryMutualBind(this, backObject, createButton, leftRight: true);
-
-        //Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, bottom:true);
     }
 
     private void CreateLobby(SimplerButton obj)

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -1,13 +1,14 @@
 // HACK
+using BepInEx;
 using Menu;
 using Menu.Remix;
 using Menu.Remix.MixedUI;
+using RainMeadow.UI.Components;
+using RainMeadow.UI.Pages;
+using RWCustom;
 using System;
 using System.Linq;
-using RWCustom;
 using UnityEngine;
-using BepInEx;
-using RainMeadow.UI.Components;
 
 namespace RainMeadow;
 
@@ -96,10 +97,14 @@ public class LobbyCreateMenu : SmartMenu
         mainPage.subObjects.Add(versionLabel);
 
         if (backObject is SimplerButton backButton) backButton.menuLabel.text = Utils.Translate("CANCEL");
-        selectedObject = modeDropDown.wrapper;
 
         UpdateModeDescription();
         CreateElementBindings();
+    }
+    public override void Init()
+    {
+        base.Init();
+        selectedObject = modeDropDown.wrapper;
     }
 
     private void UpdateModeDescription()

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using RWCustom;
 using UnityEngine;
 using BepInEx;
+using RainMeadow.UI.Components;
 
 namespace RainMeadow;
 
@@ -97,12 +98,44 @@ public class LobbyCreateMenu : SmartMenu
         if (backObject is SimplerButton backButton) backButton.menuLabel.text = Utils.Translate("CANCEL");
 
         UpdateModeDescription();
-
+        CreateElementBindings();
     }
 
     private void UpdateModeDescription()
     {
         modeDescriptionLabel.text = Custom.ReplaceLineDelimeters(Translate(OnlineGameMode.OnlineGameModeType.descriptions[new OnlineGameMode.OnlineGameModeType(modeDropDown.value)]));
+    }
+    private void CreateElementBindings()
+    {
+        Extensions.TryBind(modeDropDown.wrapper, lobbyLimitNumberTextBox.wrapper, top: true);
+        Extensions.TryBind(modeDropDown.wrapper, visibilityDropDown.wrapper, bottom: true);
+        Extensions.TryBind(modeDropDown.wrapper, backObject, left: true);
+        Extensions.TryBind(modeDropDown.wrapper, createButton, right: true);
+
+        Extensions.TryBind(visibilityDropDown.wrapper, modeDropDown.wrapper, top: true);
+        Extensions.TryBind(visibilityDropDown.wrapper, passwordInputBox.wrapper, bottom: true);
+        Extensions.TryBind(visibilityDropDown.wrapper, backObject, left: true);
+        Extensions.TryBind(visibilityDropDown.wrapper, createButton, right: true);
+
+        Extensions.TryBind(passwordInputBox.wrapper, visibilityDropDown.wrapper, top: true);
+        Extensions.TryBind(passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper, bottom: true);
+        Extensions.TryBind(passwordInputBox.wrapper, backObject, left: true);
+        Extensions.TryBind(passwordInputBox.wrapper, createButton, right: true);
+
+        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, passwordInputBox.wrapper, top: true);
+        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, bottom: true);
+        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, backObject, left: true);
+        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, right: true);
+
+        Extensions.TryBind(backObject, lobbyLimitNumberTextBox.wrapper, top: true);
+        Extensions.TryBind(backObject, modeDropDown.wrapper, bottom: true);
+        Extensions.TryBind(backObject, createButton, left: true);
+        Extensions.TryBind(backObject, createButton, right: true);
+
+        Extensions.TryBind(createButton, lobbyLimitNumberTextBox.wrapper, top: true);
+        Extensions.TryBind(createButton, modeDropDown.wrapper, bottom: true);
+        Extensions.TryBind(createButton, backObject, left: true);
+        Extensions.TryBind(createButton, backObject, right: true);
     }
 
     private void CreateLobby(SimplerButton obj)

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -3,8 +3,6 @@ using BepInEx;
 using Menu;
 using Menu.Remix;
 using Menu.Remix.MixedUI;
-using RainMeadow.UI.Components;
-using RainMeadow.UI.Pages;
 using RWCustom;
 using System;
 using System.Collections.Generic;

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -113,9 +113,9 @@ public class LobbyCreateMenu : SmartMenu
     public void CreateElementBindings()
     {
         List<MenuObject> VerticalElements = new List<MenuObject>() { modeDropDown.wrapper, visibilityDropDown.wrapper, passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper };
+        Extensions.TryMassMutualBind(this, VerticalElements, bottomTop: true, loopLastIndex: true, reverseList: true);
         Extensions.TryMassBind(VerticalElements, backObject, left:true);
         Extensions.TryMassBind(VerticalElements, createButton, right:true);
-        Extensions.TryMassMutualBind(this, VerticalElements, bottomTop:true, loopLastIndex:true, reverseList:true);
 
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, createButton };
         Extensions.TryMassBind(BottomRowElements, lobbyLimitNumberTextBox.wrapper, top:true);

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -7,6 +7,7 @@ using RainMeadow.UI.Components;
 using RainMeadow.UI.Pages;
 using RWCustom;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -113,35 +114,17 @@ public class LobbyCreateMenu : SmartMenu
     }
     private void CreateElementBindings()
     {
-        Extensions.TryBind(modeDropDown.wrapper, lobbyLimitNumberTextBox.wrapper, top: true);
-        Extensions.TryBind(modeDropDown.wrapper, visibilityDropDown.wrapper, bottom: true);
-        Extensions.TryBind(modeDropDown.wrapper, backObject, left: true);
-        Extensions.TryBind(modeDropDown.wrapper, createButton, right: true);
+        List<MenuObject> VerticalElements = new List<MenuObject>() { modeDropDown.wrapper, visibilityDropDown.wrapper, passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper };
+        Extensions.TryMassBind(VerticalElements, backObject, left:true);
+        Extensions.TryMassBind(VerticalElements, createButton, right:true);
+        Extensions.TryMassMutualBind(this, VerticalElements, bottomTop:true, loopLastIndex:true, reverseList:true);
 
-        Extensions.TryBind(visibilityDropDown.wrapper, modeDropDown.wrapper, top: true);
-        Extensions.TryBind(visibilityDropDown.wrapper, passwordInputBox.wrapper, bottom: true);
-        Extensions.TryBind(visibilityDropDown.wrapper, backObject, left: true);
-        Extensions.TryBind(visibilityDropDown.wrapper, createButton, right: true);
+        List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, createButton };
+        Extensions.TryMassBind(BottomRowElements, lobbyLimitNumberTextBox.wrapper, top:true);
+        Extensions.TryMassBind(BottomRowElements, modeDropDown.wrapper, bottom:true);
+        Extensions.TryMutualBind(this, backObject, createButton, leftRight: true);
 
-        Extensions.TryBind(passwordInputBox.wrapper, visibilityDropDown.wrapper, top: true);
-        Extensions.TryBind(passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper, bottom: true);
-        Extensions.TryBind(passwordInputBox.wrapper, backObject, left: true);
-        Extensions.TryBind(passwordInputBox.wrapper, createButton, right: true);
-
-        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, passwordInputBox.wrapper, top: true);
-        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, bottom: true);
-        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, backObject, left: true);
-        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, right: true);
-
-        Extensions.TryBind(backObject, lobbyLimitNumberTextBox.wrapper, top: true);
-        Extensions.TryBind(backObject, modeDropDown.wrapper, bottom: true);
-        Extensions.TryBind(backObject, createButton, left: true);
-        Extensions.TryBind(backObject, createButton, right: true);
-
-        Extensions.TryBind(createButton, lobbyLimitNumberTextBox.wrapper, top: true);
-        Extensions.TryBind(createButton, modeDropDown.wrapper, bottom: true);
-        Extensions.TryBind(createButton, backObject, left: true);
-        Extensions.TryBind(createButton, backObject, right: true);
+        Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, bottom:true);
     }
 
     private void CreateLobby(SimplerButton obj)

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -1,13 +1,13 @@
 // HACK
-using BepInEx;
 using Menu;
 using Menu.Remix;
 using Menu.Remix.MixedUI;
-using RWCustom;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using RWCustom;
 using UnityEngine;
+using BepInEx;
 
 namespace RainMeadow;
 

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -113,7 +113,7 @@ public class LobbyCreateMenu : SmartMenu
     public void CreateElementBindings()
     {
         List<MenuObject> VerticalElements = new List<MenuObject>() { modeDropDown.wrapper, visibilityDropDown.wrapper, passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper };
-        Extensions.TryMassMutualBind(this, VerticalElements, bottomTop: true, loopLastIndex: true, reverseList: true);
+        Extensions.TrySequentialMutualBind(this, VerticalElements, bottomTop: true, loopLastIndex: true, reverseList: true);
         Extensions.TryMassBind(VerticalElements, backObject, left:true);
         Extensions.TryMassBind(VerticalElements, createButton, right:true);
 

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -110,16 +110,16 @@ public class LobbyCreateMenu : SmartMenu
     {
         modeDescriptionLabel.text = Custom.ReplaceLineDelimeters(Translate(OnlineGameMode.OnlineGameModeType.descriptions[new OnlineGameMode.OnlineGameModeType(modeDropDown.value)]));
     }
-    private void CreateElementBindings()
+    public void CreateElementBindings()
     {
         List<MenuObject> VerticalElements = new List<MenuObject>() { modeDropDown.wrapper, visibilityDropDown.wrapper, passwordInputBox.wrapper, lobbyLimitNumberTextBox.wrapper };
-        Extensions.TryMassBind(VerticalElements, backObject, left:true);
-        Extensions.TryMassBind(VerticalElements, createButton, right:true);
+        Extensions.TryMassBindTo(VerticalElements, backObject, left:true);
+        Extensions.TryMassBindTo(VerticalElements, createButton, right:true);
         Extensions.TryMassMutualBind(this, VerticalElements, bottomTop:true, loopLastIndex:true, reverseList:true);
 
         List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, createButton };
-        Extensions.TryMassBind(BottomRowElements, lobbyLimitNumberTextBox.wrapper, top:true);
-        Extensions.TryMassBind(BottomRowElements, modeDropDown.wrapper, bottom:true);
+        Extensions.TryMassBindTo(BottomRowElements, lobbyLimitNumberTextBox.wrapper, top:true);
+        Extensions.TryMassBindTo(BottomRowElements, modeDropDown.wrapper, bottom:true);
         Extensions.TryMutualBind(this, backObject, createButton, leftRight: true);
 
         Extensions.TryBind(lobbyLimitNumberTextBox.wrapper, createButton, bottom:true);

--- a/Menu/LobbyCreateMenu.cs
+++ b/Menu/LobbyCreateMenu.cs
@@ -96,6 +96,7 @@ public class LobbyCreateMenu : SmartMenu
         mainPage.subObjects.Add(versionLabel);
 
         if (backObject is SimplerButton backButton) backButton.menuLabel.text = Utils.Translate("CANCEL");
+        selectedObject = modeDropDown.wrapper;
 
         UpdateModeDescription();
         CreateElementBindings();

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -253,11 +253,11 @@ namespace RainMeadow
         }
         public void CreateElementBindings()
         {
-            List<MenuObject> LeftColumnElements = new List<MenuObject>() { filterModeDropDown.wrapper, filterPublicLobbiesOnly.wrapper, filterLobbyLimit.wrapper, filterModsDropDown.wrapper, backObject };
+            List<MenuObject> LeftColumnElements = new List<MenuObject>() { filterModeDropDown.wrapper, filterPublicLobbiesOnly.wrapper, filterLobbyLimit.wrapper, filterModsDropDown.wrapper};
             List<MenuObject> RightColumnElements = new List<MenuObject>() { creditsButton, directConnectButton, domainDropDown.wrapper, createButton };
-            Extensions.TryMassMutualBind(this, LeftColumnElements, bottomTop: true, loopLastIndex: true, reverseList: true);
+            Extensions.TryMassMutualBind(this, LeftColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
             Extensions.TryMassMutualBind(this, RightColumnElements, bottomTop: true, loopLastIndex: true, reverseList: true);
-            Extensions.TryMassBindTo(LeftColumnElements, domainDropDown.wrapper, left: true); //This binds the cancel button which we don't want, but it gets overwritten later.
+            Extensions.TryMassBind(LeftColumnElements, domainDropDown.wrapper, left: true);
 
             List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, lobbyList.scrollDownButton, lobbyList.RefreshButton, createButton };
             Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true, reverseList: false);

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -135,7 +135,7 @@ namespace RainMeadow
             where.y -= 27;
             List<ListItem> requiredModsList = [
                 new("Any", Translate("Unfiltered"), 0),
-                new("MSC", Translate("MSC"), 1),    
+                new("MSC", Translate("MSC"), 1),
                 new("Watcher", Translate("Watcher"), 2),
                 new("MSC + Watcher", Translate("MSC + Watcher"), 3),
                 new("Exact", Translate("Exact order"), 4),

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -16,6 +16,8 @@ namespace RainMeadow
     public class LobbySelectMenu : SmartMenu
     {
         private SimplerButton createButton;
+        private SimplerButton creditsButton;
+        private SimplerButton directConnectButton;
         private OpComboBox2 filterModsDropDown;
         private OpComboBox2 domainDropDown;
         private OpComboBox2 filterModeDropDown;
@@ -45,7 +47,7 @@ namespace RainMeadow
             this.scene.AddIllustration(new MenuIllustration(this, this.scene, "illustrations/rainmeadowtitle", Utils.GetMeadowTitleFileName(false), new Vector2(-2.99f, 265.01f), true, false));
             this.scene.flatIllustrations[this.scene.flatIllustrations.Count - 1].sprite.shader = this.manager.rainWorld.Shaders["MenuText"];
 
-            var creditsButton = new SimplerButton(this, mainPage, Translate("Credits"), new Vector2(1056f, 600f), new Vector2(110f, 30f));
+            creditsButton = new SimplerButton(this, mainPage, Translate("Credits"), new Vector2(1056f, 600f), new Vector2(110f, 30f));
             creditsButton.OnClick += (_) =>
             {
                 manager.RequestMainProcessSwitch(RainMeadow.Ext_ProcessID.MeadowCredits);
@@ -133,7 +135,7 @@ namespace RainMeadow
             where.y -= 27;
             List<ListItem> requiredModsList = [
                 new("Any", Translate("Unfiltered"), 0),
-                new("MSC", Translate("MSC"), 1),
+                new("MSC", Translate("MSC"), 1),    
                 new("Watcher", Translate("Watcher"), 2),
                 new("MSC + Watcher", Translate("MSC + Watcher"), 3),
                 new("Exact", Translate("Exact order"), 4),
@@ -152,7 +154,7 @@ namespace RainMeadow
             where = new Vector2(manager.rainWorld.screenSize.x - 320f , 400f);
 
 
-            var directConnectButton = new SimplerButton(this, mainPage, Translate("Direct Connect"), new Vector2(where.x, where.y), new Vector2(160f, 30f));
+            directConnectButton = new SimplerButton(this, mainPage, Translate("Direct Connect"), new Vector2(where.x, where.y), new Vector2(160f, 30f));
             directConnectButton.OnClick += (_) =>
             {   
                 if (MatchmakingManager.currentDomain != MatchmakingManager.MatchMakingDomain.LAN)
@@ -185,7 +187,8 @@ namespace RainMeadow
 
 
             new UIelementWrapper(this.tabWrapper, domainDropDown);
-    
+
+            CreateElementBindings();
 
             // if (OnlineManager.currentlyJoiningLobby != default)
             // {
@@ -247,6 +250,22 @@ namespace RainMeadow
                 statisticsLabel.text = $"{Translate("Online:")} {playerCount} | {Translate("Lobbies:")} {lobbyCount}";
                 statisticsLabel.size = new Vector2(statisticsLabel.label.textRect.width, statisticsLabel.size.y);
             }
+        }
+        public void CreateElementBindings()
+        {
+            List<MenuObject> LeftColumnElements = new List<MenuObject>() { filterModeDropDown.wrapper, filterPublicLobbiesOnly.wrapper, filterLobbyLimit.wrapper, filterModsDropDown.wrapper, backObject };
+            List<MenuObject> RightColumnElements = new List<MenuObject>() { creditsButton, directConnectButton, domainDropDown.wrapper, createButton };
+            Extensions.TryMassMutualBind(this, LeftColumnElements, bottomTop: true, loopLastIndex: true, reverseList: true);
+            Extensions.TryMassMutualBind(this, RightColumnElements, bottomTop: true, loopLastIndex: true, reverseList: true);
+            Extensions.TryMassBindTo(LeftColumnElements, domainDropDown.wrapper, left: true); //This binds the cancel button which we don't want, but it gets overwritten later.
+
+            List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, lobbyList.scrollDownButton, lobbyList.RefreshButton, createButton };
+            Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true, reverseList: false);
+
+            Extensions.TryMutualBind(this, lobbyList.scrollUpButton, creditsButton, leftRight: true); //These aren't working and I don't know why...
+            Extensions.TryMutualBind(this, lobbyList.RefreshButton, lobbyList.OrderButton, bottomTop: true); //Tried a lot of stuff too.
+            Extensions.TryBind(directConnectButton, filterModeDropDown.wrapper, right: true);
+            Extensions.TryBind(domainDropDown.wrapper, filterModeDropDown.wrapper, right: true);
         }
 
         public override void GrafUpdate(float timeStacker)

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -253,19 +253,21 @@ namespace RainMeadow
         }
         public void CreateElementBindings()
         {
+            //Group up elements
             List<MenuObject> LeftColumnElements = new List<MenuObject>() { filterModeDropDown.wrapper, filterPublicLobbiesOnly.wrapper, filterLobbyLimit.wrapper, filterModsDropDown.wrapper};
             List<MenuObject> RightColumnElements = new List<MenuObject>() { creditsButton, directConnectButton, domainDropDown.wrapper, createButton };
+            List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, lobbyList.scrollDownButton, lobbyList.RefreshButton, createButton };
+            //Enforce order for the left column, right column, and bottom row
             Extensions.TrySequentialMutualBind(this, LeftColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
             Extensions.TrySequentialMutualBind(this, RightColumnElements, bottomTop: true, loopLastIndex: true, reverseList: true);
-            Extensions.TryMassBind(LeftColumnElements, domainDropDown.wrapper, left: true);
-
-            List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, lobbyList.scrollDownButton, lobbyList.RefreshButton, createButton };
             Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true, reverseList: false);
-
-            Extensions.TryMutualBind(this, lobbyList.scrollUpButton, creditsButton, leftRight: true);
-            Extensions.TryMutualBind(this, lobbyList.RefreshButton, lobbyList.OrderButton, bottomTop: true); //I can't get OrderButton to work for some reason, this line does nothing. Keeping it in case someone else knows a fix.
+            //Improve upon moving horizontally through the screen edge
+            Extensions.TryMassBind(LeftColumnElements, domainDropDown.wrapper, left: true);
             Extensions.TryBind(directConnectButton, filterModeDropDown.wrapper, right: true);
             Extensions.TryBind(domainDropDown.wrapper, filterModeDropDown.wrapper, right: true);
+            //Tweaks and cleanup
+            Extensions.TryMutualBind(this, lobbyList.scrollUpButton, creditsButton, leftRight: true);
+            Extensions.TryMutualBind(this, lobbyList.RefreshButton, lobbyList.OrderButton, bottomTop: true); //I can't get OrderButton to work for some reason, this line does nothing. Keeping it in case someone else knows a fix.
         }
 
         public override void GrafUpdate(float timeStacker)

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -262,8 +262,8 @@ namespace RainMeadow
             List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, lobbyList.scrollDownButton, lobbyList.RefreshButton, createButton };
             Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true, reverseList: false);
 
-            Extensions.TryMutualBind(this, lobbyList.scrollUpButton, creditsButton, leftRight: true); //These aren't working and I don't know why...
-            Extensions.TryMutualBind(this, lobbyList.RefreshButton, lobbyList.OrderButton, bottomTop: true); //Tried a lot of stuff too.
+            Extensions.TryMutualBind(this, lobbyList.scrollUpButton, creditsButton, leftRight: true);
+            Extensions.TryMutualBind(this, lobbyList.RefreshButton, lobbyList.OrderButton, bottomTop: true); //I can't get OrderButton to work for some reason, this line does nothing. Keeping it in case someone else knows a fix.
             Extensions.TryBind(directConnectButton, filterModeDropDown.wrapper, right: true);
             Extensions.TryBind(domainDropDown.wrapper, filterModeDropDown.wrapper, right: true);
         }

--- a/Menu/LobbySelectMenu.cs
+++ b/Menu/LobbySelectMenu.cs
@@ -255,12 +255,12 @@ namespace RainMeadow
         {
             List<MenuObject> LeftColumnElements = new List<MenuObject>() { filterModeDropDown.wrapper, filterPublicLobbiesOnly.wrapper, filterLobbyLimit.wrapper, filterModsDropDown.wrapper};
             List<MenuObject> RightColumnElements = new List<MenuObject>() { creditsButton, directConnectButton, domainDropDown.wrapper, createButton };
-            Extensions.TryMassMutualBind(this, LeftColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
-            Extensions.TryMassMutualBind(this, RightColumnElements, bottomTop: true, loopLastIndex: true, reverseList: true);
+            Extensions.TrySequentialMutualBind(this, LeftColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
+            Extensions.TrySequentialMutualBind(this, RightColumnElements, bottomTop: true, loopLastIndex: true, reverseList: true);
             Extensions.TryMassBind(LeftColumnElements, domainDropDown.wrapper, left: true);
 
             List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, lobbyList.scrollDownButton, lobbyList.RefreshButton, createButton };
-            Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true, reverseList: false);
+            Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true, reverseList: false);
 
             Extensions.TryMutualBind(this, lobbyList.scrollUpButton, creditsButton, leftRight: true); //These aren't working and I don't know why...
             Extensions.TryMutualBind(this, lobbyList.RefreshButton, lobbyList.OrderButton, bottomTop: true); //Tried a lot of stuff too.

--- a/Menu/MeadowMenu.cs
+++ b/Menu/MeadowMenu.cs
@@ -1,5 +1,6 @@
 ﻿using Menu;
 using Menu.Remix;
+using RainMeadow.UI.Pages;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -173,7 +174,32 @@ namespace RainMeadow
                 tintSlider.Hidden = true;
                 tintPreview.isVisible = false;
             }
+            UpdateElementBindings();
         }
+        public void UpdateElementBindings()
+        {
+            List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, prevButton, startButton, colorpicker.wrapper, nextButton };
+            List<MenuObject> SkinColumnElements = skinButtons.Cast<MenuObject>().ToList();
+
+            Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
+            Extensions.TryMassMutualBind(this, SkinColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
+
+            Extensions.TryMassBind(SkinColumnElements, startButton, right: true);
+            Extensions.TryMassBind(SkinColumnElements, backObject, left: true);
+            Extensions.TryMassBind(BottomRowElements, SkinColumnElements.Last(), top: true);
+            Extensions.TryMassBind(BottomRowElements, SkinColumnElements.First(), bottom: true);
+
+            Extensions.TryBind(SkinColumnElements.Last(), backObject, bottom: true);
+            Extensions.TryMutualBind(this, tintSlider, colorpicker.wrapper, bottomTop: true);
+            Extensions.TryBind(tintSlider, colorpicker.wrapper, bottom:true);
+        }
+        public override void Init()
+        {
+            base.Init();
+            UpdateElementBindings();
+            selectedObject = startButton;
+        }
+
 
         public override void Update()
         {
@@ -230,6 +256,7 @@ namespace RainMeadow
                 RainMeadow.Debug("personaSettings.tint: " + personaSettings.tint);
                 RainMeadow.Debug("personaSettings.tintAmount: " + personaSettings.tintAmount);
             }
+            UpdateElementBindings();
         }
 
         private void ReadCharacterSettings()

--- a/Menu/MeadowMenu.cs
+++ b/Menu/MeadowMenu.cs
@@ -1,6 +1,5 @@
 ﻿using Menu;
 using Menu.Remix;
-using RainMeadow.UI.Pages;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -178,17 +177,18 @@ namespace RainMeadow
         }
         public void UpdateElementBindings()
         {
+            //Group up elements
             List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, prevButton, startButton, colorpicker.wrapper, nextButton };
             List<MenuObject> SkinColumnElements = skinButtons.Cast<MenuObject>().ToList();
-
+            //Enforce row/column element order
             Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
             Extensions.TrySequentialMutualBind(this, SkinColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
-
+            //Make the row and column play nicely
             Extensions.TryMassBind(SkinColumnElements, startButton, right: true);
             Extensions.TryMassBind(SkinColumnElements, backObject, left: true);
             Extensions.TryMassBind(BottomRowElements, SkinColumnElements.Last(), top: true);
             Extensions.TryMassBind(BottomRowElements, SkinColumnElements.First(), bottom: true);
-
+            //Tweaks and cleanup
             Extensions.TryBind(SkinColumnElements.Last(), backObject, bottom: true);
             Extensions.TryMutualBind(this, tintSlider, colorpicker.wrapper, bottomTop: true);
             Extensions.TryBind(tintSlider, colorpicker.wrapper, bottom:true);

--- a/Menu/MeadowMenu.cs
+++ b/Menu/MeadowMenu.cs
@@ -181,8 +181,8 @@ namespace RainMeadow
             List<MenuObject> BottomRowElements = new List<MenuObject>() { backObject, prevButton, startButton, colorpicker.wrapper, nextButton };
             List<MenuObject> SkinColumnElements = skinButtons.Cast<MenuObject>().ToList();
 
-            Extensions.TryMassMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
-            Extensions.TryMassMutualBind(this, SkinColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
+            Extensions.TrySequentialMutualBind(this, BottomRowElements, leftRight: true, loopLastIndex: true);
+            Extensions.TrySequentialMutualBind(this, SkinColumnElements.Concat(new List<MenuObject>() { backObject }).ToList(), bottomTop: true, loopLastIndex: true, reverseList: true);
 
             Extensions.TryMassBind(SkinColumnElements, startButton, right: true);
             Extensions.TryMassBind(SkinColumnElements, backObject, left: true);
@@ -256,7 +256,6 @@ namespace RainMeadow
                 RainMeadow.Debug("personaSettings.tint: " + personaSettings.tint);
                 RainMeadow.Debug("personaSettings.tintAmount: " + personaSettings.tintAmount);
             }
-            UpdateElementBindings();
         }
 
         private void ReadCharacterSettings()

--- a/Menu/Pages/ArenaMainLobbyPage.cs
+++ b/Menu/Pages/ArenaMainLobbyPage.cs
@@ -271,6 +271,7 @@ public class ArenaMainLobbyPage : PositionedMenuObject
                     signalText = "START_MATCH"
                 };
                 subObjects.Add(startButton);
+                ArenaMenu.UpdateElementBindings();
             }
             Arena.shufflePlayList = levelSelector.selectedLevelsPlaylist.ShuffleStatus;
         }

--- a/RainMeadow.Logging.cs
+++ b/RainMeadow.Logging.cs
@@ -26,6 +26,10 @@ namespace RainMeadow
         {
             instance.Logger.LogInfo($"{LogDOT()}|{LogTime()}|{TrimCaller(callerFile)}.{callerName}");
         }
+        public static void Warn(object data, [CallerFilePath] string callerFile = "", [CallerMemberName] string callerName = "")
+        {
+            instance.Logger.LogWarning($"{LogDOT()}|{LogTime()}|{TrimCaller(callerFile)}.{callerName}:{data}");
+        }
         public static void Error(object data, [CallerFilePath] string callerFile = "", [CallerMemberName] string callerName = "")
         {
             instance.Logger.LogError($"{LogDOT()}|{LogTime()}|{TrimCaller(callerFile)}.{callerName}:{data}");


### PR DESCRIPTION
Fixes and improves many bugs and frustrations related to navigating meadow UIs with a controller; as-is many buttons jump to unexpected places, and some are difficult or impossible to reach as a result. Includes frameworks for making future improvements far easier. Adds a meadow logging "warn" channel (why don't we have one?). Full list of changes follows:

User-facing:
	- The lobby creation, meadow lobby, and meadow pause menus have had their binds completely fixed and marginally redesigned for more intuitive movement.
	- Similarly, the lobby selection and arena lobby menus have significant, and marginal improvements respectively.
	- The lobby creation and arena lobby menus have smarter default cursor positions.

Known issues:
	- Certain parts of the arena lobby menu are still horrible to navigate. I may work on additional fixes for this later, but the problems all stem from the dynamic lists, which will be extremely difficult to programmatically fix due to limitations in determining an element's actual position within the UI. The lobby select menu has similar problems, but they're *far* less intrusive due to having a much lower list density.
	- The lobby select menu's "sort lobbies by X" button should move to the refresh button when up is pressed, but it jumps to a different button instead. I have no idea why this happens, how to fix it, or what makes this one particular button problematic (and not the almost identical one right below).

Technical:
	- Certain existing bind functions now run as needed instead of every tick.
	- Adds 6 new extension functions to help refine and automate rebinding UI elements. These should make all future UI binding operations trivial, with the sole exception of the aforementioned variable-length lists.
	- Added a RainMeadow.Warn() logging channel. Went to go use it, and found we didn't actually have one for some reason, so now we do. If for some reason a warn channel is *unwanted*, the Warn()s I wrote should be changed to Error() rather than Debug().