### PR TITLE
watcher 5.0 update

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -859,28 +859,7 @@ namespace RainMeadow
         {
             if (isArenaMode(out var arena))
             {
-                if ((classID is null) || (classID == RainMeadow.Ext_SlugcatStatsName.OnlineRandomSlugcat))
-                {
-                    return "MultiplayerPortrait02";
-                }
-                if (ArenaHelpers.vanillaSlugcats.Contains(classID))
-                {
-                    // subtract 1 since 
-                    return $"MultiplayerPortrait{ArenaHelpers.vanillaSlugcats.IndexOf(classID)}1";
-                }
-                if (ModManager.Watcher && classID == Watcher.WatcherEnums.SlugcatStatsName.Watcher)
-                {
-                    return $"MultiplayerPortrait{3}1"; // take advantage of nightcat profile pic
-                }
-                if (ModManager.MSC && ArenaHelpers.mscSlugcats.Contains(classID))
-                {
-                    return $"MultiplayerPortrait{(classID == MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel ? UnityEngine.Random.Range(0, 5) : 4)}1-{classID}";
-
-                }
-                if (!ArenaHelpers.baseGameSlugcats.Contains(classID))
-                {
-                    return $"MultiplayerPortrait{0}{1}-{classID}";
-                }
+                return SlugcatColorableButton.GetFileForSlugcatIndex(classID, color, false);
             }
             return orig(self, classID, color);
         }

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -131,11 +131,11 @@ namespace RainMeadow
             self.AddPart(new OnlineHUD(self, session.game.cameras[0], arena));
             self.AddPart(new Pointing(self));
             self.AddPart(new ArenaSpawnLocationIndicator(self, session.game.cameras[0]));
-            self.AddPart(new Watcher.CamoMeter(self, self.fContainers[1]));
+            self.AddPart(new Watcher.CamoMeter(self, null, self.fContainers[1]));
             if (ModManager.Watcher && OnlineManager.lobby.clientSettings[OnlineManager.mePlayer].GetData<ArenaClientSettings>().playingAs == Watcher.WatcherEnums.SlugcatStatsName.Watcher)
             {
                 RainMeadow.Debug("Adding Watcher Camo Meter");
-                self.AddPart(new Watcher.CamoMeter(self, self.fContainers[1]));
+                self.AddPart(new Watcher.CamoMeter(self, null, self.fContainers[1]));
             }
         }
         public virtual void ArenaCreatureSpawner_SpawnCreatures(ArenaOnlineGameMode arena, On.ArenaCreatureSpawner.orig_SpawnArenaCreatures orig, RainWorldGame game, ArenaSetup.GameTypeSetup.WildLifeSetting wildLifeSetting, ref List<AbstractCreature> availableCreatures, ref MultiplayerUnlocks unlocks)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Adds piggyback toggle
 - Fixed a *specific* edge case where a player might not be protected from a parry.
 - Fixed a crash in Teams mode when another user suddenly disconnected 
-- If you had choppy frame rate in Teams UI, please resubscribe to  ìExtended Color Configî mod. 
+- If you had choppy frame rate in Teams UI, please resubscribe to  ‚ÄúExtended Color Config‚Äù mod. 
 - Fixed dupe trophy awards in results screen 
 - Fixed timer not showing when running some langugages
 - Fixed an issue where Inv's friend would cause you to duplicate your spawn
@@ -15,7 +15,7 @@
 - Added multipage slugcat select to support modded cats
 - Fixed kicking someone else crashing you
 
-- ## Engine:
+## Engine:
 - Added additional security measures 
 - Fixed an issue with shortcut loading 
 - Added custom packet capabilities 
@@ -46,7 +46,7 @@
 ## Story:
 - Fixed Slugcat selection not allowing a specific slug to be chosen 
 - Fixed a crash when selecting slugcat colors
-- Fixed Saintís ending 
+- Fixed Saint‚Äôs ending 
 - Fixed cases where single room warp code  was not running 
 - Fixed players inability to progress past the end-of-game statistics screen
 - Updated client story menu to match host's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed Team names not allowing spaces
 - Fixed some water reflection issues related to Watcher 1.5 maps.
 - Added multipage slugcat select to support modded cats
+- Fixed kicking someone else crashing you
 
 - ## Engine:
 - Added additional security measures 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Release 1.7.0
+
+## Arena:
+- Adds Slugcat banning 
+- Adds piggyback toggle
+- Fixed a *specific* edge case where a player might not be protected from a parry.
+- Fixed a crash in Teams mode when another user suddenly disconnected 
+- If you had choppy frame rate in Teams UI, please resubscribe to  “Extended Color Config” mod. 
+- Fixed dupe trophy awards in results screen 
+- Fixed timer not showing when running some langugages
+- Fixed an issue where Inv's friend would cause you to duplicate your spawn
+- Fixed Arena's menu chatbot interactions duplicating in Team name display
+- Fixed Team names not allowing spaces
+- Fixed some water reflection issues related to Watcher 1.5 maps.
+- Added multipage slugcat select to support modded cats
+
+- ## Engine:
+- Added additional security measures 
+- Fixed an issue with shortcut loading 
+- Added custom packet capabilities 
+
+
+## General
+- Updated pointing logic to prefer *primary* hand, Slups can now poke eyes
+- Fixed Gourm stomp not hurting NPCs
+- Desynced 5P neurons to marginally improve latency. 
+- Synced Vulture grub & hazers  
+- Synced Player "special" input 
+- Fixed the AFK sleeping animation not cancelling when stunned/killed (thanks <@380127561621176323> for AFK fixes)
+- Fixed Spearmaster not closing their eyes during afk sleep.
+- Fixed afk sleep rarely triggering when piggybacked onto someone else. 
+- Fixed the "Don't fall back asleep when waking up" check not working.
+- Fixed an oddity where shelters closing would cause afk sleep to stop.
+- Cleared ping label when a user leaves instead of burning it into the foreground in memorium
+- Fixed a crash while pointing if the lobby no longer existed <:rmconfused:1177681041822072892>
+- Added chat typing notification
+
+
+## Meadow:
+- Fixed Slugcat timelines (Meadow mode)
+- Fixed Emote grid animations not playing 
+- Updated autohide for emote grid
+
+
+## Story:
+- Fixed Slugcat selection not allowing a specific slug to be chosen 
+- Fixed a crash when selecting slugcat colors
+- Fixed Saint’s ending 
+- Fixed cases where single room warp code  was not running 
+- Fixed players inability to progress past the end-of-game statistics screen
+- Updated client story menu to match host's
+- Updated to support Watcher 1.5

--- a/Game/CustomCosmetics/RainMeadow.CustomCosmeticHooks.cs
+++ b/Game/CustomCosmetics/RainMeadow.CustomCosmeticHooks.cs
@@ -16,7 +16,7 @@ namespace RainMeadow
             On.PlayerGraphics.Reset += PlayerGraphics_ResetCosmetics;
             On.PlayerGraphics.DrawSprites += PlayerGraphics_DrawSpritesCosmetics;
             On.PlayerGraphics.AddToContainer += PlayerGraphics_AddToContainerCosmetics;
-            IL.PlayerGraphics.InitiateSprites += PlayerGraphics_InitiateSpritesCosmetics;
+            //IL.PlayerGraphics.InitiateSprites += PlayerGraphics_InitiateSpritesCosmetics;
         }
 
         void PlayerGraphics_InitiateSpritesCosmetics(ILContext cursor) {

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -24,6 +24,7 @@ namespace RainMeadow
 
             On.AbstractPhysicalObject.ChangeRooms += AbstractPhysicalObject_ChangeRooms;
             On.AbstractCreature.ChangeRooms += AbstractCreature_ChangeRooms1;
+            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
 
             On.AbstractCreature.Abstractize += AbstractCreature_Abstractize; // get real
             On.AbstractPhysicalObject.Abstractize += AbstractPhysicalObject_Abstractize; // get real
@@ -37,6 +38,25 @@ namespace RainMeadow
             On.Watcher.SandGrubGraphics.DrawSprites += SandGrubGraphics_DrawSprites;
 
             new Hook(typeof(AbstractCreature).GetProperty("Quantify").GetGetMethod(), this.AbstractCreature_Quantify);
+        }
+
+        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
+        {
+            if (OnlineManager.lobby != null)
+            {
+                if (self.waterLight != null)
+                {
+                    if (newRoom.waterObject == null && newRoom.water)
+                    {
+                        newRoom.AddWater();
+                    }
+                    if (newRoom.waterObject != null && !newRoom.water)
+                    {
+                        self.waterLight.CleanOut();
+                    }
+                }
+            }
+            orig(self, newRoom, cameraPosition);
         }
 
         private void SandGrubGraphics_DrawSprites(On.Watcher.SandGrubGraphics.orig_DrawSprites orig, Watcher.SandGrubGraphics self, RoomCamera.SpriteLeaser sLeaser, RoomCamera rCam, float timeStacker, UnityEngine.Vector2 camPos)

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -414,10 +414,10 @@ namespace RainMeadow
         // world transition at gates
         private void OverWorld_WorldLoaded(On.OverWorld.orig_WorldLoaded orig, OverWorld self, bool warpUsed)
         {
-            if (OnlineManager.lobby != null)
+            if (OnlineManager.lobby != null && self.worldLoader.Finished)
             {
                 WorldSession oldWorldSession = self.activeWorld.GetResource() ?? throw new KeyNotFoundException();
-                WorldSession newWorldSession = self.worldLoader.world.GetResource() ?? throw new KeyNotFoundException();
+                WorldSession newWorldSession = ((self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld()).GetResource() ?? throw new KeyNotFoundException();
                 bool isSameWorld = (self.activeWorld.name == self.worldLoader.world.name);
                 bool isEchoWarp = (self.game.GetStorySession.saveState.warpPointTargetAfterWarpPointSave != null);
                 bool isFirstWarpWorld = false;

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -24,8 +24,6 @@ namespace RainMeadow
 
             On.AbstractPhysicalObject.ChangeRooms += AbstractPhysicalObject_ChangeRooms;
             On.AbstractCreature.ChangeRooms += AbstractCreature_ChangeRooms1;
-            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
-
             On.AbstractCreature.Abstractize += AbstractCreature_Abstractize; // get real
             On.AbstractPhysicalObject.Abstractize += AbstractPhysicalObject_Abstractize; // get real
             On.AbstractCreature.Realize += AbstractCreature_Realize; // get real, also customization happens here
@@ -38,25 +36,6 @@ namespace RainMeadow
             On.Watcher.SandGrubGraphics.DrawSprites += SandGrubGraphics_DrawSprites;
 
             new Hook(typeof(AbstractCreature).GetProperty("Quantify").GetGetMethod(), this.AbstractCreature_Quantify);
-        }
-
-        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
-        {
-            if (OnlineManager.lobby != null)
-            {
-                if (self.waterLight != null)
-                {
-                    if (newRoom.waterObject == null && newRoom.water)
-                    {
-                        newRoom.AddWater();
-                    }
-                    if (newRoom.waterObject != null && !newRoom.water)
-                    {
-                        self.waterLight.CleanOut();
-                    }
-                }
-            }
-            orig(self, newRoom, cameraPosition);
         }
 
         private void SandGrubGraphics_DrawSprites(On.Watcher.SandGrubGraphics.orig_DrawSprites orig, Watcher.SandGrubGraphics self, RoomCamera.SpriteLeaser sLeaser, RoomCamera rCam, float timeStacker, UnityEngine.Vector2 camPos)

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -418,7 +418,7 @@ namespace RainMeadow
             {
                 WorldSession oldWorldSession = self.activeWorld.GetResource() ?? throw new KeyNotFoundException();
                 WorldSession newWorldSession = ((self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld()).GetResource() ?? throw new KeyNotFoundException();
-                bool isSameWorld = (self.activeWorld.name == self.worldLoader.world.name);
+                bool isSameWorld = (self.activeWorld.name == ((self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld()).name);
                 bool isEchoWarp = (self.game.GetStorySession.saveState.warpPointTargetAfterWarpPointSave != null);
                 bool isFirstWarpWorld = false;
 
@@ -426,7 +426,7 @@ namespace RainMeadow
                 {
                     // Regular gate switch
                     AbstractRoom oldAbsroom = self.reportBackToGate.room.abstractRoom;
-                    AbstractRoom newAbsroom = self.worldLoader.world.GetAbstractRoom(oldAbsroom.name);
+                    AbstractRoom newAbsroom = ((self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld()).GetAbstractRoom(oldAbsroom.name);
                     List<AbstractWorldEntity> entitiesFromNewRoom = newAbsroom.entities; // these get ovewritten and need handling
                     List<AbstractCreature> creaturesFromNewRoom = newAbsroom.creatures;
 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -414,7 +414,7 @@ namespace RainMeadow
         // world transition at gates
         private void OverWorld_WorldLoaded(On.OverWorld.orig_WorldLoaded orig, OverWorld self, bool warpUsed)
         {
-            if (OnlineManager.lobby != null && self.worldLoader.Finished)
+            if (OnlineManager.lobby != null)
             {
                 WorldSession oldWorldSession = self.activeWorld.GetResource() ?? throw new KeyNotFoundException();
                 WorldSession newWorldSession = ((self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld()).GetResource() ?? throw new KeyNotFoundException();

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -49,7 +49,7 @@ namespace RainMeadow
             // can't pause it's online mom
             new Hook(typeof(RainWorldGame).GetProperty("GamePaused").GetGetMethod(), this.RainWorldGame_GamePaused);
 
-           // IL.RainWorldGame.Update += RainWorldGame_Update;
+            IL.RainWorldGame.Update += RainWorldGame_Update;
             On.RainWorldGame.Update += RainWorldGame_Update1;
 
             // Arena specific

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -47,7 +47,7 @@ namespace RainMeadow
             // can't pause it's online mom
             new Hook(typeof(RainWorldGame).GetProperty("GamePaused").GetGetMethod(), this.RainWorldGame_GamePaused);
 
-            IL.RainWorldGame.Update += RainWorldGame_Update;
+           // IL.RainWorldGame.Update += RainWorldGame_Update;
             On.RainWorldGame.Update += RainWorldGame_Update1;
 
             // Arena specific

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -558,7 +558,7 @@ namespace RainMeadow
                 c.Emit(OpCodes.Ldarg_0);
                 c.EmitDelegate((Room self) =>
                 {
-                    if (OnlineManager.lobby != null)
+                    if (OnlineManager.lobby != null && self.game != null)
                     {
                         if (RoomSession.map.TryGetValue(self.abstractRoom, out RoomSession rs))
                         {

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -157,7 +157,7 @@ namespace RainMeadow
                     i => i.MatchLdarg(0),
                     i => i.MatchLdfld<RainWorldGame>("lastPauseButton"),
                     i => i.MatchBrfalse(out var _),
-                    i => i.MatchCall<Kittehface.Framework20.Platform>("get_systemMenuShowing"),
+                    i => i.MatchCall<Kittehface.Framework20.Platform>("get_systemMenuShowingExplicit"),
                     i => i.MatchBrfalse(out skip)
                 );
                 c.MoveAfterLabels();

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -169,7 +169,7 @@ namespace RainMeadow
                     i => i.MatchStfld<RainWorldGame>("pauseMenu")
                     );
                 c.GotoPrev(moveType: MoveType.After,
-                    i => i.MatchBrfalse(out skip)
+                    i => i.MatchBrtrue(out skip)
                     );
                 c.MoveAfterLabels();
                 c.Emit(OpCodes.Ldarg_0);

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -510,7 +510,6 @@ namespace RainMeadow
         // Prevent gameplay items
         private void Room_ctor(On.Room.orig_ctor orig, Room self, RainWorldGame game, World world, AbstractRoom abstractRoom, bool devUI)
         {
-            if (abstractRoom.GetResource() is RoomSession rs) rs.loadedPending = false;
             orig(self, game, world, abstractRoom, devUI);
             if (game != null && OnlineManager.lobby != null)
             {
@@ -554,33 +553,10 @@ namespace RainMeadow
         {
             try
             {
-                var c = new ILCursor(il);
-                c.Emit(OpCodes.Ldarg_0);
-                c.EmitDelegate((Room self) =>
-                {
-                    if (OnlineManager.lobby != null)
-                    {
-                        if (RoomSession.map.TryGetValue(self.abstractRoom, out RoomSession rs))
-                        {
-                            if (!rs.isAvailable)
-                            {
-                                rs.Needed();
-                                rs.loadedPending = true;
-                                return false;
-                            }
-                        }
-                    }
-                    return true;
-                });
-                ILLabel label = c.DefineLabel();
-                c.Emit(OpCodes.Brtrue, label);
-                c.Emit(OpCodes.Ret);
-                c.MarkLabel(label);
-
-
                 // if (this.world != null && this.game != null && this.abstractRoom.firstTimeRealized && (!this.game.IsArenaSession || this.game.GetArenaGameSession.GameTypeSetup.levelItems))
                 //becomes
                 // if (this.world != null && this.game != null && this.abstractRoom.firstTimeRealized && (OnlineManager.lobby == null || gameMode.ShouldSpawnRoomItems()) && (!this.game.IsArenaSession || this.game.GetArenaGameSession.GameTypeSetup.levelItems))
+                var c = new ILCursor(il);
                 var skip = il.DefineLabel();
                 c.GotoNext(moveType: MoveType.After,
                     i => i.MatchLdarg(0),
@@ -612,7 +588,7 @@ namespace RainMeadow
                     );
                     //c.MoveAfterLabels();
                     c.Emit(OpCodes.Ldarg_0);
-                    c.EmitDelegate((Room self) => self.abstractRoom.GetResource().isOwner);
+                    c.EmitDelegate((Room self) => OnlineManager.lobby == null || OnlineManager.lobby.isOwner); //roomsession not available yet
                     c.Emit(OpCodes.Brfalse, skipApo);
                 }
             }

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -813,10 +813,10 @@ namespace RainMeadow
                         Trace($"Grabbed object {grasp.grabbed.abstractPhysicalObject} {grasp.grabbed.abstractPhysicalObject.ID} doesn't exist in online space!");
                         continue;
                     }
-                    if (!onlineGrabbed.isMine && onlineGrabbed.isTransferable && !onlineGrabbed.isPending) // been leased to someone else
+                    if (!onlineGrabbed.isMine && onlineGrabbed.isTransferable && !onlineGrabbed.isPending && onlineGrabbed != null) // been leased to someone else
                     {
                         var grabbersOtherThanMe = grasp.grabbed.grabbedBy.Select(x => x.grabber).Where(x => x != self);
-                        if (grabbersOtherThanMe.All(x => x.abstractPhysicalObject.GetOnlineObject(out var opo) && opo.isMine))
+                        if (grabbersOtherThanMe.All(x => x.abstractPhysicalObject.GetOnlineObject(out var opo) && opo != null && opo.isMine))
                             onlineGrabbed.Request();
                     }
                 }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -29,15 +29,21 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null)
             {
+                if (self.waterLight == null && newRoom.water)
+                {
+                    self.waterLight = new WaterLight(self, newRoom.game.rainWorld.Shaders["WaterLight"]);
+                }
+                else if (self.waterLight != null && !newRoom.water)
+                {
+                    self.waterLight.CleanOut();
+                    self.waterLight = null;
+                }
+
                 if (self.waterLight != null)
                 {
                     if (newRoom.waterObject == null && newRoom.water)
                     {
                         newRoom.AddWater();
-                    }
-                    if (newRoom.waterObject != null && !newRoom.water)
-                    {
-                        self.waterLight.CleanOut();
                     }
                 }
             }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -35,10 +35,6 @@ namespace RainMeadow
                     {
                         newRoom.AddWater();
                     }
-                    //if (newRoom.waterObject != null && !newRoom.water)
-                    //{
-                    //    self.waterLight.CleanOut();
-                    //}
                 }
             }
             orig(self, newRoom, cameraPosition);

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -233,21 +233,16 @@ namespace RainMeadow
         // Room wait and activate
         private void RoomPreparer_Update(On.RoomPreparer.orig_Update orig, RoomPreparer self)
         {
-            if (OnlineManager.lobby != null)
+            if (!self.shortcutsOnly && self.room.game != null && OnlineManager.lobby != null)
             {
                 if (RoomSession.map.TryGetValue(self.room.abstractRoom, out RoomSession rs))
                 {
-
-                    if (!self.shortcutsOnly && self.room.game != null)
-                    {
-                        RainMeadow.Trace($"{rs} : {rs.isPending} {rs.isAvailable} {rs.isActive}");
-                        rs.Needed();
-                        if (!rs.isAvailable || rs.isPending) return;
-                        if ((self.requestShortcutsReady || self.room.shortCutsReady) && !rs.isActive) rs.Activate();
-                    }
+                    RainMeadow.Trace($"{rs} : {rs.isPending} {rs.isAvailable} {rs.isActive}");
+                    rs.Needed();
+                    if (!rs.isAvailable || rs.isPending) return;
+                    if ((self.requestShortcutsReady || self.room.shortCutsReady) && !rs.isActive) rs.Activate();
                 }
-
-            } 
+            }
             orig(self);
         }
 

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -35,10 +35,10 @@ namespace RainMeadow
                     {
                         newRoom.AddWater();
                     }
-                    if (newRoom.waterObject != null && !newRoom.water)
-                    {
-                        self.waterLight.CleanOut();
-                    }
+                    //if (newRoom.waterObject != null && !newRoom.water)
+                    //{
+                    //    self.waterLight.CleanOut();
+                    //}
                 }
             }
             orig(self, newRoom, cameraPosition);

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -19,35 +19,8 @@ namespace RainMeadow
             On.RoomPreparer.ctor += RoomPreparer_ctor;
             On.AbstractRoom.Abstractize += AbstractRoom_Abstractize;
             On.ArenaSitting.NextLevel += ArenaSitting_NextLevel;
-            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
-
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.StoryCharacter)).GetGetMethod(), RainWorldGame_StoryCharacter);
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.TimelinePoint)).GetGetMethod(), RainWorldGame_TimelinePoint);
-        }
-
-        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
-        {
-            if (OnlineManager.lobby != null)
-            {
-                if (self.waterLight == null && newRoom.water)
-                {
-                    self.waterLight = new WaterLight(self, newRoom.game.rainWorld.Shaders["WaterLight"]);
-                }
-                else if (self.waterLight != null && !newRoom.water)
-                {
-                    self.waterLight.CleanOut();
-                    self.waterLight = null;
-                }
-
-                if (self.waterLight != null)
-                {
-                    if (newRoom.waterObject == null && newRoom.water)
-                    {
-                        newRoom.AddWater();
-                    }
-                }
-            }
-            orig(self, newRoom, cameraPosition);
         }
 
         SlugcatStats.Name RainWorldGame_StoryCharacter(Func<RainWorldGame, SlugcatStats.Name> orig, RainWorldGame self)

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -19,9 +19,29 @@ namespace RainMeadow
             On.RoomPreparer.ctor += RoomPreparer_ctor;
             On.AbstractRoom.Abstractize += AbstractRoom_Abstractize;
             On.ArenaSitting.NextLevel += ArenaSitting_NextLevel;
+            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
 
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.StoryCharacter)).GetGetMethod(), RainWorldGame_StoryCharacter);
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.TimelinePoint)).GetGetMethod(), RainWorldGame_TimelinePoint);
+        }
+
+        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
+        {
+            if (OnlineManager.lobby != null)
+            {
+                if (self.waterLight != null)
+                {
+                    if (newRoom.waterObject == null && newRoom.water)
+                    {
+                        newRoom.AddWater();
+                    }
+                    if (newRoom.waterObject != null && !newRoom.water)
+                    {
+                        self.waterLight.CleanOut();
+                    }
+                }
+            }
+            orig(self, newRoom, cameraPosition);
         }
 
         SlugcatStats.Name RainWorldGame_StoryCharacter(Func<RainWorldGame, SlugcatStats.Name> orig, RainWorldGame self)

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -19,26 +19,12 @@ namespace RainMeadow
             On.RoomPreparer.ctor += RoomPreparer_ctor;
             On.AbstractRoom.Abstractize += AbstractRoom_Abstractize;
             On.ArenaSitting.NextLevel += ArenaSitting_NextLevel;
-            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
 
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.StoryCharacter)).GetGetMethod(), RainWorldGame_StoryCharacter);
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.TimelinePoint)).GetGetMethod(), RainWorldGame_TimelinePoint);
         }
 
-        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
-        {
-            if (OnlineManager.lobby != null)
-            {
-                if (self.waterLight != null)
-                {
-                    if (newRoom.waterObject == null && newRoom.water)
-                    {
-                        newRoom.AddWater();
-                    }
-                }
-            }
-            orig(self, newRoom, cameraPosition);
-        }
+
 
         SlugcatStats.Name RainWorldGame_StoryCharacter(Func<RainWorldGame, SlugcatStats.Name> orig, RainWorldGame self)
         {
@@ -263,7 +249,7 @@ namespace RainMeadow
                     }
                 }
 
-            } 
+            }
             orig(self);
         }
 

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -232,15 +232,20 @@ namespace RainMeadow
         // Room wait and activate
         private void RoomPreparer_Update(On.RoomPreparer.orig_Update orig, RoomPreparer self)
         {
-            if (!self.shortcutsOnly && self.room.game != null && OnlineManager.lobby != null)
+            if (OnlineManager.lobby != null)
             {
                 if (RoomSession.map.TryGetValue(self.room.abstractRoom, out RoomSession rs))
                 {
-                    RainMeadow.Trace($"{rs} : {rs.isPending} {rs.isAvailable} {rs.isActive}");
-                    rs.Needed();
-                    if (!rs.isAvailable || rs.isPending) return;
-                    if ((self.requestShortcutsReady || self.room.shortCutsReady) && !rs.isActive) rs.Activate();
+
+                    if (!self.shortcutsOnly && self.room.game != null)
+                    {
+                        RainMeadow.Trace($"{rs} : {rs.isPending} {rs.isAvailable} {rs.isActive}");
+                        rs.Needed();
+                        if (!rs.isAvailable || rs.isPending) return;
+                        if ((self.requestShortcutsReady || self.room.shortCutsReady) && !rs.isActive) rs.Activate();
+                    }
                 }
+
             }
             orig(self);
         }

--- a/Game/RainMeadow.ObjectHooks.cs
+++ b/Game/RainMeadow.ObjectHooks.cs
@@ -13,28 +13,6 @@ namespace RainMeadow
         private void Room_Update(ILContext il)
         {
             ILCursor c = new ILCursor(il);
-
-            c.Emit(OpCodes.Ldarg_0);
-            c.EmitDelegate((Room self) =>
-            {
-                if (OnlineManager.lobby != null)
-                {
-                    if (RoomSession.map.TryGetValue(self.abstractRoom, out RoomSession rs))
-                    {
-                        if (rs.loadedPending)
-                        {
-                            rs.Needed();
-                            return false;
-                        }
-                    }
-                }
-                return true;
-            });
-            ILLabel label = c.DefineLabel();
-            c.Emit(OpCodes.Brtrue, label);
-            c.Emit(OpCodes.Ret);
-            c.MarkLabel(label);
-
             ILLabel skip = null;
             int locuad = -1;
 

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -74,7 +74,7 @@ public partial class RainMeadow
         new Hook(typeof(Watcher.CamoMeter).GetProperty("ForceShow").GetGetMethod(), this.CamoMeter_SetCamoMeter);
         new Hook(typeof(Player).GetProperty("CanSpawnDynamicWarpPoints").GetGetMethod(), this.Player_CanSpawnDynamicWarpPoints);
 
-        On.Player.TickLevitation += (On.Player.orig_TickLevitation orig, Player self, bool levitateUp) =>
+        On.Player.TickLevitation_bool += (On.Player.orig_TickLevitation_bool orig, Player self, bool levitateUp) =>
         {
             WatcherOverrideForLevitation = true;
             orig(self, levitateUp);

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -675,15 +675,6 @@ namespace RainMeadow
         }
 
 
-        public override void PlayerLeftLobby(OnlinePlayer player)
-        {
-            base.PlayerLeftLobby(player);
-            if (player == lobby.owner)
-            {
-                OnlineManager.instance.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.MainMenu);
-            }
-        }
-
         public override bool AllowedInMode(PlacedObject item)
         {
             if (item.type == PlacedObject.Type.SporePlant)
@@ -735,17 +726,6 @@ namespace RainMeadow
             return roomSession.owner == null || roomSession.isOwner;
         }
 
-
-        public override void NewResourceOwner(OnlineResource resource, OnlinePlayer? oldOwner, OnlinePlayer? newOwner)
-        {
-            if (resource is Lobby)
-            {
-                if (OnlineManager.instance.manager.currentMainLoop is RainWorldGame)
-                {
-                    OnlineManager.instance.manager.RequestMainProcessSwitch(RainMeadow.Ext_ProcessID.ArenaLobbyMenu);
-                }
-            }
-        }
 
         public override void ResourceAvailable(OnlineResource onlineResource)
         {

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -735,6 +735,18 @@ namespace RainMeadow
             return roomSession.owner == null || roomSession.isOwner;
         }
 
+
+        public override void NewResourceOwner(OnlineResource resource, OnlinePlayer? oldOwner, OnlinePlayer? newOwner)
+        {
+            if (resource is Lobby)
+            {
+                if (OnlineManager.instance.manager.currentMainLoop is RainWorldGame)
+                {
+                    OnlineManager.instance.manager.RequestMainProcessSwitch(RainMeadow.Ext_ProcessID.ArenaLobbyMenu);
+                }
+            }
+        }
+
         public override void ResourceAvailable(OnlineResource onlineResource)
         {
             base.ResourceAvailable(onlineResource);

--- a/GameModes/OnlineGameMode.cs
+++ b/GameModes/OnlineGameMode.cs
@@ -280,6 +280,11 @@ namespace RainMeadow
             return true;
         }
 
+        public virtual void NewResourceOwner(OnlineResource resource, OnlinePlayer? oldOwner, OnlinePlayer? newOwner)
+        {
+
+        }
+
         public virtual void PlayerLeftLobby(OnlinePlayer player)
         {
 

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -244,13 +244,14 @@ namespace RainMeadow
             }
         }
 
-        public override void PlayerLeftLobby(OnlinePlayer player)
+        public override void NewResourceOwner(OnlineResource resource, OnlinePlayer? oldOwner, OnlinePlayer? newOwner)
         {
-            base.PlayerLeftLobby(player);
-            // XXX: does not work as expected, new lobby owner is assigned before we receive this
-            if (player == lobby.owner)
+            if (resource is Lobby)
             {
-                OnlineManager.instance.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.MainMenu);
+                if (OnlineManager.instance.manager.currentMainLoop is RainWorldGame)
+                {
+                    OnlineManager.instance.manager.RequestMainProcessSwitch(RainMeadow.Ext_ProcessID.StoryMenu);
+                }
             }
         }
 

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -163,7 +163,7 @@ namespace RainMeadow
 
         public override SlugcatStats.Timeline LoadWorldIn(RainWorldGame game)
         {
-            return game.GetStorySession.saveState.currentTimelinePosition;
+            return game.GetStorySession.saveState.currentTimelinePosition ?? SlugcatStats.SlugcatToTimeline(currentCampaign);
         }
 
         public override bool ShouldSpawnFly(FliesWorldAI self, int spawnRoom)

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -235,13 +235,6 @@ namespace RainMeadow
                     }
                 }
             }
-
-            if (OnlineManager.lobby.isOwner && menuSaveState != null)
-            {
-                menuSaveState = null;
-                menuSaveGameData = null;
-                needMenuSaveUpdate = true;
-            }
         }
 
         public override void PlayerLeftLobby(OnlinePlayer player)
@@ -251,6 +244,11 @@ namespace RainMeadow
             if (player == lobby.owner)
             {
                 OnlineManager.instance.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.MainMenu);
+            }
+
+            if (lobby.isOwner)
+            {
+                needMenuSaveUpdate = true; // reload menu with local save
             }
         }
 

--- a/Meadow/Creatures/LizardController.cs
+++ b/Meadow/Creatures/LizardController.cs
@@ -17,7 +17,7 @@ namespace RainMeadow
             // don't drop it
             IL.Lizard.CarryObject += Lizard_CarryObject1;
             // swim, bastard
-            IL.Lizard.SwimBehavior += Lizard_SwimBehavior;
+            //IL.Lizard.SwimBehavior += Lizard_SwimBehavior;
 
             On.Lizard.SwimBehavior += Lizard_SwimBehavior1;
             On.Lizard.FollowConnection += Lizard_FollowConnection;

--- a/Meadow/Creatures/LizardController.cs
+++ b/Meadow/Creatures/LizardController.cs
@@ -17,7 +17,7 @@ namespace RainMeadow
             // don't drop it
             IL.Lizard.CarryObject += Lizard_CarryObject1;
             // swim, bastard
-            //IL.Lizard.SwimBehavior += Lizard_SwimBehavior;
+            IL.Lizard.SwimBehavior += Lizard_SwimBehavior;
 
             On.Lizard.SwimBehavior += Lizard_SwimBehavior1;
             On.Lizard.FollowConnection += Lizard_FollowConnection;
@@ -81,38 +81,14 @@ namespace RainMeadow
             {
                 var c = new ILCursor(il);
 
-                // replace "is salamander" checks with custom
+                // replace "this.Swimmer" checks with custom || swimmer
 
-                // if (base.Template.type == CreatureTemplate.Type.Salamander || ...
-                ILLabel norun = null;
-                c.GotoNext(moveType: MoveType.After,
+                ILLabel run = c.DefineLabel();
+                // if (this.Swimmer)
+                c.GotoNext(moveType: MoveType.AfterLabel,
                      i => i.MatchLdarg(0),
-                     i => i.MatchCall<Creature>("get_Template"),
-                     i => i.MatchLdfld<CreatureTemplate>("type"),
-                     i => i.MatchLdsfld<CreatureTemplate.Type>("Salamander"),
-                     i => i.MatchCall("ExtEnum`1<CreatureTemplate/Type>", "op_Inequality"),
-                     i => i.MatchBrfalse(out norun)
-                     );
-                c.Emit(OpCodes.Ldarg_0);
-                c.EmitDelegate((Lizard self) =>
-                {
-                    if (creatureControllers.TryGetValue(self, out var controller))
-                    {
-                        return false;
-                    }
-                    return true;
-                });
-                c.Emit(OpCodes.Brfalse, norun);
-
-                // if (base.Template.type == CreatureTemplate.Type.Salamander || ...
-                ILLabel run = null;
-                c.GotoNext(moveType: MoveType.After,
-                     i => i.MatchLdarg(0),
-                     i => i.MatchCall<Creature>("get_Template"),
-                     i => i.MatchLdfld<CreatureTemplate>("type"),
-                     i => i.MatchLdsfld<CreatureTemplate.Type>("Salamander"),
-                     i => i.MatchCall("ExtEnum`1<CreatureTemplate/Type>", "op_Equality"),
-                     i => i.MatchBrtrue(out run)
+                     i => i.MatchCall<Lizard>("get_Swimmer"),
+                     i => i.MatchBrfalse(out _)
                      );
                 c.Emit(OpCodes.Ldarg_0);
                 c.EmitDelegate((Lizard self) =>
@@ -123,7 +99,10 @@ namespace RainMeadow
                     }
                     return false;
                 });
+
                 c.Emit(OpCodes.Brtrue, run);
+                c.Index += 3;
+                c.MarkLabel(run);
             }
             catch (Exception e)
             {

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -300,6 +300,11 @@ namespace RainMeadow
             {
                 line5.Add(self, lines[5]);
             }
+
+            if (OnlineManager.lobby != null && self.water && self.waterObject is null)
+            {
+                self.AddWater();
+            }
         }
 
         private void AbstractCreature_ChangeRooms(On.AbstractCreature.orig_ChangeRooms orig, AbstractCreature self, WorldCoordinate newCoord)

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -300,11 +300,6 @@ namespace RainMeadow
             {
                 line5.Add(self, lines[5]);
             }
-
-            if (OnlineManager.lobby != null && self.water && self.waterObject is null)
-            {
-                self.AddWater();
-            }
         }
 
         private void AbstractCreature_ChangeRooms(On.AbstractCreature.orig_ChangeRooms orig, AbstractCreature self, WorldCoordinate newCoord)

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -300,11 +300,6 @@ namespace RainMeadow
             {
                 line5.Add(self, lines[5]);
             }
-
-            //if (OnlineManager.lobby != null && self.water && self.waterObject is null)
-            //{
-            //    self.AddWater();
-            //}
         }
 
         private void AbstractCreature_ChangeRooms(On.AbstractCreature.orig_ChangeRooms orig, AbstractCreature self, WorldCoordinate newCoord)

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -301,10 +301,10 @@ namespace RainMeadow
                 line5.Add(self, lines[5]);
             }
 
-            if (OnlineManager.lobby != null && self.water && self.waterObject is null)
-            {
-                self.AddWater();
-            }
+            //if (OnlineManager.lobby != null && self.water && self.waterObject is null)
+            //{
+            //    self.AddWater();
+            //}
         }
 
         private void AbstractCreature_ChangeRooms(On.AbstractCreature.orig_ChangeRooms orig, AbstractCreature self, WorldCoordinate newCoord)

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -26,8 +26,7 @@ namespace RainMeadow
 
             On.RoomCamera.Update += RoomCamera_Update; // init meadow hud
 
-            IL.HUD.Map.ctor += Map_OwnerFixup; // support non-slug owner
-            IL.HUD.Map.GetSaveState += Map_OwnerFixup; // support non-slug owner
+            IL.HUD.Map.GetSaveState += Map_GetSaveState; // support non-slug owner
 
             On.RegionGate.ctor += RegionGate_ctor;
             On.RegionGate.PlayersInZone += RegionGate_PlayersInZone1;
@@ -364,44 +363,23 @@ namespace RainMeadow
             return orig(self);
         }
 
-        private void Map_OwnerFixup(ILContext il)
+
+        private void Map_GetSaveState(ILContext il)
         {
             try
             {
-                //else if (this.hud.owner.GetOwnerType() != HUD.OwnerType.RegionOverview)
-                //{
-                //    saveState = (this.hud.owner as SleepAndDeathScreen).saveState;
-                //}
-                // becomes
-                //else if (this.hud.owner.GetOwnerType() == HUD.OwnerType.SleepScreen || this.hud.owner.GetOwnerType() == HUD.OwnerType.DeathScreen)
-                //{
-                //    if (this.hud.owner.GetOwnerType() == MeadowCustomization.creatureControllerHudOwner)
-                //        this.hud.rainWorld.progression.currentSaveState;
-                //    else 
-                //        saveState = (this.hud.owner as SleepAndDeathScreen).saveState;
-                //}
+                //( ... || this.hud.owner.GetOwnerType() == HUD.OwnerType.RegionOverview || [new condition])
 
                 var c = new ILCursor(il);
-                var loc = il.Body.Variables.First(v => v.VariableType.Name == "SaveState").Index;
-                ILLabel vanilla = il.DefineLabel();
-                ILLabel skipToEnd = null;
-                MethodReference op_Ineq;
+                ILLabel dorun = null;
                 c.GotoNext(moveType: MoveType.After,
                     i => i.MatchLdsfld<HUD.HUD.OwnerType>("RegionOverview"),
-                    i => i.MatchCall(out op_Ineq),
-                    i => i.MatchBrfalse(out skipToEnd)
+                    i => i.MatchCall(out _),
+                    i => i.MatchBrtrue(out dorun)
                     );
                 c.Emit(OpCodes.Ldarg_0);
-                c.EmitDelegate((HUD.Map map) => map.hud.owner.GetOwnerType() != CreatureController.controlledCreatureHudOwner);
-                c.Emit(OpCodes.Brtrue, vanilla);
-                c.Emit(OpCodes.Ldarg_0);
-                c.Emit<HUD.HudPart>(OpCodes.Ldfld, "hud");
-                c.Emit<HUD.HUD>(OpCodes.Ldfld, "rainWorld");
-                c.Emit<RainWorld>(OpCodes.Ldfld, "progression");
-                c.Emit<PlayerProgression>(OpCodes.Ldfld, "currentSaveState");
-                c.Emit(OpCodes.Stloc, loc);
-                c.Emit(OpCodes.Br, skipToEnd);
-                c.MarkLabel(vanilla);
+                c.EmitDelegate((HUD.Map map) => map.hud.owner.GetOwnerType() == CreatureController.controlledCreatureHudOwner);
+                c.Emit(OpCodes.Brtrue, dorun);
             }
             catch (Exception e)
             {

--- a/Menu/Components/ArenaLevelSelector.cs
+++ b/Menu/Components/ArenaLevelSelector.cs
@@ -674,7 +674,7 @@ public class ArenaLevelSelector : PositionedMenuObject, IPLEASEUPDATEME
         string[] rawLevelDirData = AssetManager.ListDirectory("Levels");
         for (int j = 0; j < rawLevelDirData.Length; j++)
         {
-            if (rawLevelDirData[j].Substring(rawLevelDirData[j].Length - 4, 4) != ".txt" || rawLevelDirData[j].Substring(rawLevelDirData[j].Length - 13, 13) == "_settings.txt" || rawLevelDirData[j].Substring(rawLevelDirData[j].Length - 10, 10) == "_arena.txt" || rawLevelDirData[j].Contains("unlockall"))
+            if (rawLevelDirData[j].Substring(rawLevelDirData[j].Length - 4, 4) != ".txt" || rawLevelDirData[j].Substring(rawLevelDirData[j].Length - 13, 13) == "_settings.txt" || rawLevelDirData[j].Substring(rawLevelDirData[j].Length - 10, 10) == "_arena.txt" || rawLevelDirData[j].Substring(rawLevelDirData[j].Length - 15, 15) == "_properties.txt" || rawLevelDirData[j].Contains("unlockall"))
                 continue;
 
             string[] levelName = rawLevelDirData[j].Substring(0, rawLevelDirData[j].Length - 4).Split(Path.DirectorySeparatorChar);

--- a/Menu/Components/SlugcatColorableButton.cs
+++ b/Menu/Components/SlugcatColorableButton.cs
@@ -35,7 +35,7 @@ namespace RainMeadow.UI.Components
                 return $"Multiplayerportrait{colorIndex}2";
             }
             int deadIndex = isDead ? 0 : 1;
-            if (slugcat == SlugcatStats.Name.Night || (ModManager.Watcher && slugcat == Watcher.WatcherEnums.SlugcatStatsName.Watcher))
+            if (slugcat == SlugcatStats.Name.Night)
             {
                 return $"Multiplayerportrait3{deadIndex}"; //no multi color support for night portrait yet
             }

--- a/Menu/Objects/ChatTextBox.cs
+++ b/Menu/Objects/ChatTextBox.cs
@@ -14,8 +14,8 @@ namespace RainMeadow
         private ButtonTypingHandler typingHandler;
         private GameObject gameObject;
         private bool isUnloading = false;
-        private float DASDelay = 1f/2f; //In seconds
-        private float DASRepeatRate = 1f/30f; //In seconds/proc
+        private float DASDelay = 1f / 2f; //In seconds
+        private float DASRepeatRate = 1f / 30f; //In seconds/proc
         private float backspaceHeld = 0f;
         private float backspaceRepeater = 0f;
         private float arrowHeld = 0f;
@@ -120,14 +120,14 @@ namespace RainMeadow
             }
             else if (!isUnloading)
             {
-                if(selectionPos != -1)
+                if (selectionPos != -1)
                 {
                     // replaces the selected text with the emitted character
                     menu.PlaySound(SoundID.MENU_Checkbox_Check);
                     DeleteSelection();
                     lastSentMessage = lastSentMessage.Insert(cursorPos, input.ToString());
                     cursorPos++;
-                    if(cursorPos == lastSentMessage.Length)
+                    if (cursorPos == lastSentMessage.Length)
                     {
                         SetCursorSprite(false);
                     }
@@ -192,7 +192,7 @@ namespace RainMeadow
                             int space = msg.Substring(cursorPos, len - cursorPos).IndexOf(' ');
                             lastSentMessage = msg.Remove(cursorPos, (space < 0 || space >= len) ? (space = len - cursorPos) : space + 1);
                             menuLabel.text = lastSentMessage;
-                            
+
                         }
                         else
                         {
@@ -359,7 +359,14 @@ namespace RainMeadow
             }
         }
 
-        public static void InvokeShutDownChat() => OnShutDownRequest.Invoke();
+        public static void InvokeShutDownChat()
+        {
+            if (OnlineManager.lobby.clientSettings.TryGetValue(OnlineManager.mePlayer, out var cs))
+            {
+                cs.isInteracting = false;
+            }
+            OnShutDownRequest.Invoke();
+        }
 
         // input blocker for the sake of dev tools/other outside processes that make use of input keys
         // thanks to SlimeCubed's dev console 
@@ -405,13 +412,13 @@ namespace RainMeadow
         {
             if (code == KeyCode.UpArrow || code == KeyCode.DownArrow) return orig(code);
 
-            return blockInput? false : orig(code);
+            return blockInput ? false : orig(code);
         }
         private static bool GetKeyDown(Func<string, bool> orig, string name) => blockInput ? false : orig(name);
         private static bool GetKeyDown(Func<KeyCode, bool> orig, KeyCode code)
         {
             if (code == KeyCode.Return) return orig(code);
-            
+
             return blockInput ? false : orig(code);
         }
         private static bool GetKeyUp(Func<string, bool> orig, string name) => blockInput ? false : orig(name);

--- a/Menu/Pages/ArenaMainLobbyPage.cs
+++ b/Menu/Pages/ArenaMainLobbyPage.cs
@@ -271,7 +271,7 @@ public class ArenaMainLobbyPage : PositionedMenuObject
                     signalText = "START_MATCH"
                 };
                 subObjects.Add(startButton);
-                ArenaMenu.UpdateElementBindings();
+                ArenaMenu?.UpdateElementBindings();
             }
             Arena.shufflePlayList = levelSelector.selectedLevelsPlaylist.ShuffleStatus;
         }

--- a/Menu/Pages/ArenaSlugcatSelectPage.cs
+++ b/Menu/Pages/ArenaSlugcatSelectPage.cs
@@ -289,7 +289,8 @@ public class ArenaSlugcatSelectPage : PositionedMenuObject, SelectOneButton.Sele
             OnSlugcatPressedBan(((EventfulSelectOneButton)menu.selectedObject).buttonArrayIndex);
         for (int i = 0; i < slugcatIllustrations.Length; i++)
         {
-            bool banned = Arena?.bannedSlugs?.Contains(i + (currentSlugcatSelectPage * 2 * maxScugsPerRow)) == true;
+            int slugIndex = slugcatSelectButtons[i].buttonArrayIndex;
+            bool banned = Arena?.bannedSlugs?.Contains(slugIndex) == true;
             MenuIllustration illu = slugcatIllustrations[i];
             SlugcatStats.Name slugcat = slugcatSelectNamePages[currentSlugcatSelectPage][i];
             string file = slugcat == MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel ? SlugcatColorableButton.GetFileForSlugcatIndex(slugcat, painCatIndex, banned, false) : SlugcatColorableButton.GetFileForSlugcat(slugcat, false, banned);

--- a/Menu/Pages/ArenaSlugcatSelectPage.cs
+++ b/Menu/Pages/ArenaSlugcatSelectPage.cs
@@ -290,13 +290,13 @@ public class ArenaSlugcatSelectPage : PositionedMenuObject, SelectOneButton.Sele
             OnSlugcatPressedBan(((EventfulSelectOneButton)menu.selectedObject).buttonArrayIndex);
         for (int i = 0; i < slugcatIllustrations.Length; i++)
         {
-            bool banned = Arena?.bannedSlugs?.Contains(i + (currentSlugcatSelectPage*2*maxScugsPerRow)) == true;
+            bool banned = Arena?.bannedSlugs?.Contains(i + (currentSlugcatSelectPage * 2 * maxScugsPerRow)) == true;
             MenuIllustration illu = slugcatIllustrations[i];
             SlugcatStats.Name slugcat = slugcatSelectNamePages[currentSlugcatSelectPage][i];
             string file = slugcat == MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel ? SlugcatColorableButton.GetFileForSlugcatIndex(slugcat, painCatIndex, banned, false) : SlugcatColorableButton.GetFileForSlugcat(slugcat, false, banned);
             illu.fileName = file;
             illu.LoadFile();
-            illu.sprite.SetElementByName(illu.fileName); 
+            illu.sprite.SetElementByName(illu.fileName);
             //WHY CANT MENUILLUSTRATION HAVE THEIR OWN SETNEWIMAGE.
             //Menuscene has a similar thing happening for gourmand dream scenes, Multiplayer has it, IT COULD HAVE MADE EVERYONE'S LIVES EASIER
             illu.color = banned ? MenuColorEffect.rgbDarkGrey : Color.white;
@@ -309,13 +309,14 @@ public class ArenaSlugcatSelectPage : PositionedMenuObject, SelectOneButton.Sele
                 SwitchSelectedSlugcat(ArenaHelpers.selectableSlugcats[newSlugIndex]);
                 ArenaMenu?.ChangeScene();
             }
+            lastSainot = Arena.sainot;
+
         }
         if (Arena != null && ArenaHelpers.selectableSlugcats[selectedSlugcatIndex] == MoreSlugcatsEnums.SlugcatStatsName.Saint && Arena.sainot != lastSainot)
         {
             descriptionLabel.text = menu.LongTranslate(Arena.slugcatSelectDescriptions[Arena.sainot ? "Sainot" : "Saint"]);
             if (UnityEngine.Random.Range(0, 1000) == 0) descriptionLabel.text = menu.Translate("you could have saved them");
         }
-        lastSainot = Arena.sainot;
     }
     public override void GrafUpdate(float timeStacker)
     {

--- a/Menu/Pages/ArenaSlugcatSelectPage.cs
+++ b/Menu/Pages/ArenaSlugcatSelectPage.cs
@@ -221,7 +221,6 @@ public class ArenaSlugcatSelectPage : PositionedMenuObject, SelectOneButton.Sele
         if (nonNullSlugcat == MoreSlugcatsEnums.SlugcatStatsName.Saint)
         {
             descriptionLabel.text = menu.LongTranslate(Arena.slugcatSelectDescriptions[Arena.sainot ? "Sainot" : "Saint"]);
-            if (UnityEngine.Random.Range(0, 1000) == 0) descriptionLabel.text = menu.Translate("you could have saved them");
         }
 
         if (nonNullSlugcat == MoreSlugcatsEnums.SlugcatStatsName.Artificer && UnityEngine.Random.Range(0, 1000) == 0)
@@ -309,13 +308,13 @@ public class ArenaSlugcatSelectPage : PositionedMenuObject, SelectOneButton.Sele
                 SwitchSelectedSlugcat(ArenaHelpers.selectableSlugcats[newSlugIndex]);
                 ArenaMenu?.ChangeScene();
             }
+            if (ArenaHelpers.selectableSlugcats[selectedSlugcatIndex] == MoreSlugcatsEnums.SlugcatStatsName.Saint && Arena.sainot != lastSainot)
+            {
+                descriptionLabel.text = menu.LongTranslate(Arena.slugcatSelectDescriptions[Arena.sainot ? "Sainot" : "Saint"]);
+                if (UnityEngine.Random.Range(0, 1000) == 0) descriptionLabel.text = menu.Translate("You could have saved them.");
+            }
             lastSainot = Arena.sainot;
 
-        }
-        if (Arena != null && ArenaHelpers.selectableSlugcats[selectedSlugcatIndex] == MoreSlugcatsEnums.SlugcatStatsName.Saint && Arena.sainot != lastSainot)
-        {
-            descriptionLabel.text = menu.LongTranslate(Arena.slugcatSelectDescriptions[Arena.sainot ? "Sainot" : "Saint"]);
-            if (UnityEngine.Random.Range(0, 1000) == 0) descriptionLabel.text = menu.Translate("you could have saved them");
         }
     }
     public override void GrafUpdate(float timeStacker)

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -45,7 +45,7 @@ namespace RainMeadow
             On.Menu.MenuObject.GrafUpdate += On_MenuObject_GrafUpdate;
             new Hook(typeof(ButtonTemplate).GetProperty("CurrentlySelectableMouse", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public).GetMethod, On_ButtonTemplate_Selectable);
             new Hook(typeof(ButtonTemplate).GetProperty("CurrentlySelectableNonMouse", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public).GetMethod, On_ButtonTemplate_Selectable);
-
+            new Hook(typeof(MenuObject).GetProperty("Container", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public).GetMethod, MenuObject_Container);
             On.Menu.SlugcatSelectMenu.GetSaveGameData += SlugcatSelectMenu_GetSaveGameData;
         }
         void IL_Menu_Update(ILContext il)
@@ -103,6 +103,16 @@ namespace RainMeadow
         bool On_ButtonTemplate_Selectable(Func<ButtonTemplate, bool> orig, ButtonTemplate self)
         {
             return orig(self) && !(self is ButtonScroller.IPartOfButtonScroller scrollButton && scrollButton.Alpha < 1);
+        }
+        private FContainer MenuObject_Container(Func<MenuObject, FContainer> orig, MenuObject self)
+        {
+            if (self.menu is StoryOnlineMenu stryMenu && self is SlugcatSelectMenu.SlugcatPage)
+            {
+                if (stryMenu.slugPageContainer == null) //property gets called before StoryOnlineMenu ctor, make new instance here
+                    (self.owner?.Container ?? stryMenu.container).AddChild(stryMenu.slugPageContainer = new());
+                return stryMenu.slugPageContainer; //now all slugcat pages will be in a stored in this container instead of menu.container, so refreshpages will add slugcat sprites here
+            }
+            return orig(self);
         }
         void SlugcatSelectMenu_AddColorButtons(On.Menu.SlugcatSelectMenu.orig_AddColorButtons orig, SlugcatSelectMenu self)
         {

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -473,7 +473,7 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null && !OnlineManager.lobby.isOwner)
             {
-                if (isStoryMode(out var story)&& story.menuSaveGameData != null)
+                if (isStoryMode(out var story) && story.menuSaveGameData != null)
                 {
                     return story.menuSaveGameData; // we will get this from the owner  if null next lobby tick
                 }

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -469,13 +469,13 @@ namespace RainMeadow
             }, self.mainMenuButtons.Count - 2);
         }
 
-        private Menu.SlugcatSelectMenu.SaveGameData SlugcatSelectMenu_GetSaveGameData(On.Menu.SlugcatSelectMenu.orig_GetSaveGameData orig, global::Menu.SlugcatSelectMenu self, int pageIndex)
+        private Menu.SlugcatSelectMenu.SaveGameData? SlugcatSelectMenu_GetSaveGameData(On.Menu.SlugcatSelectMenu.orig_GetSaveGameData orig, global::Menu.SlugcatSelectMenu self, int pageIndex)
         {
             if (OnlineManager.lobby != null && !OnlineManager.lobby.isOwner)
             {
-                if (isStoryMode(out var story) && story.menuSaveGameData != null)
+                if (isStoryMode(out var story))
                 {
-                    return story.menuSaveGameData;
+                    return story.menuSaveGameData; // we will get this from the owner  if null next lobby tick
                 }
             }
             return orig(self, pageIndex);

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -473,7 +473,7 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null && !OnlineManager.lobby.isOwner)
             {
-                if (isStoryMode(out var story))
+                if (isStoryMode(out var story)&& story.menuSaveGameData != null)
                 {
                     return story.menuSaveGameData; // we will get this from the owner  if null next lobby tick
                 }

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -216,7 +216,8 @@ namespace RainMeadow
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
 
-                FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
+                string clientFlags = AssembleClientFlags(player);
+                FLabel label = new FLabel(Custom.GetFont(), $"{player}{clientFlags} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
                     x = 5.01f,
                     y = screenSize.y - 25 - 15 * line,
@@ -246,7 +247,8 @@ namespace RainMeadow
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
 
-                FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
+                string clientFlags = AssembleClientFlags(player);
+                FLabel label = new FLabel(Custom.GetFont(), $"{player}{clientFlags} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
                     x = 205.01f,
                     y = screenSize.y - 25 - 15 * line,
@@ -386,17 +388,11 @@ namespace RainMeadow
                         {
                             if (onlinePhysicalObject.apo.type == AbstractPhysicalObject.AbstractObjectType.Creature)
                             {
-                                try
-                                {
-                                    AbstractCreature creature = (AbstractCreature)onlinePhysicalObject.apo;
+                                AbstractCreature creature = (AbstractCreature)onlinePhysicalObject.apo;
 
-                                    if (creature.creatureTemplate.TopAncestor().type == CreatureTemplate.Type.Slugcat)
-                                    {
-                                        isMe = true;
-                                    }
-                                } catch
+                                if (creature.creatureTemplate.TopAncestor().type == CreatureTemplate.Type.Slugcat)
                                 {
-                                    RainMeadow.Error($"Failed to cast {onlinePhysicalObject.apo} to AbstractCreature type");
+                                    isMe = true;
                                 }
                             }
                         }
@@ -464,6 +460,25 @@ namespace RainMeadow
             overlayContainer = null;
         }
 
-       
+        private static string AssembleClientFlags(OnlinePlayer player)
+        {
+            string clientFlags = "";
+            if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var playerExists) && OnlineManager.lobby.gameMode is StoryGameMode)
+            {
+                OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings);
+                if (!OnlineManager.lobby.clientSettings[player].inGame)
+                {
+                    clientFlags += "L";
+                }
+                else
+                {
+                    clientFlags += currentClientSettings.readyForWin        ? "S" : "";
+                    clientFlags += currentClientSettings.readyForTransition ? "G" : "";
+                    clientFlags += currentClientSettings.isDead             ? "D" : "";
+                }
+                clientFlags = $" [{clientFlags}]";
+            }
+            return clientFlags;
+        }
     }
 }

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -388,11 +388,17 @@ namespace RainMeadow
                         {
                             if (onlinePhysicalObject.apo.type == AbstractPhysicalObject.AbstractObjectType.Creature)
                             {
-                                AbstractCreature creature = (AbstractCreature)onlinePhysicalObject.apo;
-
-                                if (creature.creatureTemplate.TopAncestor().type == CreatureTemplate.Type.Slugcat)
+                                try
                                 {
-                                    isMe = true;
+                                    AbstractCreature creature = (AbstractCreature)onlinePhysicalObject.apo;
+
+                                    if (creature.creatureTemplate.TopAncestor().type == CreatureTemplate.Type.Slugcat)
+                                    {
+                                        isMe = true;
+                                    }
+                                } catch
+                                {
+                                    RainMeadow.Error($"Failed to cast {onlinePhysicalObject.apo} to AbstractCreature type");
                                 }
                             }
                         }
@@ -465,7 +471,7 @@ namespace RainMeadow
             string clientFlags = "";
             if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var playerExists) && OnlineManager.lobby.gameMode is StoryGameMode)
             {
-                OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings);
+             if (OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings)) {
                 if (!OnlineManager.lobby.clientSettings[player].inGame)
                 {
                     clientFlags += "L";
@@ -477,6 +483,7 @@ namespace RainMeadow
                     clientFlags += currentClientSettings.isDead             ? "D" : "";
                 }
                 clientFlags = $" [{clientFlags}]";
+              }
             }
             return clientFlags;
         }

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -216,8 +216,7 @@ namespace RainMeadow
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
 
-                string clientFlags = AssembleClientFlags(player);
-                FLabel label = new FLabel(Custom.GetFont(), $"{player}{clientFlags} ({averageBits / 1000}kbps - {playerTruePing}ms)")
+                FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
                     x = 5.01f,
                     y = screenSize.y - 25 - 15 * line,
@@ -247,8 +246,7 @@ namespace RainMeadow
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
 
-                string clientFlags = AssembleClientFlags(player);
-                FLabel label = new FLabel(Custom.GetFont(), $"{player}{clientFlags} ({averageBits / 1000}kbps - {playerTruePing}ms)")
+                FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
                     x = 205.01f,
                     y = screenSize.y - 25 - 15 * line,
@@ -466,25 +464,6 @@ namespace RainMeadow
             overlayContainer = null;
         }
 
-        private static string AssembleClientFlags(OnlinePlayer player)
-        {
-            string clientFlags = "";
-            if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var playerExists) && OnlineManager.lobby.gameMode is StoryGameMode)
-            {
-                OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings);
-                if (!OnlineManager.lobby.clientSettings[player].inGame)
-                {
-                    clientFlags += "L";
-                }
-                else
-                {
-                    clientFlags += currentClientSettings.readyForWin        ? "S" : "";
-                    clientFlags += currentClientSettings.readyForTransition ? "G" : "";
-                    clientFlags += currentClientSettings.isDead             ? "D" : "";
-                }
-                clientFlags = $" [{clientFlags}]";
-            }
-            return clientFlags;
-        }
+       
     }
 }

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -300,7 +300,7 @@ namespace RainMeadow
             }
 
             OnNewOwner?.Invoke(this, newOwner);
-            OnlineManager.lobby?.gameMode?.NewOwner(this, oldOwner, owner);
+            OnlineManager.lobby?.gameMode?.NewResourceOwner(this, oldOwner, owner);
         }
 
         protected void LeaseModified()

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -300,6 +300,7 @@ namespace RainMeadow
             }
 
             OnNewOwner?.Invoke(this, newOwner);
+            OnlineManager.lobby?.gameMode?.NewOwner(this, oldOwner, owner);
         }
 
         protected void LeaseModified()

--- a/Online/Resource/RoomSession.cs
+++ b/Online/Resource/RoomSession.cs
@@ -10,7 +10,6 @@ namespace RainMeadow
 
         public WorldSession worldSession => super as WorldSession;
         public World World => worldSession.world;
-        public bool loadedPending = false;
 
         public RoomSession(WorldSession ws, AbstractRoom absroom) : base(ws)
         {
@@ -20,18 +19,7 @@ namespace RainMeadow
 
         protected override void AvailableImpl()
         {
-            if (loadedPending)
-            {
-                loadedPending = false;
-                if (absroom.realizedRoom is null)
-                {
-                    RainMeadow.Error("RoomSession was available without being realized first");
-                }
-                else
-                {
-                    absroom.realizedRoom.Loaded();
-                }
-            }
+
         }
 
         protected override void ActivateImpl()

--- a/OnlineUIComponents/Pointing.cs
+++ b/OnlineUIComponents/Pointing.cs
@@ -35,7 +35,7 @@ namespace RainMeadow
         /// </summary>
         private static void LookAtPoint(Creature realizedPlayer, Vector2 pointingVector, int handIndex)
         {
-            if (realizedPlayer != null)
+            if (realizedPlayer != null && realizedPlayer.room != null)
             {
                 var controller = RWCustom.Custom.rainWorld.options.controls[0].GetActiveController();
                 if (realizedPlayer is Player player && player.graphicsModule is PlayerGraphics playerGraphics)

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -375,7 +375,8 @@ namespace RainMeadow
             if (isStoryMode(out var storyGameMode))
             {
                 orig(self);
-                World world = self.room.game.overWorld.worldLoader.ReturnWorld();
+
+                World world = ((self.room.game.overWorld.worldLoader == null) ? self.room.game.overWorld.activeWorld : self.room.game.overWorld.worldLoader.ReturnWorld());
                 var ws = world.GetResource() ?? throw new KeyNotFoundException();
                 ws.Deactivate();
                 ws.NotNeeded();

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -190,7 +190,7 @@ namespace RainMeadow
                     var inGameClientsData = inGameClients.Select(cs => cs.GetData<StoryClientSettingsData>());
                     var inGameAvatarOPOs = inGameClients.SelectMany(cs => cs.avatars.Select(id => id.FindEntity(true))).OfType<OnlinePhysicalObject>();
                     var rooms = inGameAvatarOPOs.Select(opo => opo.apo.pos.room);
-                    var wasOneWay = (self.overrideData != null) ? self.overrideData.wasOneWay : self.Data.wasOneWay;
+                    var wasOneWay = (self.overrideData != null) ? self.overrideData.oneWay : self.Data.oneWay;
                     // Can't warp to warp points with null rooms (echo warps)
                     // remember that echo warps are one way only, so we will NOT gate thru them
                     // so please do not pretend it's a gate, and no requirements can be met, thanks :)
@@ -248,7 +248,7 @@ namespace RainMeadow
             {
                 RainMeadow.Debug("spawning warp point from echo");
                 PlacedObject placedObject = new(PlacedObject.Type.WarpPoint, null);
-                SpinningTopData specialData = self.SpecialData;
+                Watcher.SpinningTopData specialData = self.SpecialData;
                 // setup data
                 if (specialData != null && placedObject.data is Watcher.WarpPoint.WarpPointData warpData)
                 {

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -112,9 +112,16 @@ namespace RainMeadow
                 }
                 else
                 {
-                    if (SlugcatSelectMenu.MineForSaveData(RWCustom.Custom.rainWorld.processManager, currentCampaign) is SlugcatSelectMenu.SaveGameData savedata)
+                    if (RWCustom.Custom.rainWorld.processManager.currentMainLoop is StoryOnlineMenu sOM)
                     {
-                        currentMenuSaveState = new MenuSaveStateState(savedata);
+                        if (sOM.saveGameData?[storyGameMode.currentCampaign] is SlugcatSelectMenu.SaveGameData data)
+                        {
+                            currentMenuSaveState = new MenuSaveStateState(data);
+                        }
+                        else
+                        {
+                            currentMenuSaveState = null;
+                        }
                     }
                     else
                     {

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -112,17 +112,8 @@ namespace RainMeadow
                 }
                 else
                 {
-                    if (SlugcatSelectMenu.MineForSaveData(RWCustom.Custom.rainWorld.processManager, currentCampaign) is SlugcatSelectMenu.SaveGameData savedata)
-                    {
-                        currentMenuSaveState = new MenuSaveStateState(savedata);
-                    }
-                    else
-                    {
-                        currentMenuSaveState = null;
-                    }
+                    currentMenuSaveState = storyGameMode.menuSaveState;
                 }
-
-                
 
                 food = (currentGameState?.Players[0].state as PlayerState)?.foodInStomach ?? 0;
                 quarterfood = (currentGameState?.Players[0].state as PlayerState)?.quarterFoodPoints ?? 0;

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -357,7 +357,6 @@ namespace RainMeadow
             if (OnlineManager.lobby == null) return;
             if (OnlineManager.lobby.isOwner)
             {
-                restartCheckbox.buttonBehav.greyedOut = false;
                 nextButton.buttonBehav.greyedOut = false;
                 prevButton.buttonBehav.greyedOut = false;
 
@@ -373,7 +372,6 @@ namespace RainMeadow
             else
             {
 
-                restartCheckbox.buttonBehav.greyedOut = true;
                 nextButton.buttonBehav.greyedOut = true;
                 prevButton.buttonBehav.greyedOut = true;
 

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -14,7 +14,7 @@ namespace RainMeadow
 {
     public class StoryOnlineMenu : SlugcatSelectMenu, IChatSubscriber
     {
-        private CheckBox clientWantsToOverwriteSave;
+        //private CheckBox clientWantsToOverwriteSave;
         private CheckBox friendlyFire;
         private CheckBox reqCampaignSlug;
         private MenuLabel? lobbyLabel, slugcatLabel;
@@ -254,7 +254,7 @@ namespace RainMeadow
 
             manager.arenaSitting = null;
 
-            if ((OnlineManager.lobby.isOwner && restartChecked) || (!OnlineManager.lobby.isOwner && clientWantsToOverwriteSave.Checked))
+            if (restartChecked)
             {
                 manager.rainWorld.progression.WipeSaveState(storyGameMode.currentCampaign);
                 manager.menuSetup.startGameCondition = ProcessManager.MenuSetup.StoryGameInitCondition.New;
@@ -535,6 +535,9 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby.isOwner)
             {
+                restartCheckbox.IDString = "RESTART";
+                restartCheckbox.label.text = "Restart game";
+
                 pages.RemoveRange(1, slugcatPages.Count);
                 for (int i = 0; i < slugcatPages.Count; i++)
                 {
@@ -557,7 +560,6 @@ namespace RainMeadow
             }
             else
             {
-                currentOwner = OnlineManager.lobby.owner;
                 int pageindex = 1 + indexFromColor(storyGameMode.currentCampaign);
                 if (pageindex != 0)
                 {
@@ -569,6 +571,9 @@ namespace RainMeadow
                     pages.Insert(pageindex, page);
                     slugcatPages.Insert(pageindex - 1, page);
                 }
+                restartCheckbox.IDString = "CLIENTSAVERESET";
+                restartCheckbox.label.text = "Match save";
+
             }
 
             UpdatePlayerList();
@@ -647,8 +652,11 @@ namespace RainMeadow
 
         private void SetupClientOptions()
         {
-            clientWantsToOverwriteSave = new CheckBox(this, pages[0], this, restartCheckboxPos, 70f, Translate("Match save"), "CLIENTSAVERESET", false);
-            pages[0].subObjects.Add(clientWantsToOverwriteSave);
+            //restartCheckbox = new CheckBox(this, pages[0], this, restartCheckboxPos, 70f, Translate("Match save"), "CLIENTSAVERESET", false);
+            restartCheckbox.displayText = "Match save";
+            restartCheckbox.label.text = "Match save";
+            restartCheckbox.IDString = "CLIENTSAVERESET";
+            //pages[0].subObjects.Add(clientWantsToOverwriteSave);
         }
         public StoryMenuSlugcatButton[] GetSlugcatSelectionButtons(StoryMenuSlugcatSelector slugcatSelector, ButtonScroller buttonScroller)
         {

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -25,7 +25,7 @@ namespace RainMeadow
         public SlugcatStats.Name?[] playerSelectedSlugcats;
         private StoryGameMode storyGameMode;
         private Vector2 restartCheckboxPos;
-        
+
         //Chat constants
         private const int maxVisibleMessages = 13;
         //Chat variables
@@ -35,6 +35,9 @@ namespace RainMeadow
         private bool isChatToggled = false;
         private ChatTextBox chatTextBox;
         private Vector2 chatTextBoxPos;
+        public OnlinePlayer currentOwner = OnlineManager.lobby.owner;
+
+        public bool isPrevOwner =>  OnlineManager.lobby.owner == currentOwner;
 
         public SlugcatStats.Name[] SelectableSlugcats
         {
@@ -97,11 +100,11 @@ namespace RainMeadow
                 else if (colorChecked)
                 {
                     AddColorButtons();
-                } 
+                }
             }
 
 
-            
+
             if (OnlineManager.lobby.isOwner)
             {
                 storyGameMode.requireCampaignSlugcat = false;
@@ -137,7 +140,8 @@ namespace RainMeadow
                 var SelectableSlugcatsEnumerable = slugcatColorOrder.AsEnumerable();
                 if (ModManager.MSC)
                 {
-                    if (!SelectableSlugcatsEnumerable.Contains(MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Slugpup)) {
+                    if (!SelectableSlugcatsEnumerable.Contains(MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Slugpup))
+                    {
                         SelectableSlugcatsEnumerable = SelectableSlugcatsEnumerable.Append(MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Slugpup);
                     }
                 }
@@ -164,7 +168,7 @@ namespace RainMeadow
                     }
                 }
             }
-        }   
+        }
 
         public new void StartGame(SlugcatStats.Name storyGameCharacter)
         {
@@ -294,7 +298,7 @@ namespace RainMeadow
                     {
                         AddColorButtons();
                     }
-                    
+
                     colorsCheckbox.buttonBehav.greyedOut = jollyallowed;
                 }
             }
@@ -313,16 +317,17 @@ namespace RainMeadow
             }
             base.Update();
 
-            if (ModManager.JollyCoop) {
+            if (ModManager.JollyCoop)
+            {
                 this.storyGameMode.friendlyFire = manager.rainWorld.options.friendlyFire;
                 if (jollyallowed)
                 {
                     this.jollyPlayerCountLabel.text = base.Translate("Players: <num_p>").Replace("<num_p>", Custom.rainWorld.options.JollyPlayerCount.ToString());
                     this.RefreshJollySummary();
                 }
-                
+
             }
-            
+
 
             if (this.isChatToggled)
             {
@@ -369,7 +374,7 @@ namespace RainMeadow
             }
             else
             {
-                
+
                 restartCheckbox.buttonBehav.greyedOut = true;
                 nextButton.buttonBehav.greyedOut = true;
                 prevButton.buttonBehav.greyedOut = true;
@@ -397,7 +402,7 @@ namespace RainMeadow
                     int moveInPage = currentcampaignindex - slugcatPageIndex;
                     int cycleAroundleft = moveInPage - slugcatColorOrder.Count;
                     int cycleAroundRight = moveInPage + slugcatColorOrder.Count;
-                    int bestCycleAround = Mathf.Abs(cycleAroundleft) < Mathf.Abs(cycleAroundRight)? cycleAroundleft : cycleAroundRight;
+                    int bestCycleAround = Mathf.Abs(cycleAroundleft) < Mathf.Abs(cycleAroundRight) ? cycleAroundleft : cycleAroundRight;
                     if (Mathf.Abs(moveInPage) < Mathf.Abs(bestCycleAround))
                     {
                         scroll = -moveInPage;
@@ -409,7 +414,7 @@ namespace RainMeadow
 
                     slugcatPageIndex = currentcampaignindex;
                     quedSideInput = 0;
-                    
+
 
                     UpdateSelectedSlugcatInMiscProg();
                 }
@@ -530,23 +535,10 @@ namespace RainMeadow
 
         void RefreshPages()
         {
-            if (OnlineManager.lobby.isOwner)
-            {
-                for (int i = 0; i < slugcatColorOrder.Count; i++)
-                {
-                    int pageindex = 1 + i;
-                    SlugcatPage page = GetSaveGameData(pageindex) != null ? new SlugcatPageContinue(this, null, pageindex, storyGameMode.currentCampaign) : new SlugcatPageNewGame(this, null, pageindex, storyGameMode.currentCampaign);
-                    pages[pageindex].RemoveSprites();
-                    pages.RemoveAt(pageindex);
-                    slugcatPages.RemoveAt(pageindex - 1);
+            if (!OnlineManager.lobby.isOwner || !isPrevOwner)
 
-                    pages.Insert(pageindex, page);
-                    slugcatPages.Insert(pageindex - 1, page);
-                }
-
-            }
-            else
             {
+                currentOwner = OnlineManager.lobby.owner;
                 int pageindex = 1 + indexFromColor(storyGameMode.currentCampaign);
                 SlugcatPage page = GetSaveGameData(pageindex) != null ? new SlugcatPageContinue(this, null, pageindex, storyGameMode.currentCampaign) : new SlugcatPageNewGame(this, null, pageindex, storyGameMode.currentCampaign);
                 pages[pageindex].RemoveSprites();
@@ -556,7 +548,7 @@ namespace RainMeadow
                 pages.Insert(pageindex, page);
                 slugcatPages.Insert(pageindex - 1, page);
             }
-            
+
             UpdateSelectedSlugcatInMiscProg();
 
         }
@@ -571,7 +563,7 @@ namespace RainMeadow
         {
             personaSettings = storyGameMode.avatarSettings[0];
         }
-        
+
         private void SetupOnlineMenuItems()
         {
             // Player lobby label

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -532,18 +532,26 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby.isOwner)
             {
+                for (int i = 0; i < slugcatPages.Count; i++)
+                {
+                    slugcatPages[i].RemoveSprites();
+                }
+                slugcatPages.Clear();
+
+                pages.RemoveRange(1, slugcatPages.Count - 1);
                 for (int i = 0; i < slugcatColorOrder.Count; i++)
                 {
-                    int pageindex = 1 + i;
-                    SlugcatPage page = GetSaveGameData(pageindex) != null ? new SlugcatPageContinue(this, null, pageindex, storyGameMode.currentCampaign) : new SlugcatPageNewGame(this, null, pageindex, storyGameMode.currentCampaign);
-                    pages[pageindex].RemoveSprites();
-                    pages.RemoveAt(pageindex);
-                    slugcatPages.RemoveAt(pageindex - 1);
+                    if (this.saveGameData[slugcatColorOrder[i]] != null)
+                    {
+                        slugcatPages.Add(new SlugcatPageContinue(this, null, 1 + i, slugcatColorOrder[i]));
+                    }
+                    else
+                    {
+                        slugcatPages.Add(new SlugcatPageNewGame(this, null, 1 + i, slugcatColorOrder[i]));
+                    }
 
-                    pages.Insert(pageindex, page);
-                    slugcatPages.Insert(pageindex - 1, page);
+                    pages.Add(slugcatPages[i]);
                 }
-
             }
             else
             {
@@ -558,7 +566,6 @@ namespace RainMeadow
             }
             
             UpdateSelectedSlugcatInMiscProg();
-
         }
 
         private void RemoveSlugcatList()

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -25,6 +25,7 @@ namespace RainMeadow
         public SlugcatStats.Name?[] playerSelectedSlugcats;
         private StoryGameMode storyGameMode;
         private Vector2 restartCheckboxPos;
+        public FContainer? slugPageContainer; //this is sprite container for slugcat images to not overlap sprites when refreshing
 
         //Chat constants
         private const int maxVisibleMessages = 13;
@@ -395,24 +396,25 @@ namespace RainMeadow
                 if (storyGameMode.currentCampaign != slugcatColorOrder[slugcatPageIndex])
                 {
                     var currentcampaignindex = indexFromColor(storyGameMode.currentCampaign);
-                    int moveInPage = currentcampaignindex - slugcatPageIndex;
-                    int cycleAroundleft = moveInPage - slugcatColorOrder.Count;
-                    int cycleAroundRight = moveInPage + slugcatColorOrder.Count;
-                    int bestCycleAround = Mathf.Abs(cycleAroundleft) < Mathf.Abs(cycleAroundRight) ? cycleAroundleft : cycleAroundRight;
-                    if (Mathf.Abs(moveInPage) < Mathf.Abs(bestCycleAround))
+                    if (currentcampaignindex > -1)
                     {
-                        scroll = -moveInPage;
+                        int moveInPage = currentcampaignindex - slugcatPageIndex;
+                        int cycleAroundleft = moveInPage - slugcatColorOrder.Count;
+                        int cycleAroundRight = moveInPage + slugcatColorOrder.Count;
+                        int bestCycleAround = Mathf.Abs(cycleAroundleft) < Mathf.Abs(cycleAroundRight) ? cycleAroundleft : cycleAroundRight;
+                        if (Mathf.Abs(moveInPage) < Mathf.Abs(bestCycleAround))
+                        {
+                            scroll = -moveInPage;
+                        }
+                        else
+                        {
+                            scroll = -bestCycleAround;
+                        }
+
+                        slugcatPageIndex = currentcampaignindex;
+                        quedSideInput = 0;
+                        UpdateSelectedSlugcatInMiscProg();
                     }
-                    else
-                    {
-                        scroll = -bestCycleAround;
-                    }
-
-                    slugcatPageIndex = currentcampaignindex;
-                    quedSideInput = 0;
-
-
-                    UpdateSelectedSlugcatInMiscProg();
                 }
             }
             if (storyGameMode.requireCampaignSlugcat)

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -557,7 +557,6 @@ namespace RainMeadow
             }
             else
             {
-                currentOwner = OnlineManager.lobby.owner;
                 int pageindex = 1 + indexFromColor(storyGameMode.currentCampaign);
                 if (pageindex != 0)
                 {

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -311,6 +311,15 @@ namespace RainMeadow
                 }
                 ChatTextBox.blockInput = true;
             }
+
+            if (storyGameMode.needMenuSaveUpdate)
+            {
+                RainMeadow.Debug("page refresh");
+                storyGameMode.needMenuSaveUpdate = false;
+                RefreshPages();
+            }
+
+
             base.Update();
 
             if (ModManager.JollyCoop) {
@@ -342,13 +351,6 @@ namespace RainMeadow
                         UpdateLogDisplay();
                     }
                 }
-            }
-
-            if (storyGameMode.needMenuSaveUpdate)
-            {
-                RainMeadow.Debug("page refresh");
-                storyGameMode.needMenuSaveUpdate = false;
-                RefreshPages();
             }
 
             if (OnlineManager.lobby == null) return;
@@ -532,16 +534,15 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby.isOwner)
             {
+                pages.RemoveRange(1, slugcatPages.Count);
                 for (int i = 0; i < slugcatPages.Count; i++)
                 {
                     slugcatPages[i].RemoveSprites();
                 }
                 slugcatPages.Clear();
-
-                pages.RemoveRange(1, slugcatPages.Count - 1);
                 for (int i = 0; i < slugcatColorOrder.Count; i++)
                 {
-                    if (this.saveGameData[slugcatColorOrder[i]] != null)
+                    if (GetSaveGameData(i) != null)
                     {
                         slugcatPages.Add(new SlugcatPageContinue(this, null, 1 + i, slugcatColorOrder[i]));
                     }
@@ -556,15 +557,26 @@ namespace RainMeadow
             else
             {
                 int pageindex = 1 + indexFromColor(storyGameMode.currentCampaign);
-                SlugcatPage page = GetSaveGameData(pageindex) != null ? new SlugcatPageContinue(this, null, pageindex, storyGameMode.currentCampaign) : new SlugcatPageNewGame(this, null, pageindex, storyGameMode.currentCampaign);
-                pages[pageindex].RemoveSprites();
-                pages.RemoveAt(pageindex);
-                slugcatPages.RemoveAt(pageindex - 1);
+                if (pageindex != 0)
+                {
+                    pages[pageindex].RemoveSprites();
+                    pages.RemoveAt(pageindex);
+                    slugcatPages.RemoveAt(pageindex - 1);
 
-                pages.Insert(pageindex, page);
-                slugcatPages.Insert(pageindex - 1, page);
+                    SlugcatPage page = (storyGameMode.menuSaveGameData != null)? new SlugcatPageContinue(this, null, pageindex, storyGameMode.currentCampaign) : new SlugcatPageNewGame(this, null, pageindex, storyGameMode.currentCampaign);
+                    pages.Insert(pageindex, page);
+                    slugcatPages.Insert(pageindex - 1, page);
+                }
             }
-            
+
+            UpdatePlayerList();
+
+            if (!storyGameMode.requireCampaignSlugcat)
+            {
+                RemoveSlugcatList();
+                SetupSlugcatList();
+            }
+
             UpdateSelectedSlugcatInMiscProg();
         }
 

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -60,6 +60,14 @@ namespace RainMeadow
         public static float ButtonSizeWithSpacing => ButtonSize + ButtonSpacingOffset;
         public static float ButtonSize => 30;
 
+        public void SetCampaign(SlugcatStats.Name campaign)
+        {
+            storyGameMode.currentCampaign = campaign;
+            if (GetSaveGameData(indexFromColor(campaign)) is SaveGameData sgd)
+                storyGameMode.menuSaveState = new StoryLobbyData.MenuSaveStateState(sgd);
+            else
+                storyGameMode.menuSaveState = null;
+        }
 
         public StoryOnlineMenu(ProcessManager manager) : base(manager)
         {
@@ -68,8 +76,8 @@ namespace RainMeadow
             ID = OnlineManager.lobby.gameMode.MenuProcessId();
             storyGameMode = (StoryGameMode)OnlineManager.lobby.gameMode;
             storyGameMode.Sanitize();
-            storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
-            restartCheckboxPos = restartCheckbox.pos;       
+            SetCampaign(slugcatPages[slugcatPageIndex].slugcatNumber);
+            restartCheckboxPos = restartCheckbox.pos;
             ModifyExistingMenuItems();
 
             if (ModManager.JollyCoop)
@@ -166,7 +174,7 @@ namespace RainMeadow
 
             if (OnlineManager.lobby.isOwner)
             {
-                storyGameMode.currentCampaign = storyGameCharacter;
+                SetCampaign(storyGameCharacter);
             }
 
             var jollyallowed = ModManager.JollyCoop && base.CheckJollyCoopAvailable(slugcatColorOrder[slugcatPageIndex]);
@@ -351,7 +359,7 @@ namespace RainMeadow
                 prevButton.buttonBehav.greyedOut = false;
 
 
-                storyGameMode.currentCampaign = slugcatPages[slugcatPageIndex].slugcatNumber;
+                SetCampaign(slugcatPages[slugcatPageIndex].slugcatNumber);
                 storyGameMode.region = CurrentRegion();
                 if (startButton != null)
                 {

--- a/Story/StoryRPCs.cs
+++ b/Story/StoryRPCs.cs
@@ -173,14 +173,18 @@ namespace RainMeadow
         [RPCMethod]
         public static void RaiseRippleLevel(UnityEngine.Vector2 vector)
         {
+
             if (RainMeadow.isStoryMode(out var story))
             {
-                RainMeadow.Debug($"Raising Ripple Level from: {story.rippleLevel} to {vector.y}");
-                if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession storyGameSession && game.manager.upcomingProcess is null)) return;
-                story.rippleLevel = vector.y;
-                storyGameSession.saveState.deathPersistentSaveData.minimumRippleLevel = vector.x;
-                storyGameSession.saveState.deathPersistentSaveData.maximumRippleLevel = vector.y;
-                storyGameSession.saveState.deathPersistentSaveData.rippleLevel = vector.y;
+                if (story.rippleLevel < vector.y)
+                {
+                    RainMeadow.Debug($"Raising Ripple Level from: {story.rippleLevel} to {vector.y}");
+                    if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession storyGameSession && game.manager.upcomingProcess is null)) return;
+                    story.rippleLevel = vector.y;
+                    storyGameSession.saveState.deathPersistentSaveData.minimumRippleLevel = vector.x;
+                    storyGameSession.saveState.deathPersistentSaveData.maximumRippleLevel = vector.y;
+                    storyGameSession.saveState.deathPersistentSaveData.rippleLevel = vector.y;
+                }
             }
         }
 


### PR DESCRIPTION
# Fix NREs
- [x] Investigate NREs on PerformWarp: https://github.com/henpemaz/Rain-Meadow/blob/main/Story/StoryHooks.cs#L378

PerformWarp NRE [Story save](https://discord.com/channels/1094716194180841602/1155268800669831270/1421136625324396657)
```
(On.Watcher.WarpPoint+orig_PerformWarp orig, Watcher.WarpPoint self) [0x00015] in C:\Users\6fear\source\repos\Rain-Meadow\Story\StoryHooks.cs:378 
```
- [x] Investigate NREs on Pointing: https://github.com/henpemaz/Rain-Meadow/blob/main/OnlineUIComponents/Pointing.cs#L45
```
[Error  :RainMeadow] System.NullReferenceException: Object reference not set to an instance of an object
  at Meadow\OnlineUIComponents\Pointing.cs:45 
```

# Fix IL Hooks:

- [x] RainWorldGame_Update [pause menu]
- [x] PlayerGraphics_InitiateSpritesCosmetics [capes]
- [x] LizardController.Lizard_SwimBehavior --> The check is now moved to the property, "Lizard_getSwimmer"
- [x] Map_OwnerFixup


# Warps
- OverWorld_InitiateSpecialWarp_WarpPoint (appears to be looping for an APO)

```
[Info   :RainMeadow] First world loaded, holding precycle scale.
[Info   :RainMeadow] 13:58:49|1842957|RainMeadow.EntityHooks.OverWorld_InitiateSpecialWarp_WarpPoint:doing warp point from , data=39~22~Watcher~Watcher~WTDA~wtda_b12~1630~290~9182f1c7-e0fd-4cd6-90da-7ba65329e885~WatcherOnly~0~6~8~4~8~4~4~4~7~150~150~14~0~1~true~false~true~true~false~0~-1~false~-1~false~-1~false
[Info   :RainMeadow] -- mapconfig as timeline: Watcher
[Info   :RainMeadow] Creating region state for world: WTDA
[Info   :RainMeadow] Adapt world to region state WTDA
[Info   :RainMeadow] Region WTDA ticking forward 14 cycles. (+ 0 bonus cycles for bats and consumables)
[Info   :RainMeadow] Generate population for : WTDA FRESH: True
[Info   :RainMeadow] 13:58:49|1842957|WorldSession.Entities.ApoEnteringWorld:Region WTDA - registering ID.-1.7920<oB>0<oA>Spear<oA>WTDAOffscreenDen.-1.-1.0<oA>0<oA>0<oA>0<oA>0<oA>0<oA>0<oA>0<oA>0
[Error  :RainMeadow] 13:58:49|1842957|OnlinePhysicalObject.NewFromApo:entity with repeated ID: #7920:apo:0001
[Error  :RainMeadow] 13:58:49|1842957|OnlinePhysicalObject.NewFromApo:set as: #7921:apo:0001
[Error  :RainMeadow] System.ArgumentException: An item with the same key has already been added. Key: #7921:apo:0001
```

# Story 
- [x] Fix lobby tick mine for save data per player that joins in menu  #1060 
- [x] Investigate Watcher karma RPC, maybe can just ensure only clients run it? https://github.com/henpemaz/Rain-Meadow/blob/main/Story/StoryHooks.cs#L346
- [x] Fix SlugcatSelect Menu not showing all correct campaigns 
```
[Error  :RainMeadow] System.NullReferenceException: Object reference not set to an instance of an object
  at Menu.SlugcatSelectMenu+SlugcatPageContinue..ctor (Menu.Menu menu, Menu.MenuObject owner, System.Int32 pageIndex, SlugcatStats+Name slugcatNumber) [0x0001b] in <cbade7a2a8284efba1516cb05acf10f3>:0
  at RainMeadow.StoryOnlineMenu.RefreshPages () [0x0001f] in C:\Users\6fear\source\repos\Rain-Meadow\Story\StoryOnlineMenu.cs:538
  at RainMeadow.StoryOnlineMenu.Update () [0x00290] in C:\Users\6fear\source\repos\Rain-Meadow\Story\StoryOnlineMenu.cs:351
```

https://discord.com/channels/1094716194180841602/1155268800669831270/1421921752883400737

- [x] Watcher: Fix Room_Loaded IL hook to not run in local story games

# Arena
- [x] Fix NRE from being kicked
```
[Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
Stack trace:
RainMeadow.UI.Pages.ArenaSlugcatSelectPage.Update () (at C:/Users/6fear/source/repos/Rain-Meadow/Menu/Pages/ArenaSlugcatSelectPage.cs:318
```
- [x] Fix watcher story menu overlap
- [x] Fix resetProgression checkbox in story menu on client to not be greyd out
- [x] Fix Arena saint description logic
- [ ] Fix null new world: https://discord.com/channels/1094716194180841602/1099382590449922098/1422236319622369280
- [ ] Final checks
