### PR TITLE
Revert "Revert "engine: release overworld session""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# Release 1.11.1
-## Engine 
-- Fixed an issue where transitioning regions led to disappearing players
-
 # Release 1.11.0
 ## Arena
 - Added flash to tab arrow to assist users in locating game mode tab settings

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -543,9 +543,11 @@ namespace RainMeadow
             {
                 Debug($"warpWorldLoader is null: {self.warpWorldLoader == null}, worldLoader is null: {self.worldLoader == null}");
                 World newWorld = (self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld();
-                WorldSession oldWorldSession = self.activeWorld.GetResource() ?? throw new KeyNotFoundException();
-                WorldSession newWorldSession = newWorld.GetResource() ?? throw new KeyNotFoundException();
-                bool isSameWorld = (self.activeWorld.name == newWorld.name);
+                
+                
+                WorldSession oldWorldSession = OnlineManager.lobby.gameMode.LinkWorld(self.activeWorld) ?? throw new KeyNotFoundException();
+                WorldSession newWorldSession = OnlineManager.lobby.gameMode.LinkWorld(newWorld) ?? throw new KeyNotFoundException();
+                bool isSameWorld = oldWorldSession == newWorldSession;
                 bool isEchoWarp = (self.game.GetStorySession.saveState.warpPointTargetAfterWarpPointSave != null);
                 bool isFirstWarpWorld = false;
 
@@ -701,7 +703,7 @@ namespace RainMeadow
                 { // there exists "warps" to the same world, twice, for some bloody reason
                     //this in fact probably is required for now because rain world devs DESPISE US
                     RainMeadow.Debug("Unsubscribing from old world");
-                    oldWorldSession.Deactivate();
+                    oldWorldSession.discard = true;
                     oldWorldSession.NotNeeded(); // done? let go
                 }
 

--- a/Game/RainMeadow.GameHooks.cs
+++ b/Game/RainMeadow.GameHooks.cs
@@ -119,15 +119,19 @@ namespace RainMeadow
                 {
                     if (OnlineManager.lobby != null)
                     {
-                        if (OnlineManager.lobby.overworld.isActive) OnlineManager.lobby.overworld.Deactivate();
+                        // if (OnlineManager.lobby.overworld.isActive) OnlineManager.lobby.overworld.Deactivate();
                         
                         OnlineManager.lobby.overworld.BindOverworld(self);
                         OnlineManager.lobby.overworld.Needed();
-                        while (!OnlineManager.lobby.overworld.isAvailable)
+                        while (OnlineManager.lobby != null && !OnlineManager.lobby.overworld.isAvailable)
                         {
                             OnlineManager.ForceLoadUpdate();
                         }
-                        OnlineManager.lobby.overworld.Activate();
+
+                        if (OnlineManager.lobby != null)
+                        {
+                            OnlineManager.lobby.overworld.Activate();
+                        }
                     }
                 });
             }
@@ -551,7 +555,7 @@ namespace RainMeadow
                 OnlineManager.lobby.gameMode.GameShutDown(self);
 
 
-                if (OnlineManager.lobby.overworld.isActive) OnlineManager.lobby.overworld.Deactivate();
+                
                 OnlineManager.lobby.overworld.NotNeeded();
                 if (self.manager.upcomingProcess != ProcessManager.ProcessID.MainMenu) // quit directly, otherwise wait release
                 {
@@ -560,6 +564,7 @@ namespace RainMeadow
                         OnlineManager.ForceLoadUpdate();
                     }
                 }
+                if (OnlineManager.lobby.overworld.isActive) OnlineManager.lobby.overworld.Deactivate();
             }
         }
 

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -445,34 +445,7 @@ namespace RainMeadow
                 {
                     if (entities[i] is AbstractPhysicalObject apo && OnlinePhysicalObject.map.TryGetValue(apo, out var oe))
                     {
-                        oe.apo.LoseAllStuckObjects();
-                        if (!oe.isMine)
-                        {
-                            // not-online-aware removal
-                            RainMeadow.Debug("removing remote entity from game " + oe);
-                            oe.beingMoved = true;
-
-                            if (oe.apo.realizedObject is Creature c && c.inShortcut)
-                            {
-                                if (c.RemoveFromShortcuts()) c.inShortcut = false;
-                            }
-
-                            entities.Remove(oe.apo);
-
-                            absRoom.creatures.Remove(oe.apo as AbstractCreature);
-                            if (oe.apo.realizedObject != null)
-                            {
-                                room.RemoveObject(oe.apo.realizedObject);
-                                room.CleanOutObjectNotInThisRoom(oe.apo.realizedObject);
-                            }
-                            oe.beingMoved = false;
-                        }
-                        else // mine leave the old online world elegantly
-                        {
-                            RainMeadow.Debug("removing my entity from online " + oe);
-                            oe.ExitResource(roomSession);
-                            oe.ExitResource(roomSession.worldSession);
-                        }
+                        oe.RemoveEntityFromGame();
                     }
                 }
             }

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -11,6 +11,8 @@ namespace RainMeadow
         public WorldLoader worldLoader;
         public static ConditionalWeakTable<World, WorldSession> map = new();
         public Dictionary<string, RoomSession> roomSessions = new();
+
+        public bool discard = false;
         public World World => world;
         public OverworldSession overworldSession => (OverworldSession)super;
 
@@ -27,6 +29,7 @@ namespace RainMeadow
         {
             this.world = world;
             this.worldLoader = worldLoader;
+            this.discard = false;
             map.Add(world, this);
         }
 
@@ -77,7 +80,7 @@ namespace RainMeadow
 
         protected override void UnavailableImpl()
         {
-
+            if (discard && isActive) Deactivate();
         }
 
         protected override ResourceState MakeState(uint ts)


### PR DESCRIPTION
Reverts henpemaz/Rain-Meadow#1232

- [x] Needs entity feed requests denied while process switch occurs 
- [ ] This currently creates invisible entities, may be related 