### PR TITLE
Double-check piggyback eligibility on RPC run

### DIFF
--- a/Online/Entity/OnlineCreature.cs
+++ b/Online/Entity/OnlineCreature.cs
@@ -216,6 +216,8 @@ namespace RainMeadow
                 if (uppyWanter.abstractCreature.realizedCreature is Player realizedUppyWanter)
                 {
                     if (realizedPlayer == realizedUppyWanter) return;
+                    if (!realizedPlayer.Consious) return;
+                    if (realizedPlayer.abstractCreature.GetAllConnectedObjects().Contains(realizedUppyWanter.abstractCreature)) return;
                     if (!realizedPlayer.slugOnBack.HasASlug)
                     {
                         realizedPlayer.slugOnBack.SlugToBack(realizedUppyWanter);


### PR DESCRIPTION
Fixes player A getting permanently stuck piggybacked onto player B if B dies between the RPC being sent and received.