### PR TITLE
DLL Cache

### DIFF
--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -131,11 +131,11 @@ namespace RainMeadow
             self.AddPart(new OnlineHUD(self, session.game.cameras[0], arena));
             self.AddPart(new Pointing(self));
             self.AddPart(new ArenaSpawnLocationIndicator(self, session.game.cameras[0]));
-            self.AddPart(new Watcher.CamoMeter(self, self.fContainers[1]));
+            self.AddPart(new Watcher.CamoMeter(self, null, self.fContainers[1]));
             if (ModManager.Watcher && OnlineManager.lobby.clientSettings[OnlineManager.mePlayer].GetData<ArenaClientSettings>().playingAs == Watcher.WatcherEnums.SlugcatStatsName.Watcher)
             {
                 RainMeadow.Debug("Adding Watcher Camo Meter");
-                self.AddPart(new Watcher.CamoMeter(self, self.fContainers[1]));
+                self.AddPart(new Watcher.CamoMeter(self, null, self.fContainers[1]));
             }
         }
         public virtual void ArenaCreatureSpawner_SpawnCreatures(ArenaOnlineGameMode arena, On.ArenaCreatureSpawner.orig_SpawnArenaCreatures orig, RainWorldGame game, ArenaSetup.GameTypeSetup.WildLifeSetting wildLifeSetting, ref List<AbstractCreature> availableCreatures, ref MultiplayerUnlocks unlocks)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,3 +17,4 @@
 /Meadow/	@henpemaz
 /Online/NetIO/  @invalidunits
 /Online/Matchmaking/  @invalidunits
+/Compiler/ @invalidunits

--- a/Compiler/MethodCache.cs
+++ b/Compiler/MethodCache.cs
@@ -10,13 +10,19 @@ namespace RainMeadow
 {
     static class MethodCache
     {
+        public static bool compiledCache = false;
         public static Dictionary<Module, Assembly> cachedAssemblies = new Dictionary<Module, Assembly>();
         public static Dictionary<Module, TypeBuilder> buildingTypes = new Dictionary<Module, TypeBuilder>();
+        private static List<(MethodBase, Action<MethodInfo>)> compilationCallbacks = new();
+
 
         // return false if cached. returns new MethodBase and false if not.
-        public static bool LoadMethod(string key, Module connectedModule, out MethodBase method,
+        public static bool LoadMethod(string key, Module connectedModule, out MethodBase method, Action<MethodInfo> onCompletedCompilation,
             Type returnType, params Type[] argumentTypes)
         {
+            var modCacheDirectory = Path.Combine(ModManager.GetModById("henpemaz_rainmeadow").basePath, "cache");
+            if (Directory.Exists(modCacheDirectory)) Directory.CreateDirectory(modCacheDirectory);
+
             var version = connectedModule.ModuleVersionId;
             var assemblyfile = connectedModule.Name + version.ToString("N") + ".MeadowCache" + ".dll";
 
@@ -28,7 +34,7 @@ namespace RainMeadow
                 }
                 else
                 {
-                    var buildingassemb = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName() { Name = assemblyfile }, AssemblyBuilderAccess.RunAndSave);
+                    var buildingassemb = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName() { Name = assemblyfile }, AssemblyBuilderAccess.RunAndSave, modCacheDirectory);
                     var module = buildingassemb.DefineDynamicModule(assemblyfile, assemblyfile, false);
                     buildingTypes.Add(connectedModule, module.DefineType("Cache", TypeAttributes.Public | TypeAttributes.Sealed));
                 }
@@ -37,6 +43,7 @@ namespace RainMeadow
             if (cachedAssemblies.ContainsKey(connectedModule))
             {
                 method = cachedAssemblies[connectedModule].DefinedTypes.First().DeclaredMethods.First(x => x.Name == key);
+                onCompletedCompilation((MethodInfo)method);
                 return true;
             }
 
@@ -44,6 +51,7 @@ namespace RainMeadow
             if (method is null)
             {
                 method = buildingTypes[connectedModule].DefineMethod(key, MethodAttributes.Public | MethodAttributes.Static, CallingConventions.Standard, returnType, argumentTypes);
+                compilationCallbacks.Add((method, onCompletedCompilation));
                 return false;
             }
 
@@ -52,11 +60,24 @@ namespace RainMeadow
 
         public static void SaveDynamicMethods()
         {
+            if (compiledCache) throw new InvalidOperationException("We already compiled the cache");
             foreach (TypeBuilder type in buildingTypes.Values)
             {
-                type.CreateType();
+                var compiledType = type.CreateType();
                 ((AssemblyBuilder)type.Assembly).Save(type.Assembly.GetName().Name);
+                foreach ((MethodBase info, Action<MethodInfo> action) in compilationCallbacks)
+                {
+                    var compiledMethod = compiledType.GetMethod(
+                        info.Name, BindingFlags.Public | BindingFlags.Static, null, CallingConventions.Standard, info.GetParameters().Select(x => x.ParameterType).ToArray(), null
+                    );
+
+                    if (compiledMethod is null) throw new InvalidProgrammerException($"Could not find compiled method \"{info.Name}\" ");
+                    action(compiledMethod);
+                }
+
+                compilationCallbacks.Clear();
             }
+            compiledCache = true;
         }
     }
 }

--- a/Compiler/MethodCache.cs
+++ b/Compiler/MethodCache.cs
@@ -1,0 +1,62 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace RainMeadow
+{
+    static class MethodCache
+    {
+        public static Dictionary<Module, Assembly> cachedAssemblies = new Dictionary<Module, Assembly>();
+        public static Dictionary<Module, TypeBuilder> buildingTypes = new Dictionary<Module, TypeBuilder>();
+
+        // return false if cached. returns new MethodBase and false if not.
+        public static bool LoadMethod(string key, Module connectedModule, out MethodBase method,
+            Type returnType, params Type[] argumentTypes)
+        {
+            var version = connectedModule.ModuleVersionId;
+            var assemblyfile = connectedModule.Name + version.ToString("N") + ".MeadowCache" + ".dll";
+
+            if (!cachedAssemblies.ContainsKey(connectedModule) && !buildingTypes.ContainsKey(connectedModule))
+            {
+                if (File.Exists(assemblyfile))
+                {
+                    cachedAssemblies.Add(connectedModule, Assembly.Load(File.ReadAllBytes(assemblyfile)));
+                }
+                else
+                {
+                    var buildingassemb = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName() { Name = assemblyfile }, AssemblyBuilderAccess.RunAndSave);
+                    var module = buildingassemb.DefineDynamicModule(assemblyfile, assemblyfile, false);
+                    buildingTypes.Add(connectedModule, module.DefineType("Cache", TypeAttributes.Public | TypeAttributes.Sealed));
+                }
+            }
+
+            if (cachedAssemblies.ContainsKey(connectedModule))
+            {
+                method = cachedAssemblies[connectedModule].DefinedTypes.First().DeclaredMethods.First(x => x.Name == key);
+                return true;
+            }
+
+            method = buildingTypes[connectedModule].GetMethods().Where(x => x.Name == key).FirstOrDefault();
+            if (method is null)
+            {
+                method = buildingTypes[connectedModule].DefineMethod(key, MethodAttributes.Public | MethodAttributes.Static, CallingConventions.Standard, returnType, argumentTypes);
+                return false;
+            }
+
+            return true;
+        }
+
+        public static void SaveDynamicMethods()
+        {
+            foreach (TypeBuilder type in buildingTypes.Values)
+            {
+                type.CreateType();
+                ((AssemblyBuilder)type.Assembly).Save(type.Assembly.GetName().Name);
+            }
+        }
+    }
+}

--- a/Game/CustomCosmetics/RainMeadow.CustomCosmeticHooks.cs
+++ b/Game/CustomCosmetics/RainMeadow.CustomCosmeticHooks.cs
@@ -16,7 +16,7 @@ namespace RainMeadow
             On.PlayerGraphics.Reset += PlayerGraphics_ResetCosmetics;
             On.PlayerGraphics.DrawSprites += PlayerGraphics_DrawSpritesCosmetics;
             On.PlayerGraphics.AddToContainer += PlayerGraphics_AddToContainerCosmetics;
-            IL.PlayerGraphics.InitiateSprites += PlayerGraphics_InitiateSpritesCosmetics;
+            //IL.PlayerGraphics.InitiateSprites += PlayerGraphics_InitiateSpritesCosmetics;
         }
 
         void PlayerGraphics_InitiateSpritesCosmetics(ILContext cursor) {

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -24,6 +24,7 @@ namespace RainMeadow
 
             On.AbstractPhysicalObject.ChangeRooms += AbstractPhysicalObject_ChangeRooms;
             On.AbstractCreature.ChangeRooms += AbstractCreature_ChangeRooms1;
+            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
 
             On.AbstractCreature.Abstractize += AbstractCreature_Abstractize; // get real
             On.AbstractPhysicalObject.Abstractize += AbstractPhysicalObject_Abstractize; // get real
@@ -37,6 +38,25 @@ namespace RainMeadow
             On.Watcher.SandGrubGraphics.DrawSprites += SandGrubGraphics_DrawSprites;
 
             new Hook(typeof(AbstractCreature).GetProperty("Quantify").GetGetMethod(), this.AbstractCreature_Quantify);
+        }
+
+        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
+        {
+            if (OnlineManager.lobby != null)
+            {
+                if (self.waterLight != null)
+                {
+                    if (newRoom.waterObject == null && newRoom.water)
+                    {
+                        newRoom.AddWater();
+                    }
+                    if (newRoom.waterObject != null && !newRoom.water)
+                    {
+                        self.waterLight.CleanOut();
+                    }
+                }
+            }
+            orig(self, newRoom, cameraPosition);
         }
 
         private void SandGrubGraphics_DrawSprites(On.Watcher.SandGrubGraphics.orig_DrawSprites orig, Watcher.SandGrubGraphics self, RoomCamera.SpriteLeaser sLeaser, RoomCamera rCam, float timeStacker, UnityEngine.Vector2 camPos)

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -24,8 +24,6 @@ namespace RainMeadow
 
             On.AbstractPhysicalObject.ChangeRooms += AbstractPhysicalObject_ChangeRooms;
             On.AbstractCreature.ChangeRooms += AbstractCreature_ChangeRooms1;
-            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
-
             On.AbstractCreature.Abstractize += AbstractCreature_Abstractize; // get real
             On.AbstractPhysicalObject.Abstractize += AbstractPhysicalObject_Abstractize; // get real
             On.AbstractCreature.Realize += AbstractCreature_Realize; // get real, also customization happens here
@@ -38,25 +36,6 @@ namespace RainMeadow
             On.Watcher.SandGrubGraphics.DrawSprites += SandGrubGraphics_DrawSprites;
 
             new Hook(typeof(AbstractCreature).GetProperty("Quantify").GetGetMethod(), this.AbstractCreature_Quantify);
-        }
-
-        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
-        {
-            if (OnlineManager.lobby != null)
-            {
-                if (self.waterLight != null)
-                {
-                    if (newRoom.waterObject == null && newRoom.water)
-                    {
-                        newRoom.AddWater();
-                    }
-                    if (newRoom.waterObject != null && !newRoom.water)
-                    {
-                        self.waterLight.CleanOut();
-                    }
-                }
-            }
-            orig(self, newRoom, cameraPosition);
         }
 
         private void SandGrubGraphics_DrawSprites(On.Watcher.SandGrubGraphics.orig_DrawSprites orig, Watcher.SandGrubGraphics self, RoomCamera.SpriteLeaser sLeaser, RoomCamera rCam, float timeStacker, UnityEngine.Vector2 camPos)

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -47,7 +47,7 @@ namespace RainMeadow
             // can't pause it's online mom
             new Hook(typeof(RainWorldGame).GetProperty("GamePaused").GetGetMethod(), this.RainWorldGame_GamePaused);
 
-            IL.RainWorldGame.Update += RainWorldGame_Update;
+           // IL.RainWorldGame.Update += RainWorldGame_Update;
             On.RainWorldGame.Update += RainWorldGame_Update1;
 
             // Arena specific

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -29,15 +29,21 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null)
             {
+                if (self.waterLight == null && newRoom.water)
+                {
+                    self.waterLight = new WaterLight(self, newRoom.game.rainWorld.Shaders["WaterLight"]);
+                }
+                else if (self.waterLight != null && !newRoom.water)
+                {
+                    self.waterLight.CleanOut();
+                    self.waterLight = null;
+                }
+
                 if (self.waterLight != null)
                 {
                     if (newRoom.waterObject == null && newRoom.water)
                     {
                         newRoom.AddWater();
-                    }
-                    if (newRoom.waterObject != null && !newRoom.water)
-                    {
-                        self.waterLight.CleanOut();
                     }
                 }
             }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -19,35 +19,8 @@ namespace RainMeadow
             On.RoomPreparer.ctor += RoomPreparer_ctor;
             On.AbstractRoom.Abstractize += AbstractRoom_Abstractize;
             On.ArenaSitting.NextLevel += ArenaSitting_NextLevel;
-            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
-
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.StoryCharacter)).GetGetMethod(), RainWorldGame_StoryCharacter);
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.TimelinePoint)).GetGetMethod(), RainWorldGame_TimelinePoint);
-        }
-
-        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
-        {
-            if (OnlineManager.lobby != null)
-            {
-                if (self.waterLight == null && newRoom.water)
-                {
-                    self.waterLight = new WaterLight(self, newRoom.game.rainWorld.Shaders["WaterLight"]);
-                }
-                else if (self.waterLight != null && !newRoom.water)
-                {
-                    self.waterLight.CleanOut();
-                    self.waterLight = null;
-                }
-
-                if (self.waterLight != null)
-                {
-                    if (newRoom.waterObject == null && newRoom.water)
-                    {
-                        newRoom.AddWater();
-                    }
-                }
-            }
-            orig(self, newRoom, cameraPosition);
         }
 
         SlugcatStats.Name RainWorldGame_StoryCharacter(Func<RainWorldGame, SlugcatStats.Name> orig, RainWorldGame self)

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -19,9 +19,29 @@ namespace RainMeadow
             On.RoomPreparer.ctor += RoomPreparer_ctor;
             On.AbstractRoom.Abstractize += AbstractRoom_Abstractize;
             On.ArenaSitting.NextLevel += ArenaSitting_NextLevel;
+            On.RoomCamera.ChangeRoom += RoomCamera_ChangeRoom;
 
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.StoryCharacter)).GetGetMethod(), RainWorldGame_StoryCharacter);
             // new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.TimelinePoint)).GetGetMethod(), RainWorldGame_TimelinePoint);
+        }
+
+        private void RoomCamera_ChangeRoom(On.RoomCamera.orig_ChangeRoom orig, RoomCamera self, Room newRoom, int cameraPosition)
+        {
+            if (OnlineManager.lobby != null)
+            {
+                if (self.waterLight != null)
+                {
+                    if (newRoom.waterObject == null && newRoom.water)
+                    {
+                        newRoom.AddWater();
+                    }
+                    if (newRoom.waterObject != null && !newRoom.water)
+                    {
+                        self.waterLight.CleanOut();
+                    }
+                }
+            }
+            orig(self, newRoom, cameraPosition);
         }
 
         SlugcatStats.Name RainWorldGame_StoryCharacter(Func<RainWorldGame, SlugcatStats.Name> orig, RainWorldGame self)

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -74,7 +74,7 @@ public partial class RainMeadow
         new Hook(typeof(Watcher.CamoMeter).GetProperty("ForceShow").GetGetMethod(), this.CamoMeter_SetCamoMeter);
         new Hook(typeof(Player).GetProperty("CanSpawnDynamicWarpPoints").GetGetMethod(), this.Player_CanSpawnDynamicWarpPoints);
 
-        On.Player.TickLevitation += (On.Player.orig_TickLevitation orig, Player self, bool levitateUp) =>
+        On.Player.TickLevitation_bool += (On.Player.orig_TickLevitation_bool orig, Player self, bool levitateUp) =>
         {
             WatcherOverrideForLevitation = true;
             orig(self, levitateUp);

--- a/Meadow/Creatures/LizardController.cs
+++ b/Meadow/Creatures/LizardController.cs
@@ -17,7 +17,7 @@ namespace RainMeadow
             // don't drop it
             IL.Lizard.CarryObject += Lizard_CarryObject1;
             // swim, bastard
-            IL.Lizard.SwimBehavior += Lizard_SwimBehavior;
+            //IL.Lizard.SwimBehavior += Lizard_SwimBehavior;
 
             On.Lizard.SwimBehavior += Lizard_SwimBehavior1;
             On.Lizard.FollowConnection += Lizard_FollowConnection;

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -300,6 +300,11 @@ namespace RainMeadow
             {
                 line5.Add(self, lines[5]);
             }
+
+            if (OnlineManager.lobby != null && self.water && self.waterObject is null)
+            {
+                self.AddWater();
+            }
         }
 
         private void AbstractCreature_ChangeRooms(On.AbstractCreature.orig_ChangeRooms orig, AbstractCreature self, WorldCoordinate newCoord)

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -300,11 +300,6 @@ namespace RainMeadow
             {
                 line5.Add(self, lines[5]);
             }
-
-            if (OnlineManager.lobby != null && self.water && self.waterObject is null)
-            {
-                self.AddWater();
-            }
         }
 
         private void AbstractCreature_ChangeRooms(On.AbstractCreature.orig_ChangeRooms orig, AbstractCreature self, WorldCoordinate newCoord)

--- a/Online/State/OnlineState.cs
+++ b/Online/State/OnlineState.cs
@@ -1,9 +1,11 @@
-﻿using RainMeadow.Generics;
+﻿using MonoMod.Utils;
+using RainMeadow.Generics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Reflection.Emit;
 using UnityEngine;
 
 namespace RainMeadow
@@ -269,274 +271,302 @@ namespace RainMeadow
                     var expressions = new List<Expression>();
 
                     // make factory
+                    factory = () => (OnlineState)Activator.CreateInstance(type);
 
-                    factory = Expression.Lambda<Func<OnlineState>>(Expression.New(type.GetConstructor(new Type[] { }))).Compile();
 
                     // make serialize func
 
-                    ParameterExpression self = Expression.Parameter(typeof(OnlineState), "self");
-                    ParameterExpression selfConverted = Expression.Variable(type, "selfConverted");
-                    ParameterExpression serializer = Expression.Parameter(typeof(Serializer), "serializer");
-
-                    MemberExpression serializerIsDelta = Expression.Field(serializer, serializerIsDeltaAcessor);
-                    MemberExpression selfIsDelta = Expression.Field(self, isDeltaAcessor);
-
-                    expressions = new List<Expression>();
-                    expressions.Add(Expression.Assign(selfConverted, Expression.Convert(self, type)));
-
-                    switch (deltaSupport)
+                    if (!MethodCache.LoadMethod("Serialize" + type.Name, type.Module, out var serializationMethod, null, typeof(OnlineState), typeof(Serializer)))
                     {
-                        case DeltaSupport.None:
-                            // serializer.Serialize(ref field);
-                            expressions.Add(Expression.Block(fields.Select(
-                                f => f.GetCustomAttribute<OnlineFieldAttribute>().SerializerCallMethod(f, serializer, Expression.Field(selfConverted, f))
-                            ).Where(e => e != null)));
-                            break;
-                        case DeltaSupport.FollowsContainer:
-                            // Main delta-aware serialization logic here
+                        ParameterExpression self = Expression.Parameter(typeof(OnlineState), "self");
+                        ParameterExpression selfConverted = Expression.Variable(type, "selfConverted");
+                        ParameterExpression serializer = Expression.Parameter(typeof(Serializer), "serializer");
 
-                            // for each group
-                            //      if (serializer.IsDelta) serializer.Serialize(ref hasGroupValue[n]);
-                            //      if (!serializer.IsDelta || hasGroupValue[n])
-                            //      {
-                            //          serializer.Serialize(ref fieldInGroup);
-                            //      }
+                        MemberExpression serializerIsDelta = Expression.Field(serializer, serializerIsDeltaAcessor);
+                        MemberExpression selfIsDelta = Expression.Field(self, isDeltaAcessor);
 
-                            expressions.Add(Expression.Assign(selfIsDelta, serializerIsDelta));
+                        expressions = new List<Expression>();
+                        expressions.Add(Expression.Assign(selfConverted, Expression.Convert(self, type)));
 
-                            // always send
-                            if (keys.Count > 0)
+                        switch (deltaSupport)
+                        {
+                            case DeltaSupport.None:
+                                // serializer.Serialize(ref field);
+                                expressions.Add(Expression.Block(fields.Select(
+                                    f => f.GetCustomAttribute<OnlineFieldAttribute>().SerializerCallMethod(f, serializer, Expression.Field(selfConverted, f))
+                                ).Where(e => e != null)));
+                                break;
+                            case DeltaSupport.FollowsContainer:
+                                // Main delta-aware serialization logic here
+
+                                // for each group
+                                //      if (serializer.IsDelta) serializer.Serialize(ref hasGroupValue[n]);
+                                //      if (!serializer.IsDelta || hasGroupValue[n])
+                                //      {
+                                //          serializer.Serialize(ref fieldInGroup);
+                                //      }
+
+                                expressions.Add(Expression.Assign(selfIsDelta, serializerIsDelta));
+
+                                // always send
+                                if (keys.Count > 0)
+                                {
+                                    expressions.Add(Expression.Block(keys.Select(
+                                            f => f.GetCustomAttribute<OnlineFieldAttribute>().SerializerCallMethod(f, serializer, Expression.Field(selfConverted, f))
+                                        ).Where(e => e != null)));
+                                }
+
+                                for (int i = 0; i < ngroups; i++)
+                                {
+                                    if (deltaGroups[deltaGroups.Keys.ToList()[i]].Count == 0) continue;
+
+                                    expressions.Add(Expression.IfThen(serializerIsDelta,
+                                        Expression.Call(serializer, serializeBoolRef, new[] {
+                                    Expression.ArrayAccess(Expression.Field(selfConverted, valueFlagsAcessor), Expression.Constant(i)) })));
+                                    var deltagroupname = deltaGroups.Keys.ToList()[i];
+                                    expressions.Add(Expression.IfThen(Expression.OrElse(Expression.Not(serializerIsDelta),
+                                            Expression.ArrayAccess(Expression.Field(selfConverted, valueFlagsAcessor), Expression.Constant(i))),
+#if TRACING
+                                        Expression.Block(Expression.Invoke(Expression.Constant((Serializer s) => { if (s.IsWriting) RainMeadow.Trace("sending " + deltagroupname); }), serializer),
+#endif                                   
+                                        Expression.Block(deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
+                                            f =>
+#if TRACING
+                                                Expression.Block(Expression.Invoke(Expression.Constant((Serializer s) => { if (s.IsWriting) RainMeadow.Trace(f.Name); }), serializer),
+#endif
+                                                f.GetCustomAttribute<OnlineFieldAttribute>().SerializerCallMethod(f, serializer, Expression.Field(selfConverted, f))
+#if TRACING
+                                            )
+#endif
+                                        ).Where(e => e != null))
+#if TRACING
+                                        )
+#endif
+                                        ));
+
+                                }
+                                break;
+                            case DeltaSupport.NullableDelta:
+                                // if (serializer.IsDelta) // In a non-delta context, can only be non-delta
+                                // {
+                                //     serializer.Serialize(ref IsDelta);
+                                //     serializer.IsDelta = IsDelta;
+                                // }
+                                // if (IsDelta) serializer.Serialize(ref hasGroupValue);
+                                // if (!IsDelta || hasGroupValue)
+                                // {
+                                //     serializer.Serialize(ref fieldInGroup);
+                                // }
+                                expressions.Add(Expression.IfThen(serializerIsDelta, Expression.Block(
+                                        Expression.Call(serializer, serializeBoolRef, new[] { selfIsDelta }),
+                                        Expression.Assign(serializerIsDelta, selfIsDelta
+                                    ))));
+                                goto case DeltaSupport.FollowsContainer;
+                            case DeltaSupport.Full:
+                                // serializer.Serialize(ref IsDelta);
+                                // if (!serializer.IsDelta && IsDelta) { serializer.Serialize(ref Baseline); }
+                                // serializer.IsDelta = IsDelta; // Serializer wraps this call and restores the previous value later
+                                // ...etc
+                                expressions.Add(Expression.Call(serializer, serializeBoolRef, new[] { selfIsDelta }));
+                                expressions.Add(Expression.IfThen(Expression.AndAlso(Expression.Not(serializerIsDelta),
+                                                                        selfIsDelta),
+                                            Expression.Call(serializer, serializeUintRef, new[] { Expression.Field(selfConverted, baselineAcessor) })));
+                                expressions.Add(Expression.Assign(serializerIsDelta, selfIsDelta));
+                                goto case DeltaSupport.FollowsContainer;
+                        }
+
+                        Expression.Lambda<Action<OnlineState, Serializer>>(Expression.Block(new[] { selfConverted }, expressions), self, serializer).CompileToMethod((MethodBuilder)serializationMethod);
+                    }
+
+                    serialize = (a, b) => serializationMethod.Invoke(null, [a, b]);
+
+                    // if supports delta
+                    if (deltaSupport != DeltaSupport.None)
+                    {
+                        if (!MethodCache.LoadMethod("Delta" + type.Name, type.Module, out var deltaMethod, typeof(OnlineState), typeof(OnlineState), typeof(OnlineState)))
+                        {
+                            // make delta func
+                            ParameterExpression self = Expression.Parameter(typeof(OnlineState), "self");
+                            ParameterExpression selfConverted = Expression.Variable(type, "selfConverted");
+                            ParameterExpression serializer = Expression.Parameter(typeof(Serializer), "serializer");
+
+                            ParameterExpression baseline = Expression.Parameter(typeof(OnlineState), "baseline");
+                            ParameterExpression baselineConverted = Expression.Variable(type, "baselineConverted");
+                            ParameterExpression output = Expression.Variable(type, "output");
+                            MethodInfo cloneRef = typeof(OnlineState).GetMethod("Clone", anyInstance);
+
+                            // if (baseline == null) throw new InvalidProgrammerException("baseline is null");
+                            // **if (baseline.IsDelta) throw new InvalidProgrammerException("baseline is delta");
+                            // var output = DeepCopy();
+                            // **output.IsDelta = true;
+                            // **output.baseline = baseline.tick;
+                            // 
+                            // output.fieldWithDelta = this.fieldWithDelta?.Delta(baseline.fieldWithDelta);
+                            // 
+                            // output.hasGroupValue = field != baseline.field || field2 != baseline.field2;
+
+                            expressions = new List<Expression>();
+                            // todo arg checking
+                            expressions.Add(Expression.Assign(selfConverted, Expression.Convert(self, type)));
+                            expressions.Add(Expression.Assign(baselineConverted, Expression.Convert(baseline, type)));
+                            expressions.Add(Expression.Assign(output, Expression.Convert(Expression.Call(selfConverted, cloneRef), type)));
+
+                            expressions.Add(Expression.Assign(Expression.Field(output, isDeltaAcessor), Expression.Constant(true)));
+                            if (deltaSupport == DeltaSupport.Full)
+                                expressions.Add(Expression.Assign(Expression.Field(output, baselineAcessor), Expression.Field(baselineConverted, tickAcessor)));
+
+                            foreach (var f in fields)
                             {
-                                expressions.Add(Expression.Block(keys.Select(
-                                        f => f.GetCustomAttribute<OnlineFieldAttribute>().SerializerCallMethod(f, serializer, Expression.Field(selfConverted, f))
-                                    ).Where(e => e != null)));
+                                // fields have already been copied, this is for sub-deltas
+
+                                if (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && (x.GetGenericTypeDefinition() == typeof(Generics.IDelta<>) || x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>))))
+                                {
+                                    // IPrimaryDelta:   o.f = this.f ? (b.f ? this.f.delta(b.f) : this.f) : null // can this be simplified?
+                                    //                        b.f != null ? f?.delta(b.f) : f;
+                                    // IDelta:          o.f = this.f?.delta(b.f)
+                                    expressions.Add(Expression.Assign(Expression.Field(output, f),
+                                                Expression.Condition(Expression.Equal(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
+                                                    Expression.Constant(null, f.FieldType),
+                                                    (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>))) ?
+                                                        Expression.Condition(Expression.Equal(Expression.Field(baselineConverted, f), Expression.Constant(null, f.FieldType)),
+                                                        Expression.Field(selfConverted, f),
+                                                        Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("Delta"), Expression.Field(baselineConverted, f)), f.FieldType))
+                                                    : Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("Delta"), Expression.Field(baselineConverted, f)), f.FieldType)
+                                                    )
+                                            ));
+                                }
+                            }
+
+                            // set flags for sent/omitted fields
+                            for (int i = 0; i < ngroups; i++)
+                            {
+                                if (deltaGroups[deltaGroups.Keys.ToList()[i]].Count == 0) continue;
+                                // valueFlags[i] = self.f != baseline.f || self.f2 != baseline.f2 || ...
+                                expressions.Add(Expression.Assign(Expression.ArrayAccess(Expression.Field(output, valueFlagsAcessor), Expression.Constant(i)),
+                                    OrAny(deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
+                                            f => Expression.Not(
+                                                (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IPrimaryDelta<>))) ?
+                                                    // (this.f && b.f) ? delta.f.isempty : (this.f == b.f)
+                                                    Expression.Condition(Expression.AndAlso(
+                                                        Expression.NotEqual(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
+                                                        Expression.NotEqual(Expression.Field(baselineConverted, f), Expression.Constant(null, f.FieldType))
+                                                        ),
+                                                        Expression.Call(Expression.Field(output, f), f.FieldType.GetProperty("IsEmptyDelta").GetMethod),
+                                                        Expression.Equal(Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
+                                                    )
+                                                : (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IDelta<>))) ?
+                                                    Expression.Equal(Expression.Field(output, f), Expression.Constant(null, f.FieldType))
+                                                : f.GetCustomAttribute<OnlineFieldAttribute>().ComparisonMethod(f, Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
+                                                )
+                                        ).Where(e => e != null).ToArray())
+                                    ));
+#if TRACING
+                                expressions.Add(Expression.Block(
+                                    deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
+                                            f => Expression.Invoke(Expression.Constant((string n, bool v) =>
+                                            {
+                                                RainMeadow.Trace(n + " has changed?: " + v);
+                                            }), Expression.Constant(f.Name), Expression.Not(
+                                                (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IPrimaryDelta<>))) ?
+                                                    // (this.f && b.f) ? delta.f.isempty : (this.f == b.f)
+                                                    Expression.Condition(Expression.AndAlso(
+                                                        Expression.NotEqual(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
+                                                        Expression.NotEqual(Expression.Field(baselineConverted, f), Expression.Constant(null, f.FieldType))
+                                                        ),
+                                                        Expression.Call(Expression.Field(output, f), f.FieldType.GetProperty("IsEmptyDelta").GetMethod),
+                                                        Expression.Equal(Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
+                                                    )
+                                                : (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IDelta<>))) ?
+                                                    Expression.Equal(Expression.Field(output, f), Expression.Constant(null, f.FieldType))
+                                                : f.GetCustomAttribute<OnlineFieldAttribute>().ComparisonMethod(f, Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
+                                                )
+                                        )
+                                    )));
+                                var deltagroupname = deltaGroups.Keys.ToList()[i];
+                                expressions.Add(Expression.Invoke(Expression.Constant((bool v) =>
+                                {
+                                    RainMeadow.Trace(deltagroupname + " has value?: " + v);
+                                }), Expression.ArrayAccess(Expression.Field(output, valueFlagsAcessor), Expression.Constant(i))));
+#endif
+                            }
+
+                            expressions.Add(output); // return
+                            Expression.Lambda<Func<OnlineState, OnlineState, OnlineState>>(Expression.Block(new[] { selfConverted, baselineConverted, output }, expressions), self, baseline).CompileToMethod((MethodBuilder)deltaMethod);
+                        }
+
+                        delta = (a, b) => (OnlineState)deltaMethod.Invoke(null, [a, b]);
+
+
+                        // make applydelta func
+                        if (!MethodCache.LoadMethod("ApplyDelta" + type.Name, type.Module, out var applyDeltaMethod, typeof(OnlineState), typeof(OnlineState), typeof(OnlineState)))
+                        {
+                            ParameterExpression self = Expression.Parameter(typeof(OnlineState), "self");
+                            ParameterExpression selfConverted = Expression.Variable(type, "selfConverted");
+                            ParameterExpression serializer = Expression.Parameter(typeof(Serializer), "serializer");
+
+                            ParameterExpression baseline = Expression.Parameter(typeof(OnlineState), "baseline");
+                            ParameterExpression baselineConverted = Expression.Variable(type, "baselineConverted");
+                            ParameterExpression output = Expression.Variable(type, "output");
+                            MethodInfo cloneRef = typeof(OnlineState).GetMethod("Clone", anyInstance);
+
+                            ParameterExpression incoming = Expression.Parameter(typeof(OnlineState));
+                            ParameterExpression incomingConverted = Expression.Variable(type);
+
+                            // self is baseline
+                            // if (incoming == null) throw new InvalidProgrammerException("incoming is null");
+                            // **if (!incoming.IsDelta) throw new InvalidProgrammerException("incoming not delta");
+                            // var result = DeepClone();
+                            // **result.tick = incoming.tick;
+                            // if incoming.hasGroupValue
+                            //      result.field1 = incoming.field1;
+                            // return result;
+
+                            expressions = new List<Expression>();
+
+                            // todo arg checking
+                            expressions.Add(Expression.Assign(selfConverted, Expression.Convert(self, type)));
+                            expressions.Add(Expression.Assign(incomingConverted, Expression.Convert(incoming, type)));
+                            expressions.Add(Expression.Assign(output, Expression.Convert(Expression.Call(selfConverted, cloneRef), type)));
+
+                            if (deltaSupport != DeltaSupport.FollowsContainer && deltaSupport != DeltaSupport.NullableDelta)
+                            {
+                                expressions.Add(Expression.Assign(Expression.Field(output, tickAcessor), Expression.Field(incomingConverted, tickAcessor)));
                             }
 
                             for (int i = 0; i < ngroups; i++)
                             {
                                 if (deltaGroups[deltaGroups.Keys.ToList()[i]].Count == 0) continue;
 
-                                expressions.Add(Expression.IfThen(serializerIsDelta,
-                                    Expression.Call(serializer, serializeBoolRef, new[] {
-                                Expression.ArrayAccess(Expression.Field(selfConverted, valueFlagsAcessor), Expression.Constant(i)) })));
-                                var deltagroupname = deltaGroups.Keys.ToList()[i];
-                                expressions.Add(Expression.IfThen(Expression.OrElse(Expression.Not(serializerIsDelta),
-                                        Expression.ArrayAccess(Expression.Field(selfConverted, valueFlagsAcessor), Expression.Constant(i))),
-#if TRACING
-                                    Expression.Block(Expression.Invoke(Expression.Constant((Serializer s) => { if (s.IsWriting) RainMeadow.Trace("sending " + deltagroupname); }), serializer),
-#endif                                   
-                                    Expression.Block(deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
-                                        f =>
-#if TRACING
-                                            Expression.Block(Expression.Invoke(Expression.Constant((Serializer s) => { if (s.IsWriting) RainMeadow.Trace(f.Name); }), serializer),
-#endif
-                                            f.GetCustomAttribute<OnlineFieldAttribute>().SerializerCallMethod(f, serializer, Expression.Field(selfConverted, f))
-#if TRACING
-                                        )
-#endif
-                                    ).Where(e => e != null))
-#if TRACING
-                                    )
-#endif
-                                    ));
+                                expressions.Add(Expression.IfThen(Expression.ArrayAccess(Expression.Field(incomingConverted, valueFlagsAcessor), Expression.Constant(i)),
+                                        Expression.Block(deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
 
-                            }
-                            break;
-                        case DeltaSupport.NullableDelta:
-                            // if (serializer.IsDelta) // In a non-delta context, can only be non-delta
-                            // {
-                            //     serializer.Serialize(ref IsDelta);
-                            //     serializer.IsDelta = IsDelta;
-                            // }
-                            // if (IsDelta) serializer.Serialize(ref hasGroupValue);
-                            // if (!IsDelta || hasGroupValue)
-                            // {
-                            //     serializer.Serialize(ref fieldInGroup);
-                            // }
-                            expressions.Add(Expression.IfThen(serializerIsDelta, Expression.Block(
-                                    Expression.Call(serializer, serializeBoolRef, new[] { selfIsDelta }),
-                                    Expression.Assign(serializerIsDelta, selfIsDelta
-                                ))));
-                            goto case DeltaSupport.FollowsContainer;
-                        case DeltaSupport.Full:
-                            // serializer.Serialize(ref IsDelta);
-                            // if (!serializer.IsDelta && IsDelta) { serializer.Serialize(ref Baseline); }
-                            // serializer.IsDelta = IsDelta; // Serializer wraps this call and restores the previous value later
-                            // ...etc
-                            expressions.Add(Expression.Call(serializer, serializeBoolRef, new[] { selfIsDelta }));
-                            expressions.Add(Expression.IfThen(Expression.AndAlso(Expression.Not(serializerIsDelta),
-                                                                     selfIsDelta),
-                                        Expression.Call(serializer, serializeUintRef, new[] { Expression.Field(selfConverted, baselineAcessor) })));
-                            expressions.Add(Expression.Assign(serializerIsDelta, selfIsDelta));
-                            goto case DeltaSupport.FollowsContainer;
-                    }
+                                            // regular:         o.f = i.f;
+                                            // IPrimaryDelta:   o.f = f ? (i.f ? f.applydelta(i.f) : null) : i.f
+                                            // IDelta:          o.f = f ? f.applydelta(i.f) : i.f
 
-                    serialize = Expression.Lambda<Action<OnlineState, Serializer>>(Expression.Block(new[] { selfConverted }, expressions), self, serializer).Compile();
-
-                    // if supports delta
-                    if (deltaSupport != DeltaSupport.None)
-                    {
-                        // make delta func
-
-                        ParameterExpression baseline = Expression.Parameter(typeof(OnlineState), "baseline");
-                        ParameterExpression baselineConverted = Expression.Variable(type, "baselineConverted");
-                        ParameterExpression output = Expression.Variable(type, "output");
-                        MethodInfo cloneRef = typeof(OnlineState).GetMethod("Clone", anyInstance);
-
-                        // if (baseline == null) throw new InvalidProgrammerException("baseline is null");
-                        // **if (baseline.IsDelta) throw new InvalidProgrammerException("baseline is delta");
-                        // var output = DeepCopy();
-                        // **output.IsDelta = true;
-                        // **output.baseline = baseline.tick;
-                        // 
-                        // output.fieldWithDelta = this.fieldWithDelta?.Delta(baseline.fieldWithDelta);
-                        // 
-                        // output.hasGroupValue = field != baseline.field || field2 != baseline.field2;
-
-                        expressions = new List<Expression>();
-                        // todo arg checking
-                        expressions.Add(Expression.Assign(selfConverted, Expression.Convert(self, type)));
-                        expressions.Add(Expression.Assign(baselineConverted, Expression.Convert(baseline, type)));
-                        expressions.Add(Expression.Assign(output, Expression.Convert(Expression.Call(selfConverted, cloneRef), type)));
-
-                        expressions.Add(Expression.Assign(Expression.Field(output, isDeltaAcessor), Expression.Constant(true)));
-                        if (deltaSupport == DeltaSupport.Full)
-                            expressions.Add(Expression.Assign(Expression.Field(output, baselineAcessor), Expression.Field(baselineConverted, tickAcessor)));
-
-                        foreach (var f in fields)
-                        {
-                            // fields have already been copied, this is for sub-deltas
-
-                            if (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && (x.GetGenericTypeDefinition() == typeof(Generics.IDelta<>) || x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>))))
-                            {
-                                // IPrimaryDelta:   o.f = this.f ? (b.f ? this.f.delta(b.f) : this.f) : null // can this be simplified?
-                                //                        b.f != null ? f?.delta(b.f) : f;
-                                // IDelta:          o.f = this.f?.delta(b.f)
-                                expressions.Add(Expression.Assign(Expression.Field(output, f),
-                                            Expression.Condition(Expression.Equal(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
-                                                Expression.Constant(null, f.FieldType),
-                                                (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>))) ?
-                                                    Expression.Condition(Expression.Equal(Expression.Field(baselineConverted, f), Expression.Constant(null, f.FieldType)),
-                                                    Expression.Field(selfConverted, f),
-                                                    Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("Delta"), Expression.Field(baselineConverted, f)), f.FieldType))
-                                                : Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("Delta"), Expression.Field(baselineConverted, f)), f.FieldType)
-                                                )
-                                           ));
-                            }
-                        }
-
-                        // set flags for sent/omitted fields
-                        for (int i = 0; i < ngroups; i++)
-                        {
-                            if (deltaGroups[deltaGroups.Keys.ToList()[i]].Count == 0) continue;
-                            // valueFlags[i] = self.f != baseline.f || self.f2 != baseline.f2 || ...
-                            expressions.Add(Expression.Assign(Expression.ArrayAccess(Expression.Field(output, valueFlagsAcessor), Expression.Constant(i)),
-                                OrAny(deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
-                                        f => Expression.Not(
-                                            (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IPrimaryDelta<>))) ?
-                                                // (this.f && b.f) ? delta.f.isempty : (this.f == b.f)
-                                                Expression.Condition(Expression.AndAlso(
-                                                    Expression.NotEqual(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
-                                                    Expression.NotEqual(Expression.Field(baselineConverted, f), Expression.Constant(null, f.FieldType))
-                                                    ),
-                                                    Expression.Call(Expression.Field(output, f), f.FieldType.GetProperty("IsEmptyDelta").GetMethod),
-                                                    Expression.Equal(Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
-                                                )
-                                            : (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IDelta<>))) ?
-                                                Expression.Equal(Expression.Field(output, f), Expression.Constant(null, f.FieldType))
-                                            : f.GetCustomAttribute<OnlineFieldAttribute>().ComparisonMethod(f, Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
+                                            f => Expression.Assign(Expression.Field(output, f),
+                                                (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && (x.GetGenericTypeDefinition() == typeof(Generics.IDelta<>) || x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>)))) ?
+                                                Expression.Condition(Expression.Equal(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
+                                                    Expression.Field(incomingConverted, f),
+                                                    (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>))) ?
+                                                        Expression.Condition(Expression.Equal(Expression.Field(incomingConverted, f), Expression.Constant(null, f.FieldType)),
+                                                        Expression.Constant(null, f.FieldType),
+                                                        Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("ApplyDelta"), Expression.Field(incomingConverted, f)), f.FieldType))
+                                                    : Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("ApplyDelta"), Expression.Field(incomingConverted, f)), f.FieldType)
+                                                    )
+                                                : Expression.Field(incomingConverted, f) // regular
                                             )
-                                    ).Where(e => e != null).ToArray())
-                                ));
-#if TRACING
-                            expressions.Add(Expression.Block(
-                                deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
-                                        f => Expression.Invoke(Expression.Constant((string n, bool v) =>
-                                        {
-                                            RainMeadow.Trace(n + " has changed?: " + v);
-                                        }), Expression.Constant(f.Name), Expression.Not(
-                                            (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IPrimaryDelta<>))) ?
-                                                // (this.f && b.f) ? delta.f.isempty : (this.f == b.f)
-                                                Expression.Condition(Expression.AndAlso(
-                                                    Expression.NotEqual(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
-                                                    Expression.NotEqual(Expression.Field(baselineConverted, f), Expression.Constant(null, f.FieldType))
-                                                    ),
-                                                    Expression.Call(Expression.Field(output, f), f.FieldType.GetProperty("IsEmptyDelta").GetMethod),
-                                                    Expression.Equal(Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
-                                                )
-                                            : (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IDelta<>))) ?
-                                                Expression.Equal(Expression.Field(output, f), Expression.Constant(null, f.FieldType))
-                                            : f.GetCustomAttribute<OnlineFieldAttribute>().ComparisonMethod(f, Expression.Field(selfConverted, f), Expression.Field(baselineConverted, f))
-                                            )
-                                    )
-                                )));
-                            var deltagroupname = deltaGroups.Keys.ToList()[i];
-                            expressions.Add(Expression.Invoke(Expression.Constant((bool v) =>
-                            {
-                                RainMeadow.Trace(deltagroupname + " has value?: " + v);
-                            }), Expression.ArrayAccess(Expression.Field(output, valueFlagsAcessor), Expression.Constant(i))));
-#endif
+                                        ))));
+                            }
+
+                            expressions.Add(output); // return
+
+                            RainMeadow.Debug(Expression.Block(new[] { selfConverted, incomingConverted, output }, expressions).ToString());
+                            RainMeadow.Debug(Expression.Lambda<Func<OnlineState, OnlineState, OnlineState>>(Expression.Block(new[] { selfConverted, incomingConverted, output }, expressions), self, incoming).ToString());
+                            Expression.Lambda<Func<OnlineState, OnlineState, OnlineState>>(Expression.Block(new[] { selfConverted, incomingConverted, output }, expressions), self, incoming).CompileToMethod((MethodBuilder)applyDeltaMethod);
                         }
 
-                        expressions.Add(output); // return
-
-                        delta = Expression.Lambda<Func<OnlineState, OnlineState, OnlineState>>(Expression.Block(new[] { selfConverted, baselineConverted, output }, expressions), self, baseline).Compile();
-
-                        // make applydelta func
-
-                        ParameterExpression incoming = Expression.Parameter(typeof(OnlineState));
-                        ParameterExpression incomingConverted = Expression.Variable(type);
-                        // self is baseline
-                        // if (incoming == null) throw new InvalidProgrammerException("incoming is null");
-                        // **if (!incoming.IsDelta) throw new InvalidProgrammerException("incoming not delta");
-                        // var result = DeepClone();
-                        // **result.tick = incoming.tick;
-                        // if incoming.hasGroupValue
-                        //      result.field1 = incoming.field1;
-                        // return result;
-
-                        expressions = new List<Expression>();
-                        // todo arg checking
-                        expressions.Add(Expression.Assign(selfConverted, Expression.Convert(self, type)));
-                        expressions.Add(Expression.Assign(incomingConverted, Expression.Convert(incoming, type)));
-                        expressions.Add(Expression.Assign(output, Expression.Convert(Expression.Call(selfConverted, cloneRef), type)));
-
-                        if (deltaSupport != DeltaSupport.FollowsContainer && deltaSupport != DeltaSupport.NullableDelta)
-                        {
-                            expressions.Add(Expression.Assign(Expression.Field(output, tickAcessor), Expression.Field(incomingConverted, tickAcessor)));
-                        }
-
-                        for (int i = 0; i < ngroups; i++)
-                        {
-                            if (deltaGroups[deltaGroups.Keys.ToList()[i]].Count == 0) continue;
-
-                            expressions.Add(Expression.IfThen(Expression.ArrayAccess(Expression.Field(incomingConverted, valueFlagsAcessor), Expression.Constant(i)),
-                                    Expression.Block(deltaGroups[deltaGroups.Keys.ToList()[i]].Select(
-
-                                        // regular:         o.f = i.f;
-                                        // IPrimaryDelta:   o.f = f ? (i.f ? f.applydelta(i.f) : null) : i.f
-                                        // IDelta:          o.f = f ? f.applydelta(i.f) : i.f
-
-                                        f => Expression.Assign(Expression.Field(output, f),
-                                            (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && (x.GetGenericTypeDefinition() == typeof(Generics.IDelta<>) || x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>)))) ?
-                                            Expression.Condition(Expression.Equal(Expression.Field(selfConverted, f), Expression.Constant(null, f.FieldType)),
-                                                Expression.Field(incomingConverted, f),
-                                                (f.FieldType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(Generics.IPrimaryDelta<>))) ?
-                                                    Expression.Condition(Expression.Equal(Expression.Field(incomingConverted, f), Expression.Constant(null, f.FieldType)),
-                                                    Expression.Constant(null, f.FieldType),
-                                                    Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("ApplyDelta"), Expression.Field(incomingConverted, f)), f.FieldType))
-                                                : Expression.Convert(Expression.Call(Expression.Field(selfConverted, f), f.FieldType.GetMethod("ApplyDelta"), Expression.Field(incomingConverted, f)), f.FieldType)
-                                                )
-                                            : Expression.Field(incomingConverted, f) // regular
-                                        )
-                                    ))));
-                        }
-
-                        expressions.Add(output); // return
-
-                        RainMeadow.Debug(Expression.Block(new[] { selfConverted, incomingConverted, output }, expressions).ToString());
-                        RainMeadow.Debug(Expression.Lambda<Func<OnlineState, OnlineState, OnlineState>>(Expression.Block(new[] { selfConverted, incomingConverted, output }, expressions), self, incoming).ToString());
-                        applydelta = Expression.Lambda<Func<OnlineState, OnlineState, OnlineState>>(Expression.Block(new[] { selfConverted, incomingConverted, output }, expressions), self, incoming).Compile();
+                        applydelta = (a, b) => (OnlineState)applyDeltaMethod.Invoke(null, [a, b]);
                     }
                 }
                 catch (Exception e)

--- a/Online/State/OnlineState.cs
+++ b/Online/State/OnlineState.cs
@@ -276,7 +276,11 @@ namespace RainMeadow
 
                     // make serialize func
 
-                    if (!MethodCache.LoadMethod("Serialize" + type.Name, type.Module, out var serializationMethod, null, typeof(OnlineState), typeof(Serializer)))
+                    if (!MethodCache.LoadMethod("Serialize" + type.Name, type.Module, out var serializationMethod, 
+                        (MethodInfo method) =>
+                        {
+                            this.serialize = (Action<OnlineState, Serializer>)method.CreateDelegate(typeof(Func<OnlineState, Serializer>));
+                        }, null!, typeof(OnlineState), typeof(Serializer)))
                     {
                         ParameterExpression self = Expression.Parameter(typeof(OnlineState), "self");
                         ParameterExpression selfConverted = Expression.Variable(type, "selfConverted");
@@ -383,7 +387,12 @@ namespace RainMeadow
                     // if supports delta
                     if (deltaSupport != DeltaSupport.None)
                     {
-                        if (!MethodCache.LoadMethod("Delta" + type.Name, type.Module, out var deltaMethod, typeof(OnlineState), typeof(OnlineState), typeof(OnlineState)))
+                        if (!MethodCache.LoadMethod("Delta" + type.Name, type.Module, out var deltaMethod,
+                            (MethodInfo method) =>
+                            {
+                                this.delta = (Func<OnlineState, OnlineState, OnlineState>)method.CreateDelegate(typeof(Func<OnlineState, OnlineState, OnlineState>));
+                            },
+                            typeof(OnlineState), typeof(OnlineState), typeof(OnlineState)))
                         {
                             // make delta func
                             ParameterExpression self = Expression.Parameter(typeof(OnlineState), "self");
@@ -498,7 +507,12 @@ namespace RainMeadow
 
 
                         // make applydelta func
-                        if (!MethodCache.LoadMethod("ApplyDelta" + type.Name, type.Module, out var applyDeltaMethod, typeof(OnlineState), typeof(OnlineState), typeof(OnlineState)))
+                        if (!MethodCache.LoadMethod("ApplyDelta" + type.Name, type.Module, out var applyDeltaMethod,
+                            (MethodInfo method) =>
+                            {
+                                this.applydelta = (Func<OnlineState, OnlineState, OnlineState>)method.CreateDelegate(typeof(Func<OnlineState, OnlineState, OnlineState>));
+                            },
+                            typeof(OnlineState), typeof(OnlineState), typeof(OnlineState)))
                         {
                             ParameterExpression self = Expression.Parameter(typeof(OnlineState), "self");
                             ParameterExpression selfConverted = Expression.Variable(type, "selfConverted");

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -152,10 +152,23 @@ namespace RainMeadow
 
                 MachineConnector.SetRegisteredOI("henpemaz_rainmeadow", rainMeadowOptions);
 
+                var dynamicsw = Stopwatch.StartNew();
                 var sw = Stopwatch.StartNew();
                 OnlineState.InitializeBuiltinTypes();
                 sw.Stop();
                 RainMeadow.Debug($"OnlineState.InitializeBuiltinTypes: {sw.Elapsed}");
+
+                sw = Stopwatch.StartNew();
+                RPCManager.SetupRPCs();
+                sw.Stop();
+                RainMeadow.Debug($"RPCManager.SetupRPCs: {sw.Elapsed}");
+
+                sw = Stopwatch.StartNew();
+                MethodCache.SaveDynamicMethods();
+                sw.Stop();
+                RainMeadow.Debug($"MethodCache.SaveDynamicMethods: {sw.Elapsed}");
+                dynamicsw.Stop();
+                RainMeadow.Debug($"State & RPC Initialization time: {dynamicsw.Elapsed}");
 
                 sw = Stopwatch.StartNew();
                 OnlineGameMode.InitializeBuiltinTypes();
@@ -167,10 +180,7 @@ namespace RainMeadow
                 sw.Stop();
                 RainMeadow.Debug($"MeadowProgression.InitializeBuiltinTypes: {sw.Elapsed}");
 
-                sw = Stopwatch.StartNew();
-                RPCManager.SetupRPCs();
-                sw.Stop();
-                RainMeadow.Debug($"RPCManager.SetupRPCs: {sw.Elapsed}");
+               
 
                 AssetBundle bundle = AssetBundle.LoadFromFile(AssetManager.ResolveFilePath("assetbundles/rainmeadow"));
                 Shader[] newShaders = bundle.LoadAllAssets<Shader>();

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -166,6 +166,7 @@ namespace RainMeadow
                 sw = Stopwatch.StartNew();
                 MethodCache.SaveDynamicMethods();
                 sw.Stop();
+                
                 RainMeadow.Debug($"MethodCache.SaveDynamicMethods: {sw.Elapsed}");
                 dynamicsw.Stop();
                 RainMeadow.Debug($"State & RPC Initialization time: {dynamicsw.Elapsed}");

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -190,7 +190,7 @@ namespace RainMeadow
                     var inGameClientsData = inGameClients.Select(cs => cs.GetData<StoryClientSettingsData>());
                     var inGameAvatarOPOs = inGameClients.SelectMany(cs => cs.avatars.Select(id => id.FindEntity(true))).OfType<OnlinePhysicalObject>();
                     var rooms = inGameAvatarOPOs.Select(opo => opo.apo.pos.room);
-                    var wasOneWay = (self.overrideData != null) ? self.overrideData.wasOneWay : self.Data.wasOneWay;
+                    var wasOneWay = (self.overrideData != null) ? self.overrideData.oneWay : self.Data.oneWay;
                     // Can't warp to warp points with null rooms (echo warps)
                     // remember that echo warps are one way only, so we will NOT gate thru them
                     // so please do not pretend it's a gate, and no requirements can be met, thanks :)
@@ -248,7 +248,7 @@ namespace RainMeadow
             {
                 RainMeadow.Debug("spawning warp point from echo");
                 PlacedObject placedObject = new(PlacedObject.Type.WarpPoint, null);
-                SpinningTopData specialData = self.SpecialData;
+                Watcher.SpinningTopData specialData = self.SpecialData;
                 // setup data
                 if (specialData != null && placedObject.data is Watcher.WarpPoint.WarpPointData warpData)
                 {


### PR DESCRIPTION
Store all dynamic methods in a into a DLL. This theoretically makes the startup faster and works great with Dnspy for debugging serialization.