### PR TITLE
engine: Add null check for oracle in RealizedOracleState

### DIFF
--- a/Online/State/RealizedOracleState.cs
+++ b/Online/State/RealizedOracleState.cs
@@ -26,7 +26,7 @@ namespace RainMeadow
             base.ReadTo(onlineEntity);
 
             var oracle = (Oracle)((OnlinePhysicalObject)onlineEntity).apo.realizedObject;
-
+            if (oracle == null) return;            
             oracle.oracleBehavior.lookPoint = this.lookPoint;
 
             oracle.mySwarmers = this.mySwarmers.list


### PR DESCRIPTION
[Error  :RainMeadow] 03:46:15|390749|OnlineResource.State.ReadTo:System.NullReferenceException: Object reference not set to an instance of an object
  at RainMeadow.RealizedOracleState.ReadTo (RainMeadow.OnlineEntity onlineEntity) [0x0001f] in /Online/State/RealizedOracleState.cs:30 