### PR TITLE
fix: arena resource racing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Added flash to tab arrow to assist users in locating game mode tab settings
 - Publicized arena.blockList for developers
 - Fixed bees/bombs spawning client-side
-
+- Resolved a critical race condition when loading between levels 
 ## General
 - Added Chinese translation (thanks @havenoideawhatismyname!)
 - Fixed custom background thumbnails not disappearing when scrolling background pages

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -536,6 +536,7 @@ namespace RainMeadow
                 Error(ex);
             }
         }
+        // world transition at gates
         private void OverWorld_WorldLoaded(On.OverWorld.orig_WorldLoaded orig, OverWorld self, bool warpUsed)
         {
             if (OnlineManager.lobby != null)
@@ -658,7 +659,6 @@ namespace RainMeadow
                 }
 
                 
-
                 if (warpUsed)
                 { // and for warps we require a more manual approach; to properly make aware of old APOs entering a new region
                     foreach (var absplayer in self.game.Players)

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -575,7 +575,9 @@ namespace RainMeadow
                             }
                         }
                     }
+                    
                     orig(self, warpUsed); // this replace the list of entities in new world with that from old world
+                    
                     // post: we add our entities to the new world
                     if (room != null && RoomSession.map.TryGetValue(room.abstractRoom, out var roomSession2))
                     {

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -536,51 +536,6 @@ namespace RainMeadow
                 Error(ex);
             }
         }
-        /// <summary>
-        /// Used to control Host/Client resource racing in OverWorld_WorldLoaded
-        /// </summary>
-         private System.Collections.IEnumerator OverworldLoaded_WaitLoop(On.OverWorld.orig_WorldLoaded orig, OverWorld self, bool warpUsed, WorldSession session)
-        {
-            float startTime = UnityEngine.Time.time;
-            float timeoutSeconds = 5f;
-        
-            if (OnlineManager.lobby.isOwner) 
-            {
-                // Wait until players leave OR 5 seconds pass. No deadlocks
-                while (session.participants.Count > 0 && (UnityEngine.Time.time - startTime < timeoutSeconds))
-                {
-                    yield return null; 
-                }
-            } 
-            else
-            {
-                if (!OnlineManager.lobby.overworld.worldSessions.TryGetValue((self.worldLoader == null) ? self.activeWorld.name : self.worldLoader.ReturnWorld().name, out var worldSession))
-                {
-                    RainMeadow.Error("Could not get world session! Exiting deadlock...");
-                } 
-                else 
-                {
-                    // Wait until owner is present OR 5 seconds pass
-                    while (!worldSession.overworldSession.participants.Contains(OnlineManager.lobby.owner) && (UnityEngine.Time.time - startTime < timeoutSeconds))
-                    {
-                        yield return null; 
-                    }
-                }
-            }
-        
-            if (UnityEngine.Time.time - startTime >= timeoutSeconds)
-            {
-                Debug("WaitLoop timed out after 5 seconds. Proceeding anyway to prevent deadlock.");
-            }
-            else
-            {
-                Debug("All players left or owner found. Proceeding.");
-            }
-        
-            waitingForPlayersToLeave = false;
-            self.WorldLoaded(warpUsed);
-        }
-        // world transition at gates
         private void OverWorld_WorldLoaded(On.OverWorld.orig_WorldLoaded orig, OverWorld self, bool warpUsed)
         {
             if (OnlineManager.lobby != null)
@@ -620,22 +575,6 @@ namespace RainMeadow
                             }
                         }
                     }
-                    roomSession.ParticipantLeft(OnlineManager.mePlayer);
-                    oldWorldSession.ParticipantLeft(OnlineManager.mePlayer);
-                    if ((OnlineManager.lobby.isOwner && oldWorldSession.participants.Count > 0) || (!OnlineManager.lobby.isOwner && OnlineManager.lobby.overworld.worldSessions.TryGetValue((self.worldLoader == null) ? self.activeWorld.name : self.worldLoader.ReturnWorld().name, out var ws) && !ws.overworldSession.participants.Contains(OnlineManager.lobby.owner)))
-                    {
-                        if (OnlineManager.lobby.isOwner) {
-                        Debug($"Waiting for {oldWorldSession.participants.Count} players to leave...");
-                        } else
-                        {
-                         Debug($"Waiting for host  players to join new world...");
-
-                        }
-                        waitingForPlayersToLeave = true; 
-                        self.game.rainWorld.StartCoroutine(OverworldLoaded_WaitLoop(orig, self, warpUsed, oldWorldSession));
-                        return; 
-                    }
-
                     orig(self, warpUsed); // this replace the list of entities in new world with that from old world
 
                     // post: we add our entities to the new world
@@ -718,6 +657,8 @@ namespace RainMeadow
                     // special warp, don't bother with room items
                     orig(self, warpUsed);
                 }
+
+                
 
                 if (warpUsed)
                 { // and for warps we require a more manual approach; to properly make aware of old APOs entering a new region

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -540,7 +540,6 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null)
             {
-                if (waitingForPlayersToLeave) return;
                 Debug($"warpWorldLoader is null: {self.warpWorldLoader == null}, worldLoader is null: {self.worldLoader == null}");
                 World newWorld = (self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld();
                 WorldSession oldWorldSession = self.activeWorld.GetResource() ?? throw new KeyNotFoundException();

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -576,7 +576,6 @@ namespace RainMeadow
                         }
                     }
                     orig(self, warpUsed); // this replace the list of entities in new world with that from old world
-
                     // post: we add our entities to the new world
                     if (room != null && RoomSession.map.TryGetValue(room.abstractRoom, out var roomSession2))
                     {

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -658,7 +658,6 @@ namespace RainMeadow
                     orig(self, warpUsed);
                 }
 
-                
                 if (warpUsed)
                 { // and for warps we require a more manual approach; to properly make aware of old APOs entering a new region
                     foreach (var absplayer in self.game.Players)

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -33,7 +33,7 @@ namespace RainMeadow
             return orig(self);
         }
 
-        static bool waitingForPlayersToLeave = false;
+        private static bool waitingForPlayersToLeave = false;
 
         /// <summary>
         /// Used to control Host/Client resource racing in ArenaSitting_NextLevel

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -142,8 +142,7 @@ namespace RainMeadow
                             }
                         }
                     }
-                    roomSession.ParticipantLeft(OnlineManager.mePlayer);
-                    worldSession.ParticipantLeft(OnlineManager.mePlayer);
+                    worldSession.NotNeeded();
                     if ((OnlineManager.lobby.isOwner && worldSession.participants.Count > 0) || (!OnlineManager.lobby.isOwner && OnlineManager.lobby.overworld.worldSessions.TryGetValue("arena", out var ws) && !ws.overworldSession.participants.Contains(OnlineManager.lobby.owner)))
                     {
                         if (OnlineManager.lobby.isOwner) {

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -119,7 +119,8 @@ namespace RainMeadow
                 if (RoomSession.map.TryGetValue(absRoom, out var roomSession))
                 {
                     Debug("Next level switching");
-                    worldSession.NotNeeded();
+                    // I don't think we need this since ParticipantLeft will manage the transference
+                    //worldSession.NotNeeded();
                     
                     // Ladies and gentlemen: The Sledgehammer
                     roomSession.UpdateParticipants(

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -120,7 +120,7 @@ namespace RainMeadow
                 {
                     Debug("Next level switching");
                     // I don't think we need this since ParticipantLeft will manage the transference
-                    //worldSession.NotNeeded();
+                    worldSession.NotNeeded();
                     
                     // Ladies and gentlemen: The Sledgehammer
                     roomSession.UpdateParticipants(

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -361,7 +361,7 @@ namespace RainMeadow
         public static event Action<OnlineResource, OnlinePlayer>? OnParticipantLeft;
 
         protected virtual void ParticipantLeftImpl(OnlinePlayer player) { }
-        private void ParticipantLeft(OnlinePlayer participant)
+        public void ParticipantLeft(OnlinePlayer participant)
         {
             if (!participants.Contains(participant)) return;
             RainMeadow.Debug($"{this}-{participant}");

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -361,7 +361,7 @@ namespace RainMeadow
         public static event Action<OnlineResource, OnlinePlayer>? OnParticipantLeft;
 
         protected virtual void ParticipantLeftImpl(OnlinePlayer player) { }
-        public void ParticipantLeft(OnlinePlayer participant)
+        private void ParticipantLeft(OnlinePlayer participant)
         {
             if (!participants.Contains(participant)) return;
             RainMeadow.Debug($"{this}-{participant}");

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -17,6 +17,9 @@ namespace RainMeadow
         public string worldID;
         public ushort shortWorldID;
 
+        // Will extend beyond Arena_NextLevel eventually
+        public bool waitingForPlayersToLeave = false;
+
         public WorldSession(string worldID, ushort shortWorldID, OverworldSession overworld) : base(overworld)
         {
             this.worldID = worldID;


### PR DESCRIPTION
- Manually manages resource participation leaving  during the next round / next world instead of waiting for the process switch
- Arena testing seemed good