### PR TITLE
Profiler

### DIFF
--- a/Game/MeadowProfiler.cs
+++ b/Game/MeadowProfiler.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Profiling;
+
+namespace RainMeadow
+{
+    internal class MeadowProfiler
+    {
+        public static MeadowProfiler Instance;
+
+        public Dictionary<string, float[]> data = new();
+        public float gameUpdateTiming;
+
+        public bool open;
+
+        private Stopwatch stopwatch;
+        private int timer;
+
+        public MeadowProfiler()
+        {
+            Instance = this;
+            RainMeadow.Debug($"MeadowProfiler started.");
+        }
+
+        public void Destroy()
+        {
+            RainMeadow.Debug($"MeadowProfiler stopped.");
+            Instance = null;
+        }
+
+        public void Update()
+        {
+            timer++;
+            if (timer >= 40)
+            {
+                timer = 0;
+                open = true;
+            }
+        }
+
+        public void Pop()
+        {
+            if (stopwatch is null) return;
+            stopwatch.Stop();
+            long ticks = stopwatch.ElapsedTicks;
+            gameUpdateTiming = (float)ticks / Stopwatch.Frequency * 1000f;
+        }
+
+        public void Push()
+        {
+            stopwatch = Stopwatch.StartNew();
+        }
+
+        private string FormatedName(MethodBase method)
+        {
+            return $"{method.DeclaringType.FullName}.{method.Name}";
+        }
+    }
+}

--- a/Game/MeadowProfiler.cs
+++ b/Game/MeadowProfiler.cs
@@ -134,12 +134,13 @@ namespace RainMeadow
 
         public void Update()
         {
+            if (!patched) return;
             snapshot.Clear();
 
             snapshot.AddRange(data.Values.OrderBy(x => -x.ticksSpent));
         }
 
-        private string FormatedName(MethodBase method)
+        private static string FormatedName(MethodBase method)
         {
             return $"{method.DeclaringType.FullName}.{method.Name}";
         }
@@ -174,7 +175,7 @@ namespace RainMeadow
             public ProfilerInfo(MethodBase method)
             {
                 this.method = method;
-                this.name = $"{method.DeclaringType.FullName}.{method.Name}";
+                this.name = FormatedName(method);
 
                 this.timer = new Stopwatch();
             }

--- a/Game/MeadowProfiler.cs
+++ b/Game/MeadowProfiler.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HarmonyLib;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,22 +8,42 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Unity.IO.LowLevel.Unsafe;
 using UnityEngine;
 using UnityEngine.Profiling;
+using static Rewired.Controller;
 
 namespace RainMeadow
 {
+    // Based on the RuntimeUnityEditor profiler
     internal class MeadowProfiler
     {
         public static MeadowProfiler Instance;
 
-        public Dictionary<string, float[]> data = new();
+        public static readonly Dictionary<long, ProfilerInfo> data = new();
+        public static readonly List<ProfilerInfo> snapshot = new();
+
+        private static readonly Harmony harmony = new("meadow-profiler");
+
+        public static bool patched;
+
         public float gameUpdateTiming;
+        public static int executionCount;
+
+        public static int currentDepth;
+        public static List<StackPosition> currentStackTree = new();
 
         public bool open;
 
-        private Stopwatch stopwatch;
-        private int timer;
+        // Code dealing with shaders seems to completely expode so we'll just avoid it
+        private static readonly string[] avoid =
+        [
+            "RippleCameraData",
+            "Snow",
+            "Menu.Remix",
+            "DevInterface",
+            "ConfigAcceptable",
+        ];
 
         public MeadowProfiler()
         {
@@ -36,32 +57,155 @@ namespace RainMeadow
             Instance = null;
         }
 
+        public static void FullPatch()
+        {
+            data.Clear();
+
+            harmony.UnpatchSelf();
+
+            var asm = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(x => x.GetName().Name.Equals("Assembly-CSharp"));
+
+            var hits = asm.GetTypesSafely()
+                .Select(t =>
+                {
+                    if (t.ContainsGenericParameters)
+                    {
+                        try
+                        {
+                            var type = t.MakeGenericType(t.GetGenericArguments().Select(x => x.BaseType).ToArray());
+                            return type;
+                        }
+                        catch (Exception ex)
+                        {
+                            RainMeadow.Error($"MeadowProfiler failed to hook in class {t.FullName}");
+                            return null;
+                        }
+                    }
+                    return t;
+                })
+                .SelectMany(x => x?.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) ?? new MethodBase[0])
+                .Where(x =>
+                {
+                    return x.Name.Contains("Update") && !avoid.Any(x.Name.Contains) && !avoid.Any(x.DeclaringType.FullName.Contains);
+                })
+                .ToList();
+
+            foreach(var hit in hits)
+            {
+                try
+                {
+                    harmony.Patch(original: hit,
+                        prefix: new HarmonyMethod(typeof(MeadowProfiler), nameof(Push)) { priority = int.MaxValue },
+                        postfix: new HarmonyMethod(typeof(MeadowProfiler), nameof(Pop)) { priority = int.MinValue });
+                }
+                catch(Exception ex)
+                {
+                    RainMeadow.Error($"MeadowProfiler failed to hook {hit.FullDescription()}");
+                }
+            }
+
+            patched = true;
+        }
+
         public void Update()
         {
-            timer++;
-            if (timer >= 40)
-            {
-                timer = 0;
-                open = true;
-            }
-        }
+            snapshot.Clear();
 
-        public void Pop()
-        {
-            if (stopwatch is null) return;
-            stopwatch.Stop();
-            long ticks = stopwatch.ElapsedTicks;
-            gameUpdateTiming = (float)ticks / Stopwatch.Frequency * 1000f;
-        }
-
-        public void Push()
-        {
-            stopwatch = Stopwatch.StartNew();
+            snapshot.AddRange(data.Values.OrderBy(x => -x.ticksSpent));
         }
 
         private string FormatedName(MethodBase method)
         {
             return $"{method.DeclaringType.FullName}.{method.Name}";
+        }
+
+        public class ProfilerInfo
+        {
+            public readonly string name;
+            public readonly MethodBase method;
+
+            public readonly Stopwatch timer;
+
+            public StackPosition[] tree;
+
+            public long ticksSpent;
+            public long hash;
+            
+            private int depth;
+            private int highestDepth;
+
+            public int Depth
+            {
+                get => depth;
+                set
+                {
+                    depth = value;
+                    if (highestDepth < value)
+                    {
+                        highestDepth = value;
+                    }
+                }
+            }
+            public ProfilerInfo(MethodBase method)
+            {
+                this.method = method;
+                this.name = $"{method.DeclaringType.FullName}.{method.Name}";
+
+                this.timer = new Stopwatch();
+            }
+        }
+
+        public struct StackPosition
+        {
+            public long hash;
+            public string name;
+            public StackPosition(long hash, string name)
+            {
+                this.hash = hash;
+                this.name = name;
+            }
+        }
+
+        public static long GetKeyHash(MethodBase __originalMethod, object __instance)
+        {
+            return __instance.GetHashCode() + ((long)__originalMethod.GetHashCode() << 32);
+        }
+
+        public static bool Push(MethodBase __originalMethod, object __instance, ref ProfilerInfo __state)
+        {
+            var hash = GetKeyHash(__originalMethod, __instance);
+
+            if (!data.TryGetValue(hash, out var info))
+            {
+                info = new ProfilerInfo(__originalMethod);
+                data.Add(hash, info);
+            }
+
+            info.Depth = currentDepth++;
+
+            info.tree = currentStackTree.ToArray();
+            info.hash = hash;
+            currentStackTree.Add(new StackPosition(hash, info.name));
+
+            info.timer.Reset();
+            info.timer.Start();
+
+            __state = info;
+
+            return true;
+        }
+
+        public static void Pop(bool __runOriginal, ProfilerInfo __state)
+        {
+            if (__state == null) return;
+
+            var info = __state;
+
+            currentDepth = Math.Max(0, currentDepth - 1);
+            currentStackTree.RemoveAt(currentStackTree.FindLastIndex(x => x.hash == info.hash && x.name == info.name));
+
+            info.ticksSpent = info.timer.ElapsedTicks;
         }
     }
 }

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -56,8 +56,6 @@ public class RainMeadowOptions : OptionInterface
 
     public readonly Configurable<IntroRoll> PickedIntroRoll;
 
-    public readonly Configurable<bool> AdvancedProfiling;
-
     public enum IntroRoll
     {
         Meadow,
@@ -139,8 +137,6 @@ public class RainMeadowOptions : OptionInterface
         StopMovementWhileSpectateOverlayActive = config.Bind("StopMovementWhileSpectateOverlayActive", false);
 
         ChatBgOpacity = config.Bind("ChatBgOpacity", 0.2f);
-
-        AdvancedProfiling = config.Bind("AdvancedProfiling", false);
     }
 
     public override void Initialize()
@@ -152,11 +148,10 @@ public class RainMeadowOptions : OptionInterface
             OpTab arenaTab = new OpTab(this, Translate("Arena"));
             OpTab storyTab = new OpTab(this, Translate("Story"));
             OpTab lanTab = new OpTab(this, Translate("LAN"));
-            OpTab advancedTab = new OpTab(this, Translate("Advanced"));
 
 
 
-            Tabs = new OpTab[] { opTab, meadowTab, arenaTab, storyTab, lanTab, advancedTab };
+            Tabs = new OpTab[] { opTab, meadowTab, arenaTab, storyTab, lanTab };
 
             List<UIelement> meadowCheats;
             OpTextBox meadowCheatBox;
@@ -404,19 +399,6 @@ public class RainMeadowOptions : OptionInterface
 
         };
             lanTab.AddItems(OnlineLANSettings);
-
-            OnlineAdvancedSettings = 
-                [
-                    new OpLabel(10f, 550f, Translate("Advanced"), bigText: true),
-
-                    new OpLabel(10f, 530f, Translate("Warning: You should only touch these settings if you know what you're doing."), bigText: false),
-
-                    new OpLabel(10f, 445f, Translate("Advanced Profiler")),
-                    new OpLabel(10f, 415f, Custom.ReplaceLineDelimeters(Translate("Advanced Profiling will allow you to monitor CPU usage and determine what's using up the most CPU.<LINE>This WILL cause a lot of lag and may cause unexpected behavior and crashes.<LINE>Requires Restart."))),
-
-                    new OpCheckBox(AdvancedProfiling, new Vector2(310f, 360)),
-                ];
-            advancedTab.AddItems(OnlineAdvancedSettings);
         }
 
         catch (Exception ex)

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -56,6 +56,8 @@ public class RainMeadowOptions : OptionInterface
 
     public readonly Configurable<IntroRoll> PickedIntroRoll;
 
+    public readonly Configurable<bool> AdvancedProfiling;
+
     public enum IntroRoll
     {
         Meadow,
@@ -70,6 +72,7 @@ public class RainMeadowOptions : OptionInterface
     private UIelement[] OnlineArenaSettings;
     private UIelement[] OnlineStorySettings;
     private UIelement[] OnlineLANSettings;
+    private UIelement[] OnlineAdvancedSettings;
 
 
 
@@ -136,6 +139,8 @@ public class RainMeadowOptions : OptionInterface
         StopMovementWhileSpectateOverlayActive = config.Bind("StopMovementWhileSpectateOverlayActive", false);
 
         ChatBgOpacity = config.Bind("ChatBgOpacity", 0.2f);
+
+        AdvancedProfiling = config.Bind("AdvancedProfiling", false);
     }
 
     public override void Initialize()
@@ -147,10 +152,11 @@ public class RainMeadowOptions : OptionInterface
             OpTab arenaTab = new OpTab(this, Translate("Arena"));
             OpTab storyTab = new OpTab(this, Translate("Story"));
             OpTab lanTab = new OpTab(this, Translate("LAN"));
+            OpTab advancedTab = new OpTab(this, Translate("Advanced"));
 
 
 
-            Tabs = new OpTab[] { opTab, meadowTab, arenaTab, storyTab, lanTab };
+            Tabs = new OpTab[] { opTab, meadowTab, arenaTab, storyTab, lanTab, advancedTab };
 
             List<UIelement> meadowCheats;
             OpTextBox meadowCheatBox;
@@ -399,6 +405,18 @@ public class RainMeadowOptions : OptionInterface
         };
             lanTab.AddItems(OnlineLANSettings);
 
+            OnlineAdvancedSettings = 
+                [
+                    new OpLabel(10f, 550f, Translate("Advanced"), bigText: true),
+
+                    new OpLabel(10f, 530f, Translate("Warning: You should only touch these settings if you know what you're doing."), bigText: false),
+
+                    new OpLabel(10f, 445f, Translate("Advanced Profiler")),
+                    new OpLabel(10f, 415f, Custom.ReplaceLineDelimeters(Translate("Advanced Profiling will allow you to monitor CPU usage and determine what's using up the most CPU.<LINE>This WILL cause a lot of lag and may cause unexpected behavior and crashes.<LINE>Requires Restart."))),
+
+                    new OpCheckBox(AdvancedProfiling, new Vector2(310f, 360)),
+                ];
+            advancedTab.AddItems(OnlineAdvancedSettings);
         }
 
         catch (Exception ex)

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -238,6 +238,10 @@ namespace RainMeadow
                     MeadowProgression.AutosaveProgression();
                 }
             }
+            if (OnlineManager.lobby != null)
+            {
+                self.devToolsLabel.text = self.devToolsLabel.text + $" | Rain Meadow {RainMeadow.MeadowVersionStr} ({MatchmakingManager.currentDomain.value})";
+            }
         }
 
         public bool RainWorldGame_GamePaused(Func<RainWorldGame, bool> orig, RainWorldGame self)
@@ -378,6 +382,7 @@ namespace RainMeadow
 
         private void RainWorldGame_RawUpdate(On.RainWorldGame.orig_RawUpdate orig, RainWorldGame self, float dt)
         {
+            MeadowProfiler.Instance?.Push();
             var closeChat = false;
             if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is not MeadowGameMode && !self.lastPauseButton && ChatTextBox.blockInput)
             {
@@ -403,8 +408,10 @@ namespace RainMeadow
             if (OnlineManager.lobby != null)
             {
                 DebugOverlay.Update(self, dt);
+                ProfilerOverlay.Update(self, dt);
                 MeadowMusic.RawUpdate(self, dt);
             }
+            MeadowProfiler.Instance?.Pop();
         }
 
         private void RainWorldGame_ShutDownProcess(On.RainWorldGame.orig_ShutDownProcess orig, RainWorldGame self)
@@ -413,6 +420,7 @@ namespace RainMeadow
             if (OnlineManager.lobby != null)
             {
                 DebugOverlay.RemoveOverlay(self);
+                ProfilerOverlay.RemoveOverlay(self);
 
                 OnlineManager.lobby.gameMode.GameShutDown(self);
 

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -382,7 +382,6 @@ namespace RainMeadow
 
         private void RainWorldGame_RawUpdate(On.RainWorldGame.orig_RawUpdate orig, RainWorldGame self, float dt)
         {
-            MeadowProfiler.Instance?.Push();
             var closeChat = false;
             if (OnlineManager.lobby != null && OnlineManager.lobby.gameMode is not MeadowGameMode && !self.lastPauseButton && ChatTextBox.blockInput)
             {
@@ -411,7 +410,6 @@ namespace RainMeadow
                 ProfilerOverlay.Update(self, dt);
                 MeadowMusic.RawUpdate(self, dt);
             }
-            MeadowProfiler.Instance?.Pop();
         }
 
         private void RainWorldGame_ShutDownProcess(On.RainWorldGame.orig_ShutDownProcess orig, RainWorldGame self)

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -179,12 +179,17 @@ namespace RainMeadow
 
         public static void Update(RainWorldGame self, float dt)
         {
-            if (overlayContainer == null && self.devToolsActive)
+            if (overlayContainer == null && self.devToolsActive && !ProfilerOverlay.profilerActive)
             {
                 CreateOverlay(self);
             }
 
             if (overlayContainer != null && !self.devToolsActive)
+            {
+                RemoveOverlay(self);
+            }
+
+            if (overlayContainer != null && self.devToolsActive && ProfilerOverlay.profilerActive)
             {
                 RemoveOverlay(self);
             }

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -207,6 +207,9 @@ namespace RainMeadow
             playersWritten.removeExpired();
             playersRead.removeExpired();
 
+            ProfilerOverlay.totalRead = 0;
+            ProfilerOverlay.totalWritten = 0;
+
             int line = 0;
             foreach (playerCache.Individual idv in playersWritten.items)
             {
@@ -220,6 +223,8 @@ namespace RainMeadow
                 // averageBytes = bytes per 40 frames
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
+
+                ProfilerOverlay.totalWritten += averageBits;
 
                 FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
@@ -250,6 +255,8 @@ namespace RainMeadow
                 // averageBytes = bytes per 40 frames
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
+
+                ProfilerOverlay.totalRead += averageBits;
 
                 FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -207,9 +207,6 @@ namespace RainMeadow
             playersWritten.removeExpired();
             playersRead.removeExpired();
 
-            ProfilerOverlay.totalRead = 0;
-            ProfilerOverlay.totalWritten = 0;
-
             int line = 0;
             foreach (playerCache.Individual idv in playersWritten.items)
             {
@@ -223,8 +220,6 @@ namespace RainMeadow
                 // averageBytes = bytes per 40 frames
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
-
-                ProfilerOverlay.totalWritten += averageBits;
 
                 FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
@@ -255,8 +250,6 @@ namespace RainMeadow
                 // averageBytes = bytes per 40 frames
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
-
-                ProfilerOverlay.totalRead += averageBits;
 
                 FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -396,7 +396,9 @@ namespace RainMeadow
         public virtual void ReadState(EntityState entityState, OnlineResource inResource)
         {
             lastStates[inResource] = entityState;
+            StateProfiler.Instance?.Push(entityState.GetType());
             entityState.ReadTo(this);
+            StateProfiler.Instance?.Pop(entityState.GetType());
         }
 
         public Dictionary<OnlineResource, Queue<EntityState>> incomingState = new();

--- a/Online/OnlineManager.cs
+++ b/Online/OnlineManager.cs
@@ -48,6 +48,7 @@ namespace RainMeadow
                 MatchmakingManager.instances[last].LeaveLobby();
                 LeaveLobby();
             };
+            new StateProfiler();
             RainMeadow.Debug("OnlineManager Created");
         }
 

--- a/Online/ProfilerOverlay.cs
+++ b/Online/ProfilerOverlay.cs
@@ -280,7 +280,7 @@ namespace RainMeadow
 
                 entries = opos.Select(x => x.apo).GroupBy(x => x.type.value).ToDictionary(x => x.Key, x => x.Count()).ToList();
 
-                entries.OrderBy(x => -x.Value);
+                entries = entries.OrderBy(x => -x.Value).ToList();
 
                 if (entries.Count > 0)
                 {
@@ -346,7 +346,7 @@ namespace RainMeadow
                 entries = OnlineManager.recentEntities.Values.GroupBy(x => x.GetType()).ToDictionary(x => x.Key, x => x.Count()).ToList();
                 total = OnlineManager.recentEntities.Values.Count();
 
-                entries.OrderBy(x => -x.Value);
+                entries = entries.OrderBy(x => -x.Value).ToList();
 
                 if (entries.Count > 0)
                 {
@@ -480,7 +480,7 @@ namespace RainMeadow
                 total = failedComparisons.Count;
                 entries = failedComparisons.Distinct().ToDictionary(x => x.DeclaringType.Name + "." + x.Name, x => failedComparisons.Count(y => y == x)).ToList();
 
-                entries.OrderBy(x => -x.Value);
+                entries = entries.OrderBy(x => -x.Value).ToList();
 
                 if (entries.Count > 0)
                 {

--- a/Online/ProfilerOverlay.cs
+++ b/Online/ProfilerOverlay.cs
@@ -648,6 +648,16 @@ namespace RainMeadow
             Vector2 screenSize = self.rainWorld.options.ScreenSize;
             overlayContainer = new FContainer();
 
+            if (MeadowProfiler.patched)
+            {
+                overlayContainer.AddChild(new FLabel(Custom.GetFont(), "Advanced Profiling Enabled, press '-' to generate a collapsed stack.")
+                {
+                    x = screenSize.x / 2f + 0.01f,
+                    y = 740.01f,
+                    color = new Color(1f, 1f, 0.5f)
+                });
+            }
+
             // Framerate
             overlayContainer.AddChild(new FLabel(Custom.GetFont(), "Framerate")
             {

--- a/Online/ProfilerOverlay.cs
+++ b/Online/ProfilerOverlay.cs
@@ -402,7 +402,7 @@ namespace RainMeadow
                 int index = 0;
                 foreach (var entry in entries)
                 {
-                    labels[index].text = $"[{index}] {entry.type.Name} - {(float)(entry.ticksSpent / total) * 100}%";
+                    labels[index].text = $"[{index}] {entry.type.Name} - {(float)(entry.ticksSpent / total)}%";
                     labels[index].color = entry.color;
 
                     labels[index].x = pos.x - 80;
@@ -411,7 +411,7 @@ namespace RainMeadow
                     index++;
                 }
 
-                mainLabel.text = $"Total Write Delay - {(float)(total / Stopwatch.Frequency)}";
+                mainLabel.text = $"Total Write Delay - {total}";
 
                 int stepsTaken = 0;
                 foreach (var entry in entries)

--- a/Online/ProfilerOverlay.cs
+++ b/Online/ProfilerOverlay.cs
@@ -187,6 +187,7 @@ namespace RainMeadow
 
         private static List<ProfilerGraph> profilerGraphs = new List<ProfilerGraph>();
         private static bool keyDown;
+        private static bool minusDown;
 
         public static void Update(RainWorldGame self, float dt)
         {
@@ -204,6 +205,16 @@ namespace RainMeadow
                 RemoveOverlay(self);
             }
             if (overlayContainer == null) return;
+            if (self.devToolsActive && Input.GetKey(KeyCode.Minus) && MeadowProfiler.patched && !minusDown)
+            {
+                if (MeadowProfiler.Instance is not null)
+                {
+                    MeadowProfiler.Instance.Update();
+                    FlameGraph.OutputFlameGraph();
+                }
+            }
+            minusDown = self.devToolsActive && Input.GetKey(KeyCode.Minus);
+
             Vector2 screenSize = self.rainWorld.options.ScreenSize;
 
             framerate = (int)(1.0f / dt);

--- a/Online/ProfilerOverlay.cs
+++ b/Online/ProfilerOverlay.cs
@@ -1,0 +1,297 @@
+﻿using RWCustom;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Profiling;
+
+namespace RainMeadow
+{
+    public static class ProfilerOverlay
+    {
+        public static bool profilerActive;
+
+        private static FContainer overlayContainer;
+        private static int framerate;
+
+        private class ProfilerGraph
+        {
+            private readonly Func<float> _getValue;
+
+            public enum Format
+            {
+                None,
+                MB
+            }
+            private Format format;
+
+            public FSprite[] graphLines;
+            public FSprite[] indexLines;
+            public FLabel[] labels;
+
+            public FSprite backDrop;
+
+            private float[] pastValues;
+
+            private Vector2 pos;
+
+            private int width, height, index;
+            public float min, max;
+
+            private bool inverted;
+            private bool incremented;
+
+            public float CurrentValue => _getValue();
+
+            public ProfilerGraph(FContainer container, Vector2 pos, int width, int height, Func<float> readValue, float min, float max, bool inverted = false, bool incremented = false, Format format = Format.None)
+            {
+                _getValue = readValue;
+                this.width = width;
+                this.height = height;
+                this.pos = pos;
+
+                this.min = min;
+                this.max = max;
+                this.inverted = inverted;
+                this.format = format;
+
+                backDrop = new FSprite("pixel")
+                {
+                    color = Color.black,
+                    x = pos.x,
+                    y = pos.y,
+                    alpha = 0.25f,
+                    anchorX = 0,
+                    anchorY = 0,
+                    scaleX = width,
+                    scaleY = height,
+                };
+                container.AddChild(backDrop);
+
+                graphLines = new FSprite[width];
+                for (int i = 0; i < graphLines.Length; i++)
+                {
+                    graphLines[i] = new FSprite("pixel");
+                    graphLines[i].x = pos.x + i;
+                    graphLines[i].y = pos.y;
+                    graphLines[i].anchorY = 0;
+                    container.AddChild(graphLines[i]);
+                }
+
+                indexLines = new FSprite[3];
+
+                indexLines[0] = new FSprite("pixel"); // Min
+                indexLines[0].color = inverted ? Color.green : Color.red;
+
+                indexLines[1] = new FSprite("pixel"); // Max
+                indexLines[1].color = inverted ? Color.red : Color.green;
+
+                indexLines[2] = new FSprite("pixel"); // Average
+                indexLines[2].color = Color.yellow;
+                indexLines[2].alpha = 0.5f;
+
+                for (int i = 0; i < indexLines.Length; i++)
+                {
+                    indexLines[i].x = pos.x;
+                    indexLines[i].y = pos.y;
+
+                    indexLines[i].anchorX = 0;
+                    indexLines[i].scaleX = width;
+                    container.AddChild(indexLines[i]);
+                }
+
+                indexLines[1].y = pos.y + height;
+
+                labels = new FLabel[3];
+
+                labels[0] = new FLabel(Custom.GetFont(), min.ToString() + (format == Format.MB ? " MB" : "")) // Min
+                {
+                    alignment = FLabelAlignment.Left,
+                    x = indexLines[0].x + width + 5f,
+                    y = indexLines[0].y - 15,
+                };
+                container.AddChild(labels[0]);
+
+                labels[1] = new FLabel(Custom.GetFont(), max.ToString() + (format == Format.MB ? " MB" : "")) // Max
+                {
+                    alignment = FLabelAlignment.Left,
+                    x = indexLines[1].x + width + 5f,
+                    y = indexLines[1].y + 15,
+                };
+                container.AddChild(labels[1]);
+
+                labels[2] = new FLabel(Custom.GetFont(), (max / 2).ToString() + (format == Format.MB ? " MB" : "")) // Average
+                {
+                    alignment = FLabelAlignment.Left,
+                    x = indexLines[2].x + width + 5f,
+                    y = indexLines[2].y,
+                };
+                container.AddChild(labels[2]);
+            }
+
+            public void Increment()
+            {
+                incremented = false;
+                Update();
+                incremented = true;
+            }
+
+            public void Update()
+            {
+                if (incremented) return;
+                var value = Mathf.InverseLerp(min, max, CurrentValue);
+                var graphY = Mathf.Lerp(0, height, value);
+
+                foreach(var graphLine in graphLines)
+                {
+                    graphLine.color = Color.Lerp(Color.black, graphLine.color, 0.995f);
+                }
+
+                graphLines[index].scaleY = graphY;
+                if (inverted)
+                {
+                    graphLines[index].color = Color.Lerp(Color.green, Color.red, value);
+                }
+                else
+                {
+                    graphLines[index].color = Color.Lerp(Color.red, Color.green, value);
+                }
+                indexLines[2].y = pos.y + graphY;
+
+                labels[2].y = indexLines[2].y;
+                labels[2].text = CurrentValue.ToString() + (format == Format.MB ? " MB" : "");
+
+                index++;
+                if (index >= width) index = 0;
+            }
+
+            public void RemoveSprites()
+            {
+                backDrop.RemoveFromContainer();
+                foreach (var sprite in graphLines)
+                {
+                    sprite.RemoveFromContainer();
+                }
+                foreach (var sprite in indexLines)
+                {
+                    sprite.RemoveFromContainer();
+                }
+                foreach(var label in labels)
+                {
+                    label.RemoveFromContainer();
+                }
+            }
+        }
+
+        private static List<ProfilerGraph> profilerGraphs = new List<ProfilerGraph>();
+        private static bool keyDown;
+
+        public static void Update(RainWorldGame self, float dt)
+        {
+            if (self.devToolsActive && Input.GetKey(KeyCode.Equals) && !keyDown)
+            {
+                profilerActive = !profilerActive;
+            }
+            keyDown = self.devToolsActive && Input.GetKey(KeyCode.Equals);
+            if (overlayContainer == null && self.devToolsActive && profilerActive)
+            {
+                CreateOverlay(self);
+            }
+            if (overlayContainer != null && !self.devToolsActive || !profilerActive)
+            {
+                RemoveOverlay(self);
+            }
+            if (overlayContainer == null) return;
+            Vector2 screenSize = self.rainWorld.options.ScreenSize;
+
+            framerate = (int)(1.0f / dt);
+
+            foreach(var graph in profilerGraphs)
+            {
+                graph.Update();
+            }
+        }
+
+        public static void CreateOverlay(RainWorldGame self)
+        {
+            if (MeadowProfiler.Instance is null)
+            {
+                MeadowProfiler.Instance = new();
+            }
+
+            Vector2 screenSize = self.rainWorld.options.ScreenSize;
+            overlayContainer = new FContainer();
+
+            // Framerate
+            overlayContainer.AddChild(new FLabel(Custom.GetFont(), "Framerate")
+            {
+                alignment = FLabelAlignment.Left,
+                x = 5.01f,
+                y = screenSize.y - 10,
+            });
+
+            profilerGraphs.Add(new ProfilerGraph(overlayContainer, new Vector2(5.01f, screenSize.y - 120), 240, 80, () =>
+            {
+                return (float)framerate;
+            }, 0f, (float)(Application.targetFrameRate == -1 ? 240 : Application.targetFrameRate)));
+
+            // Memory
+            overlayContainer.AddChild(new FLabel(Custom.GetFont(), "Memory Usage")
+            {
+                alignment = FLabelAlignment.Left,
+                x = 5.01f,
+                y = screenSize.y - 210,
+            });
+
+            profilerGraphs.Add(new ProfilerGraph(overlayContainer, new Vector2(5.01f, screenSize.y - 320), 240, 80, () =>
+            {
+                return Profiler.GetTotalAllocatedMemoryLong() / (1024f * 1024f); // MB Value
+            }, 0f, SystemInfo.systemMemorySize, true, false, ProfilerGraph.Format.MB));
+
+            // Bandwidth
+            overlayContainer.AddChild(new FLabel(Custom.GetFont(), "Bandwidth Usage")
+            {
+                alignment = FLabelAlignment.Left,
+                x = 5.01f,
+                y = screenSize.y - 410,
+            });
+            // TODO Implement this
+            profilerGraphs.Add(new ProfilerGraph(overlayContainer, new Vector2(5.01f, screenSize.y - 520), 240, 80, () =>
+            {
+                return 0;
+            }, 0f, 10f, true, false, ProfilerGraph.Format.MB));
+
+            // Update Timing
+            overlayContainer.AddChild(new FLabel(Custom.GetFont(), "Game Update (ms)")
+            {
+                alignment = FLabelAlignment.Left,
+                x = 5.01f,
+                y = screenSize.y - 610,
+            });
+            // TODO Implement this
+            profilerGraphs.Add(new ProfilerGraph(overlayContainer, new Vector2(5.01f, screenSize.y - 720), 240, 80, () =>
+            {
+                float value = 0;
+                value = (float)MeadowProfiler.Instance?.gameUpdateTiming;
+                if (profilerGraphs[3].max < value)
+                {
+                    profilerGraphs[3].max = value;
+                }
+                return value;
+            }, 0f, 50f, true, false));
+
+
+            Futile.stage.AddChild(overlayContainer);
+        }
+
+        public static void RemoveOverlay(RainWorldGame self)
+        {
+            profilerGraphs.Clear();
+            overlayContainer?.RemoveFromContainer();
+            overlayContainer = null;
+            MeadowProfiler.Instance?.Destroy();
+        }
+    }
+}

--- a/Online/Serialization/Serializer.cs
+++ b/Online/Serialization/Serializer.cs
@@ -290,6 +290,7 @@ namespace RainMeadow
             while (toPlayer.OutgoingStates.Count > 0)
             {
                 var s = toPlayer.OutgoingStates.Dequeue();
+                StateProfiler.Instance?.Push(s.state.GetType());
                 if (WriteState(s.state))
                 {
                     RainMeadow.Trace($"{s.state} sent");
@@ -300,6 +301,7 @@ namespace RainMeadow
                     RainMeadow.Error($"State overflow writing to player {toPlayer}, {s.state} not sent");
                     s.Failed();
                 }
+                StateProfiler.Instance?.Pop(s.state.GetType());
             }
 
             EndWriteStates();

--- a/Online/State/AbstractPhysicalObjectState.cs
+++ b/Online/State/AbstractPhysicalObjectState.cs
@@ -162,7 +162,12 @@ namespace RainMeadow
             if (onlineObject.apo.realizedObject != null)
             {
                 RainMeadow.Trace($"{onlineEntity} realized target exists");
-                realizedObjectState?.ReadTo(onlineEntity);
+                if (realizedObjectState != null)
+                {
+                    StateProfiler.Instance?.Push(realizedObjectState.GetType());
+                    realizedObjectState.ReadTo(onlineEntity);
+                    StateProfiler.Instance?.Pop(realizedObjectState.GetType());
+                }
             }
         }
     }

--- a/Online/StateProfiler.cs
+++ b/Online/StateProfiler.cs
@@ -40,10 +40,16 @@ namespace RainMeadow
             stateRed.ticksSpent = stateRed.timer.ElapsedTicks;
         }
 
+        public enum Category
+        {
+
+        }
+
         public class StateRep
         {
             public readonly Type type;
             public readonly Color color;
+            public readonly Category category;
 
             public readonly Stopwatch timer;
 

--- a/Online/StateProfiler.cs
+++ b/Online/StateProfiler.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using static RainMeadow.StateProfiler;
+using Random = UnityEngine.Random;
+
+namespace RainMeadow
+{
+    internal class StateProfiler
+    {
+        public static StateProfiler? Instance;
+
+        public Dictionary<Type, StateRep> data = new();
+
+        public StateProfiler()
+        {
+            Instance = this;
+        }
+
+        public void Push(Type type)
+        {
+            if (!data.TryGetValue(type, out var stateRep))
+            {
+                stateRep = new StateRep(type);
+                data.Add(type, stateRep);
+            }
+
+            stateRep.timer.Reset();
+            stateRep.timer.Start();
+        }
+
+        public void Pop(Type type)
+        {
+            if (!data.TryGetValue(type, out var stateRed)) return;
+            stateRed.ticksSpent = stateRed.timer.ElapsedTicks;
+        }
+
+        public class StateRep
+        {
+            public readonly Type type;
+            public readonly Color color;
+
+            public readonly Stopwatch timer;
+
+            public long ticksSpent;
+            public StateRep(Type type)
+            {
+                this.type = type;
+                this.color = new Color(Random.Range(0.2f, 0.8f), Random.Range(0.2f, 0.8f), Random.Range(0.2f, 0.8f));
+                this.timer = new();
+            }
+        }
+    }
+}

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -27,7 +27,11 @@ namespace RainMeadow
             instance = this;
             rainMeadowOptions = new RainMeadowOptions(this);
 
-            MeadowProfiler.FullPatch();
+            // TODO fix
+            if (rainMeadowOptions.AdvancedProfiling.Value)
+            {
+                MeadowProfiler.FullPatch();
+            }
 
             On.RainWorld.OnModsInit += RainWorld_OnModsInit;
             On.ModManager.RefreshModsLists += ModManagerOnRefreshModsLists;

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -27,6 +27,8 @@ namespace RainMeadow
             instance = this;
             rainMeadowOptions = new RainMeadowOptions(this);
 
+            MeadowProfiler.FullPatch();
+
             On.RainWorld.OnModsInit += RainWorld_OnModsInit;
             On.ModManager.RefreshModsLists += ModManagerOnRefreshModsLists;
             On.RainWorld.Update += RainWorld_Update;

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -27,8 +27,7 @@ namespace RainMeadow
             instance = this;
             rainMeadowOptions = new RainMeadowOptions(this);
 
-            // TODO fix
-            if (rainMeadowOptions.AdvancedProfiling.Value)
+            if (AdvancedProfilingEnabled())
             {
                 MeadowProfiler.FullPatch();
             }
@@ -46,6 +45,15 @@ namespace RainMeadow
             On.RWCustom.Custom.LogWarning += Custom_LogWarning;
 
             DeathContextualizer.CreateBindings();
+        }
+
+        private bool AdvancedProfilingEnabled()
+        {
+            foreach(var arg in Environment.GetCommandLineArgs())
+            {
+                if (arg == "-meadowprofiler") return true;
+            }
+            return false;
         }
 
         private void Custom_LogWarning(On.RWCustom.Custom.orig_LogWarning orig, string[] values)

--- a/Utils/FlameGraph.cs
+++ b/Utils/FlameGraph.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RainMeadow
+{
+    internal static class FlameGraph
+    {
+
+        public static void OutputFlameGraph()
+        {
+
+            var snapshot = new List<MeadowProfiler.ProfilerInfo>(MeadowProfiler.snapshot);
+
+            List<string> folded = new();
+
+            foreach (var info in snapshot)
+            {
+                var folding = "root;";
+
+                for (int i = 0; i < info.tree.Length; i++)
+                {
+                    folding += info.tree[i].name + ";";
+                }
+                if (folding.StartsWith("root; "))
+                {
+                    folding = folding.TrimEnd(';');
+                }
+                folding += $" {info.ticksSpent}";
+
+                folded.Add(folding);
+            }
+            File.WriteAllText("collapsed-stack.txt", ""); // Overwrite before writing
+            File.AppendAllLines("collapsed-stack.txt", folded.ToArray());
+        }
+
+    }
+}

--- a/Utils/FlameGraph.cs
+++ b/Utils/FlameGraph.cs
@@ -21,11 +21,14 @@ namespace RainMeadow
             {
                 var folding = "root;";
 
-                for (int i = 0; i < info.tree.Length; i++)
+                if (info.tree != null)
                 {
-                    folding += info.tree[i].name + ";";
+                    for (int i = 0; i < info.tree.Length; i++)
+                    {
+                        folding += info.tree[i].name + ";";
+                    }
                 }
-                if (folding.StartsWith("root; "))
+                if (folding.EndsWith(";"))
                 {
                     folding = folding.TrimEnd(';');
                 }


### PR DESCRIPTION
Adds more profiling capabilities to Rain Meadow which should be useful for debugging those really laggy regions like Five Pebbles and optimizing the engine more.

When using Dev tools press "=" to switch to the profiler view. 

Advanced profiling can be turned on in the remix setting. (Doesn't seem to be working just yet so for now just edit the code) Upon restart the game will perform a large Harmony patch to allow profiling individual methods.

With Advanced Profiling on in the Profiling menu press "-" to create a collapsed stack file. This file will be in you game's root folder and can be viewed on a site like https://www.speedscope.app/

<img width="1920" height="925" alt="image" src="https://github.com/user-attachments/assets/547c2f3a-d098-4d70-b076-da33b0b82c8c" />
