### PR TITLE
Arena: sync trophies

### DIFF
--- a/Arena/ArenaHelpers.cs
+++ b/Arena/ArenaHelpers.cs
@@ -241,7 +241,7 @@ namespace RainMeadow
                         }
                         return tb1.team == tb2.team && creature.State.alive && friend.State.alive;
                     }
-                }         
+                }
             }
 
             RainMeadow.Debug("Different teams or Player is null");
@@ -249,6 +249,56 @@ namespace RainMeadow
         }
 
         public static int GetReadiedPlayerCount(List<OnlinePlayer> players) => players.Where(player => GetArenaClientSettings(player)?.ready ?? false).Count();
+
+        public static List<IconSymbol.IconSymbolData> GetOnlinePlayerTrophies(ArenaOnlineGameMode arena, int playerNumber)
+        {
+            List<IconSymbol.IconSymbolData> trophies = new List<IconSymbol.IconSymbolData>();
+            OnlinePlayer? onlinePlayer = FindOnlinePlayerByFakePlayerNumber(arena, playerNumber);
+            if (onlinePlayer == null)
+            {
+                RainMeadow.Error("GetPlayerTrophies: Could not find onlineplayer");
+                return trophies;
+            }
+
+            if (!arena.playerNumberWithTrophies.ContainsKey(onlinePlayer.inLobbyId))
+            {
+                RainMeadow.Error("GetPlayerTrophies: Could not find player number in dictionary");
+                return trophies;
+            }
+            for (int i = 0; i < arena.playerNumberWithTrophies[onlinePlayer.inLobbyId].Count; i++)
+            {
+                IconSymbol.IconSymbolData iconSymbolData = IconSymbol.IconSymbolData.IconSymbolDataFromString(arena.playerNumberWithTrophies[onlinePlayer.inLobbyId][i]);
+                trophies.Add(iconSymbolData);
+            }
+            return trophies;
+
+        }
+
+        public static List<string> GetPlayerTrophies(ArenaOnlineGameMode arena, ArenaSitting.ArenaPlayer sittingPlayer)
+        {
+            List<string> trophies = new List<string>();
+            OnlinePlayer? onlinePlayer = FindOnlinePlayerByFakePlayerNumber(arena, sittingPlayer.playerNumber);
+            if (onlinePlayer == null)
+            {
+                RainMeadow.Error("GetPlayerTrophies: Could not find onlineplayer");
+                return trophies;
+            }
+
+            if (!arena.playerNumberWithTrophies.ContainsKey(onlinePlayer.inLobbyId))
+            {
+                RainMeadow.Error("GetPlayerTrophies: Could not find player number in dictionary");
+                return trophies;
+            }
+
+                for (int i = 0; i < sittingPlayer.allKills.Count; i++)
+                {
+                    trophies.Add(sittingPlayer.allKills[i].ToString());
+                }
+            
+            return trophies;
+
+        }
+
     }
 
 }

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -147,11 +147,7 @@ namespace RainMeadow
                 OnlinePlayer? pl = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, player.playerNumber);
                 if (pl != null)
                 {
-
-                    if (arena.localAllKills.TryGetValue(pl.inLobbyId, out var kills))
-                    {
-                        player.allKills = kills;
-                    }
+                    player.allKills = ArenaHelpers.GetOnlinePlayerTrophies(arena, player.playerNumber);
 
                     if (arena.playerNumberWithDeaths.TryGetValue(pl.inLobbyId, out var d))
                     {
@@ -798,7 +794,7 @@ namespace RainMeadow
                         OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, player.playerNumber);
                         if (onlinePlayer != null)
                         {
-                            arena.ReadFromStats(player, onlinePlayer);
+                            arena.ReadFromStats(self.manager, player, onlinePlayer);
                         }
                     }
                     self.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.MultiplayerResults);
@@ -1299,7 +1295,7 @@ namespace RainMeadow
                         OnlinePlayer? pl = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, self.players[num2].playerNumber);
                         if (pl != null)
                         {
-                            arena.AddOrInsertPlayerStats(arena, self.players[num2], pl);
+                            arena.AddOrInsertPlayerStats(arena, session, self.players[num2], pl);
                         }
 
                     }
@@ -1474,27 +1470,24 @@ namespace RainMeadow
                         {
                             self.arenaSitting.players[i].roundKills.Add(iconSymbolData);
                             self.arenaSitting.players[i].allKills.Add(iconSymbolData);
-                            if (!arena.localAllKills.ContainsKey(absPlayerCreature.owner.inLobbyId))
-                            {
-                                arena.localAllKills.Add(absPlayerCreature.owner.inLobbyId, self.arenaSitting.players[i].allKills);
-                            }
-                            else
-                            {
-                                arena.localAllKills[absPlayerCreature.owner.inLobbyId] = self.arenaSitting.players[i].allKills;
-                            }
+                            //if (!arena.localAllKills.ContainsKey(absPlayerCreature.owner.inLobbyId))
+                            //{
+                            //    arena.localAllKills.Add(absPlayerCreature.owner.inLobbyId, self.arenaSitting.players[i].allKills);
+                            //}
+                            //else
+                            //{
+                            //    arena.localAllKills[absPlayerCreature.owner.inLobbyId] = self.arenaSitting.players[i].allKills;
+                            //}
                             if (OnlineManager.lobby.isOwner)
                             {
-                                arena.playerNumberWithKills[absPlayerCreature.owner.inLobbyId] = self.arenaSitting.players[i].allKills.Count;
+                                arena.playerNumberWithTrophies[absPlayerCreature.owner.inLobbyId].Add(iconSymbolData.ToString());
+                                //arena.playerNumberWithKills[absPlayerCreature.owner.inLobbyId] = arena.playerNumberWithTrophies[absPlayerCreature.owner.inLobbyId].Count;
                             }
-                            RainMeadow.Debug($"Arena: All Local Kills Count: {arena.localAllKills.Count}");
+                            //RainMeadow.Debug($"Arena: All Local Kills Count: {arena.localAllKills.Count}");
 
-                            for (int p = 0; p < OnlineManager.players.Count; p++)
+                            if (!OnlineManager.lobby.isOwner)
                             {
-                                if (OnlineManager.players[p].isMe)
-                                {
-                                    continue;
-                                }
-                                OnlineManager.players[p].InvokeRPC(ArenaRPCs.Arena_AddTrophy, targetAbsCreature, self.arenaSitting.players[i].playerNumber);
+                                OnlineManager.lobby.owner.InvokeRPC(ArenaRPCs.Arena_AddTrophy, targetAbsCreature, self.arenaSitting.players[i].playerNumber);
                             }
                         }
 

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1470,20 +1470,10 @@ namespace RainMeadow
                         {
                             self.arenaSitting.players[i].roundKills.Add(iconSymbolData);
                             self.arenaSitting.players[i].allKills.Add(iconSymbolData);
-                            //if (!arena.localAllKills.ContainsKey(absPlayerCreature.owner.inLobbyId))
-                            //{
-                            //    arena.localAllKills.Add(absPlayerCreature.owner.inLobbyId, self.arenaSitting.players[i].allKills);
-                            //}
-                            //else
-                            //{
-                            //    arena.localAllKills[absPlayerCreature.owner.inLobbyId] = self.arenaSitting.players[i].allKills;
-                            //}
                             if (OnlineManager.lobby.isOwner)
                             {
                                 arena.playerNumberWithTrophies[absPlayerCreature.owner.inLobbyId].Add(iconSymbolData.ToString());
-                                //arena.playerNumberWithKills[absPlayerCreature.owner.inLobbyId] = arena.playerNumberWithTrophies[absPlayerCreature.owner.inLobbyId].Count;
                             }
-                            //RainMeadow.Debug($"Arena: All Local Kills Count: {arena.localAllKills.Count}");
 
                             if (!OnlineManager.lobby.isOwner)
                             {

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -794,7 +794,7 @@ namespace RainMeadow
                         OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, player.playerNumber);
                         if (onlinePlayer != null)
                         {
-                            arena.ReadFromStats(self.manager, player, onlinePlayer);
+                            arena.ReadFromStats(player, onlinePlayer);
                         }
                     }
                     self.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.MultiplayerResults);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1295,7 +1295,7 @@ namespace RainMeadow
                         OnlinePlayer? pl = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, self.players[num2].playerNumber);
                         if (pl != null)
                         {
-                            arena.AddOrInsertPlayerStats(arena, session, self.players[num2], pl);
+                            arena.AddOrInsertPlayerStats(arena, self.players[num2], pl);
                         }
 
                     }

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -91,8 +91,6 @@ namespace RainMeadow
             public Dictionary<int, int> playerNumberWithDeaths;
             [OnlineField(group = "arenaGameplay")]
             public Dictionary<int, int> playerNumberWithWins;
-            //[OnlineField(group = "arenaGameplay")]
-            //public Dictionary<int, int> playerNumberWithKills;
             [OnlineField(group = "arenaGameplay")]
             public Dictionary<int, int> playerTotScore;
             [OnlineField(group = "arenaGameplay")]
@@ -125,7 +123,6 @@ namespace RainMeadow
                 reigningChamps = new(arena.reigningChamps.list.ToList());
                 playerNumberWithScore = new(arena.playerNumberWithScore);
                 playerNumberWithDeaths = new(arena.playerNumberWithDeaths);
-                //playerNumberWithKills = new(arena.playerNumberWithKills);
                 playerTotScore = new(arena.playerTotScore);
                 playerNumberWithWins = new(arena.playerNumberWithWins);
                 playerNumberWithTrophies = arena.playerNumberWithTrophies;
@@ -181,7 +178,6 @@ namespace RainMeadow
                 (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithTrophies = playerNumberWithTrophies;
 
 
-                //(lobby.gameMode as ArenaOnlineGameMode).playerNumberWithKills = playerNumberWithKills;
                 (lobby.gameMode as ArenaOnlineGameMode).playerTotScore = playerTotScore;
 
                 (lobby.gameMode as ArenaOnlineGameMode).playersLateWaitingInLobbyForNextRound = playersLateWaitingInLobby;

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -91,10 +91,12 @@ namespace RainMeadow
             public Dictionary<int, int> playerNumberWithDeaths;
             [OnlineField(group = "arenaGameplay")]
             public Dictionary<int, int> playerNumberWithWins;
-            [OnlineField(group = "arenaGameplay")]
-            public Dictionary<int, int> playerNumberWithKills;
+            //[OnlineField(group = "arenaGameplay")]
+            //public Dictionary<int, int> playerNumberWithKills;
             [OnlineField(group = "arenaGameplay")]
             public Dictionary<int, int> playerTotScore;
+            [OnlineField(group = "arenaGameplay")]
+            public Dictionary<int, List<string>> playerNumberWithTrophies;
             [OnlineField(group = "arenaGameplay")]
             public bool countdownInitiatedHoldFire;
             [OnlineField(group = "arenaGameplay")]
@@ -123,9 +125,10 @@ namespace RainMeadow
                 reigningChamps = new(arena.reigningChamps.list.ToList());
                 playerNumberWithScore = new(arena.playerNumberWithScore);
                 playerNumberWithDeaths = new(arena.playerNumberWithDeaths);
-                playerNumberWithKills = new(arena.playerNumberWithKills);
+                //playerNumberWithKills = new(arena.playerNumberWithKills);
                 playerTotScore = new(arena.playerTotScore);
                 playerNumberWithWins = new(arena.playerNumberWithWins);
+                playerNumberWithTrophies = arena.playerNumberWithTrophies;
                 playersLateWaitingInLobby = new(arena.playersLateWaitingInLobbyForNextRound);
 
                 playersChoosingSlugs = new(arena.playersInLobbyChoosingSlugs.ToDictionary<string, int>());
@@ -174,7 +177,11 @@ namespace RainMeadow
                 (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithScore = playerNumberWithScore;
                 (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithDeaths = playerNumberWithDeaths;
                 (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithWins = playerNumberWithWins;
-                (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithKills = playerNumberWithKills;
+
+                (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithTrophies = playerNumberWithTrophies;
+
+
+                //(lobby.gameMode as ArenaOnlineGameMode).playerNumberWithKills = playerNumberWithKills;
                 (lobby.gameMode as ArenaOnlineGameMode).playerTotScore = playerTotScore;
 
                 (lobby.gameMode as ArenaOnlineGameMode).playersLateWaitingInLobbyForNextRound = playersLateWaitingInLobby;

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -260,17 +260,8 @@ namespace RainMeadow
                             game.GetArenaGameSession.arenaSitting.players[i].allKills.Add(iconSymbolData);
                             if (pl != null)
                             {
-                                //if (!arena.localAllKills.ContainsKey(pl.inLobbyId))
-                                //{
-                                //    arena.localAllKills.Add(pl.inLobbyId, game.GetArenaGameSession.arenaSitting.players[i].allKills);
-                                //}
-                                //else
-                                //{
-                                //    arena.localAllKills[pl.inLobbyId].Add(iconSymbolData);
-                                //}
 
                                 arena.playerNumberWithTrophies[pl.inLobbyId].Add(iconSymbolData.ToString());
-                                //arena.playerNumberWithKills[pl.inLobbyId] = arena.playerNumberWithTrophies[pl.inLobbyId].Count;
 
                             }
                         }

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -260,18 +260,18 @@ namespace RainMeadow
                             game.GetArenaGameSession.arenaSitting.players[i].allKills.Add(iconSymbolData);
                             if (pl != null)
                             {
-                                if (!arena.localAllKills.ContainsKey(pl.inLobbyId))
-                                {
-                                    arena.localAllKills.Add(pl.inLobbyId, game.GetArenaGameSession.arenaSitting.players[i].allKills);
-                                }
-                                else
-                                {
-                                    arena.localAllKills[pl.inLobbyId].Add(iconSymbolData);
-                                }
-                                if (OnlineManager.lobby.isOwner)
-                                {
-                                    arena.playerNumberWithKills[pl.inLobbyId] = arena.localAllKills[pl.inLobbyId].Count;
-                                }
+                                //if (!arena.localAllKills.ContainsKey(pl.inLobbyId))
+                                //{
+                                //    arena.localAllKills.Add(pl.inLobbyId, game.GetArenaGameSession.arenaSitting.players[i].allKills);
+                                //}
+                                //else
+                                //{
+                                //    arena.localAllKills[pl.inLobbyId].Add(iconSymbolData);
+                                //}
+
+                                arena.playerNumberWithTrophies[pl.inLobbyId].Add(iconSymbolData.ToString());
+                                //arena.playerNumberWithKills[pl.inLobbyId] = arena.playerNumberWithTrophies[pl.inLobbyId].Count;
+
                             }
                         }
 

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -60,7 +60,7 @@ namespace RainMeadow
                     OnlinePlayer? currentName = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, player.playerNumber);
                     if (currentName != null)
                     {
-                        arena.ReadFromStats(player, currentName);
+                        arena.ReadFromStats(manager, player, currentName);
                     }
                 }
 
@@ -156,7 +156,8 @@ namespace RainMeadow
                             };
 
                             Debug($"Arena: Local Sitting Data: {newArenaPlayer.playerNumber}: {newArenaPlayer.playerClass}");
-                            arena.AddOrInsertPlayerStats(arena, newArenaPlayer, pl);
+                            arena.AddOrInsertPlayerStats(arena, getArenaGameSession, newArenaPlayer, pl);
+
                             self.players.Add(newArenaPlayer);
                         }
                     }
@@ -179,7 +180,7 @@ namespace RainMeadow
                                     hasEnteredGameArea = true
                                 };
                                 Debug($"Arena: Local Sitting Data: {newArenaPlayer.playerNumber}: {newArenaPlayer.playerClass}");
-                                arena.AddOrInsertPlayerStats(arena, newArenaPlayer, player);
+                                arena.AddOrInsertPlayerStats(arena, getArenaGameSession, newArenaPlayer, player);
                                 self.players.Add(newArenaPlayer);
                             }
                         }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -156,7 +156,7 @@ namespace RainMeadow
                             };
 
                             Debug($"Arena: Local Sitting Data: {newArenaPlayer.playerNumber}: {newArenaPlayer.playerClass}");
-                            arena.AddOrInsertPlayerStats(arena, getArenaGameSession, newArenaPlayer, pl);
+                            arena.AddOrInsertPlayerStats(arena, newArenaPlayer, pl);
 
                             self.players.Add(newArenaPlayer);
                         }
@@ -180,7 +180,7 @@ namespace RainMeadow
                                     hasEnteredGameArea = true
                                 };
                                 Debug($"Arena: Local Sitting Data: {newArenaPlayer.playerNumber}: {newArenaPlayer.playerClass}");
-                                arena.AddOrInsertPlayerStats(arena, getArenaGameSession, newArenaPlayer, player);
+                                arena.AddOrInsertPlayerStats(arena, newArenaPlayer, player);
                                 self.players.Add(newArenaPlayer);
                             }
                         }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -60,7 +60,7 @@ namespace RainMeadow
                     OnlinePlayer? currentName = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, player.playerNumber);
                     if (currentName != null)
                     {
-                        arena.ReadFromStats(manager, player, currentName);
+                        arena.ReadFromStats(player, currentName);
                     }
                 }
 

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -490,7 +490,7 @@ namespace RainMeadow
 
             }
         }
-        public void AddOrInsertPlayerStats(ArenaOnlineGameMode arena, ArenaGameSession session, ArenaSitting.ArenaPlayer newArenaPlayer, OnlinePlayer pl)
+        public void AddOrInsertPlayerStats(ArenaOnlineGameMode arena, ArenaSitting.ArenaPlayer newArenaPlayer, OnlinePlayer pl)
         {
 
             if (arena.playerNumberWithWins.TryGetValue(pl.inLobbyId, out var wins))

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -66,10 +66,9 @@ namespace RainMeadow
         public Dictionary<int, int> playerNumberWithScore = new Dictionary<int, int>();
         public Dictionary<int, int> playerNumberWithDeaths = new Dictionary<int, int>();
         public Dictionary<int, int> playerNumberWithWins = new Dictionary<int, int>();
-        public Dictionary<int, int> playerNumberWithKills = new Dictionary<int, int>();
 
         public Dictionary<int, int> playerTotScore = new Dictionary<int, int>();
-
+        public Dictionary<int, List<string>> playerNumberWithTrophies = new Dictionary<int, List<string>>();
 
         public bool playersEqualToOnlineSitting;
         public bool clientWantsToLeaveGame;
@@ -101,7 +100,8 @@ namespace RainMeadow
         public List<ushort> arenaSittingOnlineOrder = new List<ushort>();
         public List<ushort> playersLateWaitingInLobbyForNextRound = new List<ushort>();
         public List<int> bannedSlugs = new List<int>();
-        public Dictionary<int, List<IconSymbol.IconSymbolData>> localAllKills;
+        //public Dictionary<int, List<IconSymbol.IconSymbolData>> localAllKills;
+
 
         public ArenaOnlineGameMode(Lobby lobby) : base(lobby)
         {
@@ -130,7 +130,7 @@ namespace RainMeadow
             leaveForNextLevel = false;
             lobbyCountDown = 5;
             initiateLobbyCountdown = false;
-            localAllKills = new Dictionary<int, List<IconSymbol.IconSymbolData>>();
+            //localAllKills = new Dictionary<int, List<IconSymbol.IconSymbolData>>();
 
 
             slugcatSelectMenuScenes = new Dictionary<string, MenuScene.SceneID>()
@@ -276,7 +276,7 @@ namespace RainMeadow
             {
                 slugcatSelectMenuScenes.Add("MeadowRandom", MenuScene.SceneID.Endgame_Traveller);
             }
-            
+
 
 
             if ((OnlineManager.mePlayer.id.name == "IVLD") || (UnityEngine.Random.Range(0, 4) == 0))
@@ -416,8 +416,8 @@ namespace RainMeadow
             if (arenaClientSettings.playingAs == RainMeadow.Ext_SlugcatStatsName.OnlineRandomSlugcat)
             {
                 System.Random random = new System.Random((int)DateTime.Now.Ticks);
-                SlugcatStats.Name[] allowedSelectableScugs = AvailableSlugcats(), allowedPlayableScugs = [..ArenaHelpers.allSlugcats.Where(allowedSelectableScugs.Contains)];
-                allowedPlayableScugs = allowedPlayableScugs.Length == 0 ? [..ArenaHelpers.allSlugcats] : allowedPlayableScugs;
+                SlugcatStats.Name[] allowedSelectableScugs = AvailableSlugcats(), allowedPlayableScugs = [.. ArenaHelpers.allSlugcats.Where(allowedSelectableScugs.Contains)];
+                allowedPlayableScugs = allowedPlayableScugs.Length == 0 ? [.. ArenaHelpers.allSlugcats] : allowedPlayableScugs;
                 avatarSettings.playingAs = allowedPlayableScugs[random.Next(allowedPlayableScugs.Length)];
                 arenaClientSettings.randomPlayingAs = avatarSettings.playingAs;
             }
@@ -463,17 +463,17 @@ namespace RainMeadow
             {
                 playerNumberWithWins.Add(getPlayer.inLobbyId, 0);
             }
-            if (!playerNumberWithKills.ContainsKey(getPlayer.inLobbyId))
-            {
-                playerNumberWithKills.Add(getPlayer.inLobbyId, 0);
-            }
             if (!playerTotScore.ContainsKey(getPlayer.inLobbyId))
             {
                 playerTotScore.Add(getPlayer.inLobbyId, 0);
             }
+            if (!playerNumberWithTrophies.ContainsKey(getPlayer.inLobbyId))
+            {
+                playerNumberWithTrophies.Add(getPlayer.inLobbyId, new List<string>());
+            }
         }
 
-        public void ReadFromStats(ArenaSitting.ArenaPlayer player, OnlinePlayer pl)
+        public void ReadFromStats(ProcessManager manager, ArenaSitting.ArenaPlayer player, OnlinePlayer pl)
         {
             if (playerNumberWithWins.TryGetValue(pl.inLobbyId, out var wins))
             {
@@ -481,17 +481,21 @@ namespace RainMeadow
                 player.score = playerNumberWithScore[pl.inLobbyId];
                 player.deaths = playerNumberWithDeaths[pl.inLobbyId];
                 player.totScore = playerTotScore[pl.inLobbyId];
+                player.allKills = ArenaHelpers.GetOnlinePlayerTrophies(this, player.playerNumber);
 
                 RainMeadow.Debug($"Read stats: {player} from online player: {pl}");
                 RainMeadow.Debug($"Read witih stats: {player.wins} from online player: {player}");
                 RainMeadow.Debug($"Read witih score stats: {player.score} from online player: {player}");
                 RainMeadow.Debug($"Read witih death stats: {player.deaths} from online player: {player}");
                 RainMeadow.Debug($"Read witih totScore stats: {player.totScore} from online player: {player}");
+                RainMeadow.Debug($"Client read stats with allKills stats: {player.allKills} from online player: {player}");
+
             }
         }
-        public void AddOrInsertPlayerStats(ArenaOnlineGameMode arena, ArenaSitting.ArenaPlayer newArenaPlayer, OnlinePlayer pl)
+        public void AddOrInsertPlayerStats(ArenaOnlineGameMode arena, ArenaGameSession session, ArenaSitting.ArenaPlayer newArenaPlayer, OnlinePlayer pl)
         {
-            if (arena.playerNumberWithWins.TryGetValue(pl.inLobbyId, out var wins)) // if we have one of the dictionary entries, we can rest assured we have all
+
+            if (arena.playerNumberWithWins.TryGetValue(pl.inLobbyId, out var wins))
             {
                 if (OnlineManager.lobby.isOwner)
                 {
@@ -499,11 +503,16 @@ namespace RainMeadow
                     arena.playerNumberWithScore[pl.inLobbyId] += newArenaPlayer.score;
                     arena.playerNumberWithDeaths[pl.inLobbyId] += newArenaPlayer.deaths;
                     arena.playerTotScore[pl.inLobbyId] += newArenaPlayer.totScore;
+                    if (arena.playerNumberWithTrophies[pl.inLobbyId].Count < ArenaHelpers.GetPlayerTrophies(arena, newArenaPlayer).Count)
+                    {
+                        arena.playerNumberWithTrophies[pl.inLobbyId] = ArenaHelpers.GetPlayerTrophies(arena, newArenaPlayer);
+                    }
                     RainMeadow.Debug($"Player found witih stats: {newArenaPlayer} from online player: {pl}");
                     RainMeadow.Debug($"Player found witih stats: {newArenaPlayer.wins} from online player: {pl} => NOW {arena.playerNumberWithWins[pl.inLobbyId]} ");
                     RainMeadow.Debug($"Player found witih score stats: {newArenaPlayer.score} from online player: {pl} {arena.playerNumberWithWins[pl.inLobbyId]} ");
                     RainMeadow.Debug($"Player found witih death stats: {newArenaPlayer.deaths} from online player: {pl} {arena.playerNumberWithWins[pl.inLobbyId]} ");
                     RainMeadow.Debug($"Player found witih totScore stats: {newArenaPlayer.totScore} from online player: {pl} {arena.playerNumberWithWins[pl.inLobbyId]}");
+                    RainMeadow.Debug($"Client read stats with allKills stats: {newArenaPlayer.allKills} from online player: {pl} {arena.playerNumberWithTrophies[pl.inLobbyId]}");
 
                 }
                 else
@@ -512,12 +521,15 @@ namespace RainMeadow
                     newArenaPlayer.score = arena.playerNumberWithScore[pl.inLobbyId];
                     newArenaPlayer.deaths = arena.playerNumberWithDeaths[pl.inLobbyId];
                     newArenaPlayer.totScore = arena.playerTotScore[pl.inLobbyId];
+                    newArenaPlayer.allKills = ArenaHelpers.GetOnlinePlayerTrophies(arena, newArenaPlayer.playerNumber);
 
                     RainMeadow.Debug($"Client read stats: {newArenaPlayer} from online player: {pl}");
                     RainMeadow.Debug($"Client read stats witih stats: {newArenaPlayer.wins} from online player: {pl}");
                     RainMeadow.Debug($"Client read stats witih score stats: {newArenaPlayer.score} from online player: {pl}");
                     RainMeadow.Debug($"Client read stats witih death stats: {newArenaPlayer.deaths} from online player: {pl}");
                     RainMeadow.Debug($"Client read stats witih totScore stats: {newArenaPlayer.totScore} from online player: {pl}");
+                    RainMeadow.Debug($"Client read stats with allKills stats: {newArenaPlayer.allKills} from online player: {pl}");
+
                 }
 
             }
@@ -529,11 +541,14 @@ namespace RainMeadow
                     arena.playerNumberWithDeaths.Add(pl.inLobbyId, newArenaPlayer.deaths);
                     arena.playerNumberWithWins.Add(pl.inLobbyId, newArenaPlayer.wins);
                     arena.playerTotScore.Add(pl.inLobbyId, newArenaPlayer.totScore);
+                    arena.playerNumberWithTrophies.Add(pl.inLobbyId, ArenaHelpers.GetPlayerTrophies(arena, newArenaPlayer));
+
                     RainMeadow.Debug($"New Player assigned witih stats: {newArenaPlayer} from online player: {pl}");
                     RainMeadow.Debug($"New Player assigned witih stats: {newArenaPlayer.wins} from online player: {pl}");
                     RainMeadow.Debug($"New Player assigned witih score stats: {newArenaPlayer.score} from online player: {pl}");
                     RainMeadow.Debug($"New Player assigned witih death stats: {newArenaPlayer.deaths} from online player: {pl}");
                     RainMeadow.Debug($"New Player assigned witih totScore stats: {newArenaPlayer.totScore} from online player: {pl}");
+                    RainMeadow.Debug($"New Player assigned witih allKills stats: {newArenaPlayer.allKills} from online player: {pl}");
 
                 }
             }
@@ -566,14 +581,15 @@ namespace RainMeadow
         {
             manager.rainWorld.progression.ClearOutSaveStateFromMemory();
             manager.rainWorld.progression.SaveProgression(true, true);
-            localAllKills.Clear();
+            //localAllKills.Clear();
             if (!OnlineManager.lobby.isOwner) return;
             arenaSittingOnlineOrder.Clear();
             playerNumberWithWins.Clear();
             playerNumberWithDeaths.Clear();
             playerNumberWithScore.Clear();
-            playerNumberWithKills.Clear();
+            //playerNumberWithKills.Clear();
             playerTotScore.Clear();
+            playerNumberWithTrophies.Clear();
         }
         public void ResetReadyUpLogic(ArenaOnlineGameMode arena, ArenaLobbyMenu lobby)
         {

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -100,7 +100,6 @@ namespace RainMeadow
         public List<ushort> arenaSittingOnlineOrder = new List<ushort>();
         public List<ushort> playersLateWaitingInLobbyForNextRound = new List<ushort>();
         public List<int> bannedSlugs = new List<int>();
-        //public Dictionary<int, List<IconSymbol.IconSymbolData>> localAllKills;
 
 
         public ArenaOnlineGameMode(Lobby lobby) : base(lobby)
@@ -130,7 +129,6 @@ namespace RainMeadow
             leaveForNextLevel = false;
             lobbyCountDown = 5;
             initiateLobbyCountdown = false;
-            //localAllKills = new Dictionary<int, List<IconSymbol.IconSymbolData>>();
 
 
             slugcatSelectMenuScenes = new Dictionary<string, MenuScene.SceneID>()
@@ -581,13 +579,11 @@ namespace RainMeadow
         {
             manager.rainWorld.progression.ClearOutSaveStateFromMemory();
             manager.rainWorld.progression.SaveProgression(true, true);
-            //localAllKills.Clear();
             if (!OnlineManager.lobby.isOwner) return;
             arenaSittingOnlineOrder.Clear();
             playerNumberWithWins.Clear();
             playerNumberWithDeaths.Clear();
             playerNumberWithScore.Clear();
-            //playerNumberWithKills.Clear();
             playerTotScore.Clear();
             playerNumberWithTrophies.Clear();
         }

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -471,7 +471,7 @@ namespace RainMeadow
             }
         }
 
-        public void ReadFromStats(ProcessManager manager, ArenaSitting.ArenaPlayer player, OnlinePlayer pl)
+        public void ReadFromStats(ArenaSitting.ArenaPlayer player, OnlinePlayer pl)
         {
             if (playerNumberWithWins.TryGetValue(pl.inLobbyId, out var wins))
             {

--- a/Menu/Dialogs/ArenaPostGameStatsDialog.cs
+++ b/Menu/Dialogs/ArenaPostGameStatsDialog.cs
@@ -58,7 +58,7 @@ namespace RainMeadow.UI
             if (i == 0)
                 return [.. arenaMode.playerNumberWithWins.Where(x => ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key) != null).OrderByDescending(x => x.Value).Select(x => $"{LabelTest.TrimText(ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key).id.name, storedResults.size.x - LabelTest.GetWidth($" - {x.Value}") - 10, true)} - {x.Value}")];
             if (i == 1)
-                return [.. arenaMode.playerNumberWithKills.Where(x => ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key) != null).OrderByDescending(x =>  x.Value).Select(x => $"{LabelTest.TrimText(ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key).id.name, storedResults.size.x - LabelTest.GetWidth($" - {x.Value}") - 10, true)} - {x.Value}")]; // something about kills
+                return [.. arenaMode.playerNumberWithTrophies.Where(x => ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key) != null).OrderByDescending(x =>  x.Value.Count).Select(x => $"{LabelTest.TrimText(ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key).id.name, storedResults.size.x - LabelTest.GetWidth($" - {x.Value.Count}") - 10, true)} - {x.Value.Count}")]; // something about kills
             if (i == 2)
                 return [.. arenaMode.playerNumberWithDeaths.Where(x => ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key) != null).OrderByDescending(x => x.Value).Select(x => $"{LabelTest.TrimText(ArenaHelpers.FindOnlinePlayerByLobbyId((ushort)x.Key).id.name, storedResults.size.x - LabelTest.GetWidth($" - {x.Value}") - 10, true)} - {x.Value}")];
             return [];

--- a/Online/Serialization/Serializer.Data.cs
+++ b/Online/Serialization/Serializer.Data.cs
@@ -1,6 +1,8 @@
-﻿using RWCustom;
+﻿using Newtonsoft.Json.Linq;
+using RWCustom;
 using System.Collections.Generic;
 using UnityEngine;
+using static RainMeadow.Serializer;
 
 namespace RainMeadow
 {
@@ -1328,44 +1330,96 @@ namespace RainMeadow
 
             }
         }
-
-            public void Serialize(ref Dictionary<int, int> data)
-            {
+        public void Serialize(ref Dictionary<int, List<string>> data)
+        {
 #if TRACING
             long wasPos = this.Position;
 #endif
-                if (IsWriting)
+            if (IsWriting)
+            {
+                if (data is null)
                 {
-                    if (data is null)
+                    writer.Write((byte)0);
+                }
+                else
+                {
+                    writer.Write((byte)data.Count);
+                    foreach (var kvp in data)
                     {
-                        writer.Write((byte)0);
-                    }
-                    else
-                    {
-                        writer.Write((byte)data.Count);
-                        foreach (var kvp in data)
+                        writer.Write(kvp.Key);
+                        writer.Write((byte)kvp.Value.Count);
+                        for (int i = 0; i < kvp.Value.Count; i++)
                         {
-                            writer.Write(kvp.Key);
-                            writer.Write(kvp.Value);
+
+                            writer.Write(kvp.Value[i].ToString());
                         }
                     }
                 }
-                if (IsReading)
+            }
+            if (IsReading)
+            {
+                var dictCount = reader.ReadByte();
+                if (dictCount == 0)
                 {
-                    var count = reader.ReadByte();
-                    data = new Dictionary<int, int>(count);
-                    for (int i = 0; i < count; i++)
+                    data = new Dictionary<int, List<string>>();
+                }
+                else
+                {
+                    data = new Dictionary<int, List<string>>(dictCount);
+                    for (int i = 0; i < dictCount; i++)
                     {
                         var key = reader.ReadInt32();
-                        var value = reader.ReadInt32();
-                        data.Add(key, value);
+                        var listCount = reader.ReadByte();
+                        var value = new List<string>(listCount);
+
+                        for (int j = 0; j < listCount; j++)
+                        {
+                            value.Add(reader.ReadString());
+
+                        }
+                        data.Add(key, new List<string>(value));
                     }
 
                 }
+            }
+        }
+        public void Serialize(ref Dictionary<int, int> data)
+        {
+#if TRACING
+            long wasPos = this.Position;
+#endif
+            if (IsWriting)
+            {
+                if (data is null)
+                {
+                    writer.Write((byte)0);
+                }
+                else
+                {
+                    writer.Write((byte)data.Count);
+                    foreach (var kvp in data)
+                    {
+                        writer.Write(kvp.Key);
+                        writer.Write(kvp.Value);
+                    }
+                }
+            }
+            if (IsReading)
+            {
+                var count = reader.ReadByte();
+                data = new Dictionary<int, int>(count);
+                for (int i = 0; i < count; i++)
+                {
+                    var key = reader.ReadInt32();
+                    var value = reader.ReadInt32();
+                    data.Add(key, value);
+                }
+
+            }
 #if TRACING
             if (IsWriting) RainMeadow.Trace(this.Position - wasPos);
 #endif
-            }
+        }
 
         public void Serialize(ref Color data)
         {


### PR DESCRIPTION
- Adds serialized type, Dictionary<int, List string>. Need to maintain a running record of player inLobbyId and the trophy data since Arena supports joining-in-progress and needs data from the host. Let me know if you have a better idea for this, @henpemaz. 

- [x] Playtest this via Steam
- [x] Playtest via LAN