### PR TITLE
Story client debug info on dev tools 

### DIFF
--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -1,3 +1,4 @@
+using Ionic.Zlib;
 using RWCustom;
 using System;
 using System.Collections.Generic;
@@ -217,7 +218,8 @@ namespace RainMeadow
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
 
-                FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
+                string clientFlags = AssembleClientFlags(player);
+                FLabel label = new FLabel(Custom.GetFont(), $"{player}{clientFlags} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
                     x = 5.01f,
                     y = screenSize.y - 25 - 15 * line,
@@ -247,17 +249,8 @@ namespace RainMeadow
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
 
-                string isReadyForWin = "", isReadyForTransition = "", isDead = "";
-                if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var playerExists))
-                {
-                    OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings);
-                    OnlineManager.lobby.TryGetData<StoryLobbyData>(out var currentClientSettings2);
-                    isReadyForWin = currentClientSettings.readyForWin               ? "S" : "";
-                    isReadyForTransition = currentClientSettings.readyForTransition ? "G" : "";
-                    isDead = currentClientSettings.isDead                           ? "D" : ""; //Lobbied counts as "dead"
-                }
-
-                FLabel label = new FLabel(Custom.GetFont(), $"{player}[{isReadyForWin}{isReadyForTransition}{isDead}] ({averageBits / 1000}kbps - {playerTruePing}ms)")
+                string clientFlags = AssembleClientFlags(player);
+                FLabel label = new FLabel(Custom.GetFont(), $"{player}{clientFlags} ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
                     x = 205.01f,
                     y = screenSize.y - 25 - 15 * line,
@@ -467,6 +460,28 @@ namespace RainMeadow
             entityNodes.Clear();
             overlayContainer?.RemoveFromContainer();
             overlayContainer = null;
+        }
+
+        private static string AssembleClientFlags(OnlinePlayer player)
+        {
+            string clientFlags = "";
+            if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var playerExists) && OnlineManager.lobby.gameMode is StoryGameMode)
+            {
+                clientFlags += " [";
+                OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings);
+                if (!OnlineManager.lobby.clientSettings[player].inGame)
+                {
+                    clientFlags += "L";
+                }
+                else
+                {
+                    clientFlags += currentClientSettings.readyForWin        ? "S" : "";
+                    clientFlags += currentClientSettings.readyForTransition ? "G" : "";
+                    clientFlags += currentClientSettings.isDead             ? "D" : "";
+                }
+                clientFlags += "]";
+            }
+            return clientFlags;
         }
     }
 }

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -467,7 +467,6 @@ namespace RainMeadow
             string clientFlags = "";
             if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var playerExists) && OnlineManager.lobby.gameMode is StoryGameMode)
             {
-                clientFlags += " [";
                 OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings);
                 if (!OnlineManager.lobby.clientSettings[player].inGame)
                 {
@@ -479,7 +478,7 @@ namespace RainMeadow
                     clientFlags += currentClientSettings.readyForTransition ? "G" : "";
                     clientFlags += currentClientSettings.isDead             ? "D" : "";
                 }
-                clientFlags += "]";
+                clientFlags = $" [{clientFlags}]";
             }
             return clientFlags;
         }

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using static RainMeadow.StoryGameMode;
 
 namespace RainMeadow
 {
@@ -246,7 +247,17 @@ namespace RainMeadow
                 averageBytes = (int)((float)averageBytes / 40 * OnlineManager.instance.framesPerSecond); // bytes per second
                 var averageBits = averageBytes * 8;
 
-                FLabel label = new FLabel(Custom.GetFont(), $"{player} ({averageBits / 1000}kbps - {playerTruePing}ms)")
+                string isReadyForWin = "", isReadyForTransition = "", isDead = "";
+                if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var playerExists))
+                {
+                    OnlineManager.lobby.clientSettings[player].TryGetData<StoryClientSettingsData>(out var currentClientSettings);
+                    OnlineManager.lobby.TryGetData<StoryLobbyData>(out var currentClientSettings2);
+                    isReadyForWin = currentClientSettings.readyForWin               ? "S" : "";
+                    isReadyForTransition = currentClientSettings.readyForTransition ? "G" : "";
+                    isDead = currentClientSettings.isDead                           ? "D" : ""; //Lobbied counts as "dead"
+                }
+
+                FLabel label = new FLabel(Custom.GetFont(), $"{player}[{isReadyForWin}{isReadyForTransition}{isDead}] ({averageBits / 1000}kbps - {playerTruePing}ms)")
                 {
                     x = 205.01f,
                     y = screenSize.y - 25 - 15 * line,

--- a/Online/DebugOverlay.cs
+++ b/Online/DebugOverlay.cs
@@ -1,10 +1,8 @@
-using Ionic.Zlib;
 using RWCustom;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using static RainMeadow.StoryGameMode;
 
 namespace RainMeadow
 {


### PR DESCRIPTION
In story lobbies, players' names in the dev tools overlay will have an additional [] that will contain any amount of the following flags:
S = Ready to shelter
G = Trying to go through a gate
D = Dead
L = Waiting in lobby
This is intended to make it easier for lobby hosts to identify who is preventing a gate or shelter from working, whether a bug or not.