### PR TITLE
Pointing tweaks and fixes

### DIFF
--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -606,7 +606,9 @@ public partial class RainMeadow
         {
             // scary math below
             var vector = Custom.DegToVec(Custom.AimFromOneVectorToAnother(self.firstChunk.pos, playerGraphics.hands[hand].pos));
-            return Vector3.Slerp(vector, Custom.DegToVec(90f + (80f + Mathf.Cos((float)(self.animationFrame + (self.leftFoot ? 9 : 3)) / 12f * 2f * (float)Math.PI) * 4f * playerGraphics.spearDir) * playerGraphics.spearDir), Mathf.Abs(playerGraphics.spearDir));
+            return vector;
+            //Old second-step vector math. I believe this is supposed to be a basic rotation interpolate, but spearDir does *not* appear to do what it says on the tin, so it just breaks when walking. Keeping a copy commented in case I've misdiagnosed and it needs a revert.
+            //return Vector3.Slerp(vector, Custom.DegToVec(90f + (80f + Mathf.Cos((float)(self.animationFrame + (self.leftFoot ? 9 : 3)) / 12f * 2f * (float)Math.PI) * 4f * playerGraphics.spearDir) * playerGraphics.spearDir), Mathf.Abs(playerGraphics.spearDir));
         }
         return orig(self, hand);
     }

--- a/OnlineUIComponents/Pointing.cs
+++ b/OnlineUIComponents/Pointing.cs
@@ -62,7 +62,7 @@ namespace RainMeadow
             {
                 for (int i = 0; i <= 1; i++)
                 {
-                    if ((realizedPlayer.grasps[i] == null || realizedPlayer.grasps[i].grabbed is Weapon) && playerGraphics.hands[1 - i].reachedSnapPosition)
+                    if (realizedPlayer.grasps[i] == null || realizedPlayer.grasps[i].grabbed is Weapon)
                     {
                         return i;
                     }

--- a/OnlineUIComponents/Pointing.cs
+++ b/OnlineUIComponents/Pointing.cs
@@ -60,7 +60,7 @@ namespace RainMeadow
         {
             if (realizedPlayer is not null && realizedPlayer.graphicsModule is PlayerGraphics playerGraphics)
             {
-                for (int i = 1; i >= 0; i--)
+                for (int i = 0; i <= 1; i++)
                 {
                     if ((realizedPlayer.grasps[i] == null || realizedPlayer.grasps[i].grabbed is Weapon) && playerGraphics.hands[1 - i].reachedSnapPosition)
                     {


### PR DESCRIPTION
- Scugs now prefer to point with their primary hand, rather than their offhand, matching both jolly and community-preferred behavior. This by proxy fixes pups being entirely unable to point with items.
- Fixed an issue where spear pointing angles would completely break when normal walking left/right.
- Fixed an issue that'd sometimes select the fallback hand to point, even if the preferred was usable. This could cause pointing with the "wrong" item, item position freakouts for other clients, and I suspect it was the cause for occasional failure to point when crouched (as I can no longer reproduce that).