### PR TITLE
fix: story den forced re-sheltering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Gracefully handle when the an online game mode menu is loaded but the online lobby hasn't 
 - Updated "Match Save" to "Sync Save" for clarity
 - Updated the Text Prompt on death to dismiss after 5 seconds instead of requiring input
-- Fixed forced den re-sheltering when a client has a valid den (this feature disabled in Watcher campaign)
+- Fixed forced den re-sheltering when a client has a valid den
 # Release 1.10.0 (Anniversary Edition)
 ## Arena:
 - Fixes Amoeba controls not listening to your pointed direction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Gracefully handle when the an online game mode menu is loaded but the online lobby hasn't 
 - Updated "Match Save" to "Sync Save" for clarity
 - Updated the Text Prompt on death to dismiss after 5 seconds instead of requiring input
+- Fixed forced den re-sheltering when a client has a valid den (this feature disabled in Watcher campaign)
 # Release 1.10.0 (Anniversary Edition)
 ## Arena:
 - Fixes Amoeba controls not listening to your pointed direction

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -175,7 +175,7 @@ namespace RainMeadow
             if (RainMeadow.isStoryMode(out var story))
             {
 
-                if (!OnlineManager.lobby.isOwner)
+                if (!OnlineManager.lobby.isOwner && story.currentCampaign == Watcher.WatcherEnums.SlugcatStatsName.Watcher)
                 {
                     OnlineManager.lobby.owner.InvokeOnceRPC(StoryRPCs.ForceSaveNewDenLocation, roomName, saveWorldStates); // tell host to save den location for everyone else
                 }

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -175,7 +175,7 @@ namespace RainMeadow
             if (RainMeadow.isStoryMode(out var story))
             {
 
-                if (!OnlineManager.lobby.isOwner && story.currentCampaign == Watcher.WatcherEnums.SlugcatStatsName.Watcher)
+                if (!OnlineManager.lobby.isOwner)
                 {
                     OnlineManager.lobby.owner.InvokeOnceRPC(StoryRPCs.ForceSaveNewDenLocation, roomName, saveWorldStates); // tell host to save den location for everyone else
                 }
@@ -1721,14 +1721,23 @@ namespace RainMeadow
             RainMeadow.Debug($"START DENPOS save:{self.currentSaveState.denPosition} last:{storyGameMode.myLastDenPos} lobby:{storyGameMode.defaultDenPos}");
             RainMeadow.Debug($"START WARPPOS save:{self.currentSaveState.warpPointTargetAfterWarpPointSave} last:{storyGameMode.myLastWarp}");
 
-            if (OnlineManager.lobby.isOwner || storyGameMode.myLastDenPos is null || self.currentSaveState.denPosition != storyGameMode.defaultDenPos)
+            if (OnlineManager.lobby.isOwner)
             {
                 storyGameMode.myLastDenPos = self.currentSaveState.denPosition;
+                storyGameMode.defaultDenPos = self.currentSaveState.denPosition;
             }
-            else
+            else 
             {
-                self.currentSaveState.denPosition = storyGameMode.myLastDenPos;
+                if (storyGameMode.myLastDenPos == "" || storyGameMode.myLastDenPos is null)
+                {
+                    // user is freshly joining the game
+                    storyGameMode.myLastDenPos = self.currentSaveState.denPosition;
+                } else
+                {
+                    self.currentSaveState.denPosition = storyGameMode.myLastDenPos;
+                }
             }
+
             if (OnlineManager.lobby.isOwner || storyGameMode.myLastWarp is null || self.currentSaveState.warpPointTargetAfterWarpPointSave != storyGameMode.myLastWarp)
             {
                 storyGameMode.myLastWarp = self.currentSaveState.warpPointTargetAfterWarpPointSave;


### PR DESCRIPTION
If client is newly joined, give them the host's spot. Otherwise, give them their current spot stored in memory.