### PR TITLE
Remove duplicate hook subscription in unrelated hook method.

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1417,11 +1417,10 @@ namespace RainMeadow
                 }
                 self.outsidePlayersCountAsDead = false; // prevent killing scugs in dens
                 arena.externalArenaGameMode.ArenaSessionCtor(arena, orig, self, game);
-                On.ProcessManager.RequestMainProcessSwitch_ProcessID += ProcessManager_RequestMainProcessSwitch_ProcessID;
             }
 
-
         }
+        
         private void OverwriteArenaPlayerMax(ILContext il) => OverwriteArenaPlayerMax(il, false);
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   2. Allows players to join a lobby without immidietly loading all regions.
   3. Allows non-host players to manage WorldSessions. (Meadow mode)
   4. Adds potential for downloading custom regions while inside the lobby.
+- Removed redundant arena hook subscription.
   
 # Release 1.8.0
 ## General:


### PR DESCRIPTION
The method is correctly subscribed at RainMeadow.MenuHooks.cs:30. Without removal, the method is being subscribed to the hook each time the user enters a online arena.

If I did something wrong do tell me, this is my first time doing this.