### PR TITLE
Chatbar Fixes

### DIFF
--- a/Menu/Components/ChatTextBox2.cs
+++ b/Menu/Components/ChatTextBox2.cs
@@ -118,7 +118,7 @@ namespace RainMeadow.UI.Components
             if (cursorIsInMiddle)
             {
                 if (cursorSprite.element.name != "pixel") cursorSprite.SetElementByName("pixel");
-                cursorSprite.x = cursorPosition + 10 + screenPos.x;
+                cursorSprite.x = cursorPosition + 11 + screenPos.x;
                 cursorSprite.height = 13;
             }
             else
@@ -143,7 +143,7 @@ namespace RainMeadow.UI.Components
                 float width = LabelTest.GetWidth(menuLabel.text.Substring(start, Mathf.Min(Mathf.Abs(selectionStartPos - cursorPos), maxVisibleLength - start)), false);
                 cursorSprite.isVisible = false;
                 selectionSprite.isVisible = true;
-                selectionSprite.x = cursorPosition + screenPos.x + 10;
+                selectionSprite.x = cursorPosition + screenPos.x + 11;
                 selectionSprite.y = screenPos.y + size.y / 2;
                 selectionSprite.width = width;
             }
@@ -281,17 +281,17 @@ namespace RainMeadow.UI.Components
                 else
                 {
                     backspaceHeld = 0;
-                    if (Input.GetKeyDown(KeyCode.Home))
+                    if (Input.GetKey(KeyCode.Home))
                     {
                         cursorPos = 0;
                         selectionStartPos = -1;
                     }
-                    else if (Input.GetKeyDown(KeyCode.End) && cursorPos < len)
+                    else if (Input.GetKey(KeyCode.End) && cursorPos < len)
                     {
                         cursorPos = len;
                         selectionStartPos = -1;
                     }
-                    else if (Input.GetKeyDown(KeyCode.A) && (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)))
+                    else if (Input.GetKey(KeyCode.A) && (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)))
                     {
                         cursorPos = msg.Length;
                         selectionStartPos = 0;

--- a/Menu/Objects/ChatTemplate.cs
+++ b/Menu/Objects/ChatTemplate.cs
@@ -43,7 +43,7 @@ namespace RainMeadow
 
         }
 
-        public override void Update()
+        public override void GrafUpdate(float timeStacker)
         {
             var lowest = ChatTextBox.selectionPos != -1 ? Mathf.Min(ChatTextBox.cursorPos, ChatTextBox.selectionPos) : ChatTextBox.cursorPos;
             _cursorWidth = LabelTest.GetWidth(menuLabel.label.text.Substring(0, lowest), false);
@@ -57,7 +57,7 @@ namespace RainMeadow
                 selectionWrap.sprite.width = LabelTest.GetWidth(menuLabel.label.text.Substring(lowest, Mathf.Abs(ChatTextBox.selectionPos - ChatTextBox.cursorPos)), false);
             }
             else selectionWrap.sprite.isVisible = false;
-                base.Update();
+                base.GrafUpdate(timeStacker);
             this.roundedRect.fillAlpha = 1.0f;
         }
     }

--- a/Menu/Objects/ChatTemplate.cs
+++ b/Menu/Objects/ChatTemplate.cs
@@ -47,13 +47,13 @@ namespace RainMeadow
         {
             var lowest = ChatTextBox.selectionPos != -1 ? Mathf.Min(ChatTextBox.cursorPos, ChatTextBox.selectionPos) : ChatTextBox.cursorPos;
             _cursorWidth = LabelTest.GetWidth(menuLabel.label.text.Substring(0, lowest), false);
-            cursorWrap.sprite.x = _cursorWidth + (ChatTextBox.cursorPos < menuLabel.label.text.Length ? 8f : 15f) + this.pos.x;
+            cursorWrap.sprite.x = _cursorWidth + (ChatTextBox.cursorPos < menuLabel.label.text.Length ? 11f : 15f) + this.pos.x;
             cursorWrap.sprite.alpha = Mathf.PingPong(Time.time * 4f, 1f);
             cursorWrap.sprite.isVisible = ChatTextBox.selectionPos == -1;
             if (ChatTextBox.selectionPos != -1)
             {
                 selectionWrap.sprite.isVisible = true;
-                selectionWrap.sprite.x = _cursorWidth + this.pos.x + 7f;
+                selectionWrap.sprite.x = _cursorWidth + this.pos.x + 11f;
                 selectionWrap.sprite.width = LabelTest.GetWidth(menuLabel.label.text.Substring(lowest, Mathf.Abs(ChatTextBox.selectionPos - ChatTextBox.cursorPos)), false);
             }
             else selectionWrap.sprite.isVisible = false;

--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -131,7 +131,7 @@ namespace RainMeadow
             menuLabel.text = lastSentMessage;
         }
 
-        public override void GrafUpdate(float timeStacker)
+        public override void Update()
         {
             var msg = lastSentMessage;
             var len = msg.Length;
@@ -194,7 +194,7 @@ namespace RainMeadow
                 else
                 {
                     backspaceHeld = 0;
-                    if (Input.GetKeyDown(KeyCode.Home))
+                    if (Input.GetKey(KeyCode.Home))
                     {
                         bool changeSprite = cursorPos == len;
                         cursorPos = 0;
@@ -202,14 +202,14 @@ namespace RainMeadow
                         if (changeSprite) SetCursorSprite(true);
                     }
 
-                    else if (Input.GetKeyDown(KeyCode.End) && cursorPos < len)
+                    else if (Input.GetKey(KeyCode.End) && cursorPos < len)
                     {
                         cursorPos = len;
                         selectionPos = -1;
                         SetCursorSprite(false);
                     }
 
-                    else if (Input.GetKeyDown(KeyCode.A) && (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)))
+                    else if (Input.GetKey(KeyCode.A) && (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)))
                     {
                         if (cursorPos == len)
                         {
@@ -236,13 +236,13 @@ namespace RainMeadow
                             else
                             {
                                 var newPos = (shiftHeld && selectionActive) ? selectionPos : cursorPos;
-                                if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                                if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) && newPos > 0)
                                 {
                                     newPos = msg.Substring(0, newPos - 1).LastIndexOf(' ') + 1;
                                     if (newPos < 0 || newPos > len) newPos = 0;
                                 }
-                                else newPos--;
-                                if(shiftHeld)
+                                else newPos = Math.Max(0, newPos - 1);
+                                if (shiftHeld)
                                 {
                                     // stops the selection if it's on the same index as the anchor
                                     selectionPos = (newPos == cursorPos) ? -1 : newPos;
@@ -303,7 +303,7 @@ namespace RainMeadow
                 }
                 blockInput = true;
             }
-            base.GrafUpdate(timeStacker);
+            base.Update();
         }
 
         private void DeleteSelection()
@@ -322,7 +322,7 @@ namespace RainMeadow
                 _cursor.height = 13f;
                 float width = LabelTest.GetWidth(menuLabel.label.text.Substring(0, cursorPos), false);
                 _cursorWidth = width;
-                cursorWrap.sprite.x = width + 8f + pos.x;
+                cursorWrap.sprite.x = width + 11f + pos.x;
             }
             else
             {

--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -14,8 +14,8 @@ namespace RainMeadow
         private ButtonTypingHandler typingHandler;
         private GameObject gameObject;
         private bool isUnloading = false;
-        private float DASDelay = 1f/2f; //Sec
-        private float DASRepeatRate = 1f/30f; //Procs/sec
+        private float DASDelay = 1f/2f; //In seconds
+        private float DASRepeatRate = 1f/30f; //In seconds/proc
         private float backspaceHeld = 0f;
         private float backspaceRepeater = 0f;
         private float arrowHeld = 0f;
@@ -146,7 +146,7 @@ namespace RainMeadow
                 if (Input.GetKey(KeyCode.Backspace) && (cursorPos > 0 || selectionPos != -1))
                 {
                     // no alt + backspace, because alt can be finnicky
-                    // activates on either the first frame the key is held, or every other frame after it's been held down for half a second
+                    // activates on either the first frame the key is held, or for every (DASRepeatRate)th of a second after (DASDelay) seconds of being held
                     if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) && (backspaceHeld == 0 || (backspaceHeld >= DASDelay && backspaceRepeater >= DASRepeatRate)))
                     {
                         if (selectionPos != -1)


### PR DESCRIPTION
- Fixes the ingame and arena chatbars' cursor and text selection graphics being significantly, and slightly displaced to the left respectively.
- Fixes an issue with the ingame chatbar where Shift+Left when already at the textbox edge would reset the selection.
- Fixes an issue with the ingame chatbar where Ctrl+Shift+Left when already at the textbox edge would spam logs with OOBs.
- Fixes the ingame chatbar's keybinds' repeat rate and delay being affected by framerate.
- Fixes the ingame chatbar's visual and actual cursor position not necessarily being synced.
- Fixes an issue with the arena chatbar where Home, End, and Ctrl A would increasingly fail to register as FPS increases.