### PR TITLE
Sync Watcher Objects and Hazards.

### DIFF
--- a/Online/Resource/WorldSession.RainCycle.cs
+++ b/Online/Resource/WorldSession.RainCycle.cs
@@ -7,6 +7,7 @@
         [DeltaSupport(level = StateHandler.DeltaSupport.FollowsContainer)]
         public class RainCycleData : OnlineState
         {
+            // RainCycle
             [OnlineField]
             public int cycleLength = 0;
             [OnlineField(group: "timer")]
@@ -16,16 +17,30 @@
             [OnlineField]
             public bool antiGravity = false;
 
+            // WaterLevelCycle
+            [OnlineField]
+            public float stageDuration;
+            [OnlineField]
+            public float timeInStage;
+            [OnlineField]
+            public byte stage;
+
             public RainCycleData()
             {
 
             }
             public RainCycleData(RainCycle rainCycle)
             {
+                // RainCycle
                 this.cycleLength = rainCycle.cycleLength;
                 this.timer = rainCycle.timer;
                 this.preTimer = rainCycle.preTimer;
                 this.antiGravity = rainCycle.brokenAntiGrav?.on ?? false;
+
+                // WaterLevelCycle
+                this.stageDuration = rainCycle.waterCycle.stageDuration;
+                this.timeInStage = rainCycle.waterCycle.timeInStage;
+                this.stage = (byte)rainCycle.waterCycle.stage;
             }
 
             public override bool Equals(object obj)
@@ -33,7 +48,16 @@
                 if (obj is RainCycleData)
                 {
                     var rainCycle = (RainCycleData)obj;
-                    return (this.cycleLength == rainCycle.cycleLength && this.timer == rainCycle.timer && this.preTimer == rainCycle.preTimer && this.antiGravity == rainCycle.antiGravity);
+                    return (
+                        this.cycleLength == rainCycle.cycleLength && 
+                        this.timer == rainCycle.timer && 
+                        this.preTimer == rainCycle.preTimer && 
+                        this.antiGravity == rainCycle.antiGravity &&
+
+                        this.stageDuration == rainCycle.stageDuration &&
+                        this.timeInStage == rainCycle.timeInStage &&
+                        this.stage == rainCycle.stage
+                        );
                 }
                 return false;
             }

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -143,6 +143,10 @@ namespace RainMeadow
                     cycle.timer = rainCycleData.timer;
                     cycle.cycleLength = rainCycleData.cycleLength;
 
+                    cycle.waterCycle.timeInStage = rainCycleData.timeInStage;
+                    cycle.waterCycle.stageDuration = rainCycleData.stageDuration;
+                    cycle.waterCycle.stage = (WaterLevelCycle.Stage)rainCycleData.stage;
+
                     if (realizedRooms != null)
                     {
                         foreach (var index in realizedRooms.list)

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -106,7 +106,8 @@ namespace RainMeadow
             [OnlineField(nullable: true)]
             public Generics.DynamicOrderedUshorts realizedRooms;
 
-            // Used to sync RainWorldGame.clock which is used for a few 
+            // Used to sync RainWorldGame.clock which is used for a few APOs introduced in the Watcher as well as a few
+            // other functions in the game. Should be safe to update this way but I would keep a watch on it for a little bit.
             [OnlineField]
             public int clock;
             public WorldState() : base() { }

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -105,11 +105,17 @@ namespace RainMeadow
             public RainCycleData rainCycleData;
             [OnlineField(nullable: true)]
             public Generics.DynamicOrderedUshorts realizedRooms;
+
+            // Used to sync RainWorldGame.clock which is used for a few 
+            [OnlineField]
+            public int clock;
             public WorldState() : base() { }
             public WorldState(WorldSession resource, uint ts) : base(resource, ts)
             {
                 if (resource.world != null)
                 {
+                    clock = resource.world.game.clock;
+
                     RainCycle rainCycle = resource.world.rainCycle;
                     if (rainCycle.brokenAntiGrav == null)
                     {
@@ -128,6 +134,9 @@ namespace RainMeadow
                 if (resource.isActive)
                 {
                     var ws = (WorldSession)resource;
+
+                    ws.world.game.clock = clock;
+
                     RainCycle cycle = ws.world.rainCycle;
                     cycle.preTimer = rainCycleData.preTimer;
                     cycle.timer = rainCycleData.timer;


### PR DESCRIPTION
The Watcher DLC added a lot of room hazards that need to be synced. The following need to be synced.
- [x] Geysers (Uses `RainWorldGame.clock` for it's timing)
- [x] WaterLevelCycle (Includeds FluxWaterFall & FluxDrain, uses new parameters in RainCycle)
- [ ] FlameJet
- [ ] LethalThunderStorm
- [ ] SKLightningRod

If there's anything else that needs to be synced I'll add it to this list.