### PR TITLE
fix: entity resources sending states while transitioning

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -2325,7 +2325,7 @@ namespace RainMeadow
 
                 if (self.Players.Count != arena.arenaSittingOnlineOrder.Count)
                 {
-                    RainMeadow.Error($"Arena: Abstract Creature count does not equal registered players in the online Sitting! AC Count: {self.Players.Count} | ArenaSittingOnline Count: {arena.arenaSittingOnlineOrder.Count}");
+                    RainMeadow.Trace($"Arena: Abstract Creature count does not equal registered players in the online Sitting! AC Count: {self.Players.Count} | ArenaSittingOnline Count: {arena.arenaSittingOnlineOrder.Count}");
 
                     var extraPlayers = self.Players.Skip(arena.arenaSittingOnlineOrder.Count).ToList();
 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -577,7 +577,7 @@ namespace RainMeadow
 
                 World newWorld = self.worldLoader?.ReturnWorld() ?? self.activeWorld;
                 WorldSession newWorldSession = newWorld.GetResource() ?? throw new KeyNotFoundException("New world session not found.");
-                WorldSession oldWorldSession = self.activeWorld.GetResource() ?? newWorldSession;
+                WorldSession oldWorldSession = self.activeWorld.GetResource() ?? newWorldSession; // Do not throw for the old world to prevent error during coroutine
 
                 if (oldWorldSession.transitionInProgress) return;
 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -541,12 +541,12 @@ namespace RainMeadow
         {
             System.Func<bool> waitCondition = null;
 
-            if (OnlineManager.lobby.gameMode is not MeadowGameMode && !OnlineManager.lobby.isOwner)
+            if ((OnlineManager.lobby.gameMode is not MeadowGameMode && !OnlineManager.lobby.isOwner) || OnlineManager.lobby.gameMode is MeadowGameMode)
             {
                 waitCondition = () => !newWorldSession.isAvailable;
             }
 
-            return WaitAndExecuteSession(
+            return WorldSession.WaitAndExecuteSession(
                 oldWorldSession,
                 waitCondition, 
                 () => self.WorldLoaded(warpUsed) 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -584,18 +584,17 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby != null)
             {
-                Debug($"warpWorldLoader is null: {self.warpWorldLoader == null}, worldLoader is null: {self.worldLoader == null}");
-                World newWorld = (self.worldLoader == null) ? self.activeWorld : self.worldLoader.ReturnWorld();
-                WorldSession oldWorldSession = self.activeWorld.GetResource();
-                WorldSession newWorldSession = newWorld.GetResource() ?? throw new KeyNotFoundException();
-                bool isSameWorld = (self.activeWorld.name == newWorld.name);
-                bool isEchoWarp = (self.game.GetStorySession.saveState.warpPointTargetAfterWarpPointSave != null);
-                bool isFirstWarpWorld = false;
+                Debug($"Warp Status -> worldLoader: {self.worldLoader?.ReturnWorld().name ?? "NULL"}, activeWorld: {self.activeWorld.name}");
 
-                if (oldWorldSession != null && oldWorldSession.transitionInProgress)
-                {
-                    return;
-                }
+                World newWorld = self.worldLoader?.ReturnWorld() ?? self.activeWorld;
+                WorldSession newWorldSession = newWorld.GetResource() ?? throw new KeyNotFoundException("New world session not found.");
+                WorldSession oldWorldSession = self.activeWorld.GetResource() ?? newWorldSession;
+
+                if (oldWorldSession.transitionInProgress) return;
+
+                bool isSameWorld = self.activeWorld.name == newWorld.name;
+                bool isEchoWarp = self.game.GetStorySession.saveState.warpPointTargetAfterWarpPointSave != null;
+                bool isFirstWarpWorld = false;
 
                 if (self.reportBackToGate != null && RoomSession.map.TryGetValue(self.reportBackToGate.room.abstractRoom, out var roomSession))
                 {

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -565,18 +565,6 @@ namespace RainMeadow
                 oldWorldSession.NotNeeded(); // done? let go
             }
 
-            if (OnlineManager.lobby.gameMode is not MeadowGameMode) {
-
-                if (oldWorldSession.participants.Count > 0)
-                {
-                    if (OnlineManager.lobby.isOwner) {
-                    Debug($"Waiting for {oldWorldSession.participants.Count} players to leave...");
-                    } else
-                    {
-                        Debug($"Waiting for host  players to join new world...");
-                    }
-                }
-            }
             self.game.manager.rainWorld.StartCoroutine(Overworld_Loaded_WaitLoop(orig, self, warpUsed, oldWorldSession, newWorldSession, newWorld));
             oldWorldSession.transitionInProgress = true;
             return; 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -546,11 +546,10 @@ namespace RainMeadow
                 waitCondition = () => !newWorldSession.isAvailable;
             }
 
-            // Return the helper coroutine
             return WaitAndExecuteSession(
                 oldWorldSession,
                 waitCondition, 
-                () => self.WorldLoaded(warpUsed) // The action to run at the end
+                () => self.WorldLoaded(warpUsed) 
             );
         }
 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -555,7 +555,7 @@ namespace RainMeadow
 
         private void DeactivateAndWait(On.OverWorld.orig_WorldLoaded orig, OverWorld self, bool warpUsed, bool isSameWorld, WorldSession oldWorldSession, WorldSession newWorldSession, World newWorld)
         {
-
+            RainMeadow.Debug(this);
             if (!isSameWorld && oldWorldSession.isActive)
             { // there exists "warps" to the same world, twice, for some bloody reason
                 //this in fact probably is required for now because rain world devs DESPISE US

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -727,9 +727,7 @@ namespace RainMeadow
                 {
                     // special warp, don't bother with room items
                     orig(self, warpUsed);
-
                     DeactivateAndWait(orig, self, warpUsed, isSameWorld, oldWorldSession, newWorldSession, newWorld);
-
                 }
 
                 if (warpUsed)
@@ -771,6 +769,11 @@ namespace RainMeadow
                 }
 
 
+                if (OnlineManager.lobby.gameMode is MeadowGameMode)
+                {
+                    oldWorldSession.Deactivate();
+                    oldWorldSession.NotNeeded(); // done? let go
+                }
 
                 if (OnlineManager.lobby.gameMode is StoryGameMode storyGameMode)
                 {

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -40,11 +40,20 @@ namespace RainMeadow
 
             session.transitionInProgress = true;
 
-            while (session.participants.Count > 0 && 
-                (extraWaitCondition == null || extraWaitCondition()) && 
-                (UnityEngine.Time.time - startTime < timeoutSeconds))
+            if (OnlineManager.lobby.gameMode is not MeadowGameMode) {
+                while (session.participants.Count > 0 && 
+                    (extraWaitCondition == null || extraWaitCondition()) && 
+                    (UnityEngine.Time.time - startTime < timeoutSeconds))
+                {
+                    yield return null;
+                }
+            } else
             {
-                yield return null;
+                while (session.isActive && 
+                    (UnityEngine.Time.time - startTime < timeoutSeconds))
+                {
+                    yield return null;
+                }
             }
 
             if (UnityEngine.Time.time - startTime >= timeoutSeconds)

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -45,6 +45,7 @@ namespace RainMeadow
                     (extraWaitCondition == null || extraWaitCondition()) && 
                     (UnityEngine.Time.time - startTime < timeoutSeconds))
                 {
+                    RainMeadow.Debug($"Waiting for {session.participants.Count} to leave...");
                     yield return null;
                 }
             } else
@@ -52,6 +53,7 @@ namespace RainMeadow
                 while (session.isActive && 
                     (UnityEngine.Time.time - startTime < timeoutSeconds))
                 {
+                    RainMeadow.Debug($"Waiting for session to deactivate...");
                     yield return null;
                 }
             }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -35,8 +35,7 @@ namespace RainMeadow
         }
         private System.Collections.IEnumerator ArenaNextLevel_WaitLoop(On.ArenaSitting.orig_NextLevel orig, ArenaSitting self, ProcessManager manager, WorldSession oldWorldSession)
         {
-            System.Func<bool> waitCondition = null;
-            waitCondition = () => oldWorldSession.participants.Count > 0;
+            System.Func<bool> waitCondition = () => oldWorldSession.participants.Count > 0;
 
             return WorldSession.WaitAndExecuteSession(
                 oldWorldSession,

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using MonoMod.RuntimeDetour;
 namespace RainMeadow
 {

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -35,9 +35,12 @@ namespace RainMeadow
         }
         private System.Collections.IEnumerator ArenaNextLevel_WaitLoop(On.ArenaSitting.orig_NextLevel orig, ArenaSitting self, ProcessManager manager, WorldSession oldWorldSession)
         {
+            System.Func<bool> waitCondition = null;
+            waitCondition = () => oldWorldSession.participants.Count > 0;
+
             return WorldSession.WaitAndExecuteSession(
-                oldWorldSession, 
-                null, 
+                oldWorldSession,
+                waitCondition, 
                 () => self.NextLevel(manager) 
             );
         }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -36,7 +36,6 @@ namespace RainMeadow
         {
             float startTime = UnityEngine.Time.time;
             float timeoutSeconds = 5f;
-
             session.transitionInProgress = true;
 
             if (OnlineManager.lobby.gameMode is not MeadowGameMode) {
@@ -45,14 +44,6 @@ namespace RainMeadow
                     (UnityEngine.Time.time - startTime < timeoutSeconds))
                 {
                     RainMeadow.Debug($"Waiting for {session.participants.Count} to leave...");
-                    yield return null;
-                }
-            } else
-            {
-                while (session.isActive && 
-                    (UnityEngine.Time.time - startTime < timeoutSeconds))
-                {
-                    RainMeadow.Debug($"Waiting for session to deactivate...");
                     yield return null;
                 }
             }

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -22,44 +22,6 @@ namespace RainMeadow
             new Hook(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.TimelinePoint)).GetGetMethod(), RainWorldGame_TimelinePoint);
         }
 
-        /// <summary>
-        /// A centralized coroutine helper that waits for a WorldSession's participants to clear before proceeding.
-        /// It enforces a 5-second safety timeout to prevent softlocks (deadlocks) if entities fail to remove.
-        /// </summary>
-        /// <param name="session">The WorldSession currently transitioning.</param>
-        /// <param name="extraWaitCondition">Optional: An additional condition that must remain true to keep waiting (e.g., !newWorldSession.isAvailable). Pass null if not needed.</param>
-        /// <param name="onComplete">The action/method to execute once the wait finishes or times out (e.g., orig(self, ...)).</param>
-        private System.Collections.IEnumerator WaitAndExecuteSession(
-            WorldSession session, 
-            System.Func<bool> extraWaitCondition, 
-            System.Action onComplete)
-        {
-            float startTime = UnityEngine.Time.time;
-            float timeoutSeconds = 5f;
-            session.transitionInProgress = true;
-
-            if (OnlineManager.lobby.gameMode is not MeadowGameMode) {
-                while (session.participants.Count > 0 && 
-                    (extraWaitCondition == null || extraWaitCondition()) && 
-                    (UnityEngine.Time.time - startTime < timeoutSeconds))
-                {
-                    RainMeadow.Debug($"Waiting for {session.participants.Count} to leave...");
-                    yield return null;
-                }
-            }
-
-            if (UnityEngine.Time.time - startTime >= timeoutSeconds)
-            {
-                Debug("WaitLoop timed out after 5 seconds. Proceeding anyway to prevent deadlock.");
-            }
-            else
-            {
-                Debug("Entities removed. Proceeding...");
-            }
-
-            session.transitionInProgress = false;
-            onComplete?.Invoke();
-        }
         SlugcatStats.Name RainWorldGame_StoryCharacter(Func<RainWorldGame, SlugcatStats.Name> orig, RainWorldGame self)
         {
             if (OnlineManager.lobby != null) return OnlineManager.lobby.gameMode.LoadWorldAs(self);
@@ -73,7 +35,7 @@ namespace RainMeadow
         }
         private System.Collections.IEnumerator ArenaNextLevel_WaitLoop(On.ArenaSitting.orig_NextLevel orig, ArenaSitting self, ProcessManager manager, WorldSession oldWorldSession)
         {
-            return WaitAndExecuteSession(
+            return WorldSession.WaitAndExecuteSession(
                 oldWorldSession, 
                 null, 
                 () => self.NextLevel(manager) 

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -35,11 +35,10 @@ namespace RainMeadow
         }
         private System.Collections.IEnumerator ArenaNextLevel_WaitLoop(On.ArenaSitting.orig_NextLevel orig, ArenaSitting self, ProcessManager manager, WorldSession oldWorldSession)
         {
-            System.Func<bool> waitCondition = () => oldWorldSession.participants.Count > 0;
 
             return WorldSession.WaitAndExecuteSession(
                 oldWorldSession,
-                waitCondition, 
+                null, 
                 () => self.NextLevel(manager) 
             );
         }

--- a/Online/Entity/OnlineEntity.EntityId.cs
+++ b/Online/Entity/OnlineEntity.EntityId.cs
@@ -1,4 +1,6 @@
-﻿namespace RainMeadow
+﻿using System;
+
+namespace RainMeadow
 {
     public abstract partial class OnlineEntity
     {

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -409,7 +409,7 @@ namespace RainMeadow
             var localState = entity.GetState(tick, inResource);
             if (localState == null) return false;
 
-            // "Can the incoming state type be used to represent the local state type?"
+            // Can the incoming state type be used to represent the local state type
             return entityState.GetType().IsAssignableFrom(localState.GetType());
         }
         public Dictionary<OnlineResource, Queue<EntityState>> incomingState = new();

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -403,13 +403,26 @@ namespace RainMeadow
 
         public virtual bool CanReadTo(EntityState entityState, OnlineResource inResource, uint tick) 
         {
-            var entity = entityState.entityId.FindEntity() as OnlinePhysicalObject;
-            if (entity == null) return false;
+            var entity = entityState.entityId.FindEntity();
+            if (entity == null)
+            {
+                RainMeadow.Error($"CanReadTo: Entity state cannot readto. Reason: entity.FindEntity() is null: {entityState.from}, {entityState.entityId}");
+                return false;
+            } 
 
             var localState = entity.GetState(tick, inResource);
-            if (localState == null) return false;
+            if (localState == null)
+            {
+                RainMeadow.Error($"CanReadTo: Entity state cannot readto. Reason: localState.GetState() is null");
+                return false;
+            } 
 
-            // Can the incoming state type be used to represent the local state type
+
+            if (!entityState.GetType().IsAssignableFrom(localState.GetType()))
+            {
+            RainMeadow.Error($"CanReadTo: Is not assignable EntityState: {entityState.GetType()}, localState: {localState.GetType()}:  {entityState.GetType().IsAssignableFrom(localState.GetType())}");
+            }
+
             return entityState.GetType().IsAssignableFrom(localState.GetType());
         }
         public Dictionary<OnlineResource, Queue<EntityState>> incomingState = new();

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -263,6 +263,8 @@ namespace RainMeadow
 
         public virtual void Deregister()
         {
+            RainMeadow.Debug("Removing feed for: " + this);
+            OnlineManager.RemoveFeed(this.currentlyJoinedResource, this); // Prevent reading state from non-existent entities
             RainMeadow.Debug("Removing entity from recentEntities: " + this);
             OnlineManager.recentEntities.Remove(id);
         }

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -263,8 +263,6 @@ namespace RainMeadow
 
         public virtual void Deregister()
         {
-            RainMeadow.Debug("Removing feed for: " + this);
-            OnlineManager.RemoveFeed(this.currentlyJoinedResource, this); // Prevent reading state from non-existent entities
             RainMeadow.Debug("Removing entity from recentEntities: " + this);
             OnlineManager.recentEntities.Remove(id);
         }
@@ -397,10 +395,11 @@ namespace RainMeadow
 
         public virtual void ReadState(EntityState entityState, OnlineResource inResource)
         {
-            lastStates[inResource] = entityState;
-            StateProfiler.Instance?.Push(entityState.GetType());
-            entityState.ReadTo(this);
-            StateProfiler.Instance?.Pop(entityState.GetType());
+                lastStates[inResource] = entityState;
+                StateProfiler.Instance?.Push(entityState.GetType());
+                entityState.ReadTo(this);
+                StateProfiler.Instance?.Pop(entityState.GetType());
+
         }
 
         public virtual bool CanReadTo(EntityState entityState, OnlineResource inResource, uint tick) 

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -401,6 +401,17 @@ namespace RainMeadow
             StateProfiler.Instance?.Pop(entityState.GetType());
         }
 
+        public virtual bool CanReadTo(EntityState entityState, OnlineResource inResource, uint tick) 
+        {
+            var entity = entityState.entityId.FindEntity() as OnlinePhysicalObject;
+            if (entity == null) return false;
+
+            var localState = entity.GetState(tick, inResource);
+            if (localState == null) return false;
+
+            // "Can the incoming state type be used to represent the local state type?"
+            return entityState.GetType().IsAssignableFrom(localState.GetType());
+        }
         public Dictionary<OnlineResource, Queue<EntityState>> incomingState = new();
         public virtual void ReadState(EntityFeedState entityFeedState)
         {

--- a/Online/OnlineManager.cs
+++ b/Online/OnlineManager.cs
@@ -158,6 +158,7 @@ namespace RainMeadow
                 foreach (var feed in feeds)
                 {
                     feed.Update(mePlayer.tick);
+                    
                 }
 
 
@@ -278,7 +279,7 @@ namespace RainMeadow
                 }
                 else if (state is EntityFeedState entityFeedState)
                 {
-                    if (entityFeedState.inResource != null && entityFeedState.inResource.isAvailable)
+                    if (entityFeedState.inResource != null && entityFeedState.inResource.isAvailable && !entityFeedState.inResource.transitionInProgress)
                     {
                         var ent = entityFeedState.entityState.entityId.FindEntity();
                         if (ent != null)
@@ -338,6 +339,7 @@ namespace RainMeadow
         public static void AddFeed(OnlineResource resource, OnlineEntity oe)
         {
             feeds.Add(new EntityFeed(resource, oe));
+            
         }
 
         public static void RemoveFeed(OnlineResource resource, OnlineEntity oe)

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -230,7 +230,6 @@ namespace RainMeadow
             }
             else if (owner != null && !owner.hasLeft) // request to leave
             {
-                //oe.joinedResources.Remove(oe.currentlyEnteredResource);
                 oe.lastStates.Remove(oe.currentlyJoinedResource);
                 oe.incomingState.Remove(oe.currentlyEnteredResource);
                 RequestEntityLeave(oe);

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace RainMeadow
@@ -115,7 +115,7 @@ namespace RainMeadow
             }
             if (oe.primaryResource == this)
             {
-                    RainMeadow.Error($"ID {oe.id} is alresdy taken. Purging old {oe.GetType().Name} for new");
+                    RainMeadow.Error($"ID {oe.id} is already taken. Purging old {oe.GetType().Name} for new");
                     // Try again
                     oe = entityDefinition.MakeEntity(this, initialState);
                     return;

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -230,6 +230,9 @@ namespace RainMeadow
             }
             else if (owner != null && !owner.hasLeft) // request to leave
             {
+                //oe.joinedResources.Remove(oe.currentlyEnteredResource);
+                oe.lastStates.Remove(oe.currentlyJoinedResource);
+                oe.incomingState.Remove(oe.currentlyEnteredResource);
                 RequestEntityLeave(oe);
             }
         }

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace RainMeadow
@@ -115,15 +115,11 @@ namespace RainMeadow
             }
             if (oe.primaryResource == this)
             {
-                if (oe.GetType() != entityDefinition.GetType()) {
-                    RainMeadow.Error($"Type mismatch on ID {oe.id}. Purging old {oe.GetType().Name} for new {entityDefinition.GetType().Name}");
+                    RainMeadow.Error($"ID {oe.id} is alresdy taken. Purging old {oe.GetType().Name} for new");
                     // Logic to remove oe from the resource list so the new one can take its place
                     this.registeredEntities.Remove(oe.id);
                     oe = entityDefinition.MakeEntity(this, initialState);
-                } else {
-                    RainMeadow.Error($"Already registered: " + oe);
                     return;
-                }
             }
 
             if (oe.primaryResource is OnlineResource otherResource && otherResource != this && EventMath.IsNewer(otherResource.registeredEntities[oe.id].version, entityDefinition.version))

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -117,7 +117,7 @@ namespace RainMeadow
             {
                 if (oe.GetType() != entityDefinition.GetType()) {
                     RainMeadow.Error($"Type mismatch on ID {oe.id}. Purging old {oe.GetType().Name} for new {entityDefinition.GetType().Name}");
-                    // Logic to remove 'oe' from the resource list so the new one can take its place
+                    // Logic to remove oe from the resource list so the new one can take its place
                     this.registeredEntities.Remove(oe.id);
                     oe = entityDefinition.MakeEntity(this, initialState);
                 } else {

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -116,8 +116,7 @@ namespace RainMeadow
             if (oe.primaryResource == this)
             {
                     RainMeadow.Error($"ID {oe.id} is alresdy taken. Purging old {oe.GetType().Name} for new");
-                    // Logic to remove oe from the resource list so the new one can take its place
-                    this.registeredEntities.Remove(oe.id);
+                    // Try again
                     oe = entityDefinition.MakeEntity(this, initialState);
                     return;
             }

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -232,8 +232,6 @@ namespace RainMeadow
             }
             else if (owner != null && !owner.hasLeft) // request to leave
             {
-                oe.lastStates.Remove(oe.currentlyJoinedResource);
-                oe.incomingState.Remove(oe.currentlyEnteredResource);
                 RequestEntityLeave(oe);
             }
         }
@@ -284,11 +282,13 @@ namespace RainMeadow
         public void EntityLeftResource(OnlineEntity oe)
         {
             RainMeadow.Debug($"{oe} : {this}");
+            
             if (oe.primaryResource == this && !registeredEntities.ContainsKey(oe.id)) throw new InvalidProgrammerException("wasn't registered in resource");
             if (!joinedEntities.ContainsKey(oe.id)) throw new InvalidProgrammerException("wasn't joined in resource");
             registeredEntities.Remove(oe.id);
             joinedEntities.Remove(oe.id);
-            activeEntities.Remove(oe);
+            activeEntities.Remove(oe); 
+
             EntitiesModified();
 
             if (!oe.isMine) oe.ExitResource(this);
@@ -330,7 +330,7 @@ namespace RainMeadow
             RainMeadow.Debug($"{oe} : {this} : to {newOwner}");
             if (oe != null && entityTransferRequest.from == oe.owner && isOwner && isActive && !isReleasing)
             {
-                OnlineManager.RunDeferred(() => { // deferred so we receive the incoming state first
+                 OnlineManager.RunDeferred(() => { // deferred so we receive the incoming state first
                     EntityTransfered(oe, newOwner);
                 });
                 entityTransferRequest.from.QueueEvent(new GenericResult.Ok(entityTransferRequest));

--- a/Online/Resource/OnlineResource.Entities.cs
+++ b/Online/Resource/OnlineResource.Entities.cs
@@ -115,8 +115,15 @@ namespace RainMeadow
             }
             if (oe.primaryResource == this)
             {
-                RainMeadow.Error($"Already registered: " + oe);
-                return;
+                if (oe.GetType() != entityDefinition.GetType()) {
+                    RainMeadow.Error($"Type mismatch on ID {oe.id}. Purging old {oe.GetType().Name} for new {entityDefinition.GetType().Name}");
+                    // Logic to remove 'oe' from the resource list so the new one can take its place
+                    this.registeredEntities.Remove(oe.id);
+                    oe = entityDefinition.MakeEntity(this, initialState);
+                } else {
+                    RainMeadow.Error($"Already registered: " + oe);
+                    return;
+                }
             }
 
             if (oe.primaryResource is OnlineResource otherResource && otherResource != this && EventMath.IsNewer(otherResource.registeredEntities[oe.id].version, entityDefinition.version))

--- a/Online/Resource/OnlineResource.State.cs
+++ b/Online/Resource/OnlineResource.State.cs
@@ -212,6 +212,12 @@ namespace RainMeadow
                             {
                                 if (entity.currentlyJoinedResource == resource) // this resource is the most "detailed" provider
                                 {
+
+                                    // bandaid for mismatched entity IDs
+                                    if (entity is OnlinePhysicalObject && !entity.CanReadTo(entityState, resource, tick))
+                                    {
+                                        continue;
+                                    }
                                     try
                                     {
                                         entity.ReadState(entityState, resource);

--- a/Online/Resource/OnlineResource.State.cs
+++ b/Online/Resource/OnlineResource.State.cs
@@ -214,7 +214,7 @@ namespace RainMeadow
                                 {
 
                                     // bandaid for mismatched entity IDs
-                                    if (entity is OnlinePhysicalObject && !entity.CanReadTo(entityState, resource, tick))
+                                    if (!entity.CanReadTo(entityState, resource, tick))
                                     {
                                         continue;
                                     }

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -27,6 +27,7 @@ namespace RainMeadow
         public bool isWaitingForState { get; protected set; } // The resource was leased or subscribed to by supervisor, waiting for owner
         public bool isReleasing { get; protected set; } // Ongoing release op
         public bool isPending => isRequesting || isReleasing || isWaitingForState; // Ongoing op
+        public bool transitionInProgress = false;
 
         public bool canRelease => !isPending // no ongoing transaction
             && (!isActive || !subresources.Any(s => s.isAvailable || s.isPending)) // no subresource available or pending

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 
 namespace RainMeadow
 {
@@ -10,6 +11,55 @@ namespace RainMeadow
         public World world;
         public WorldLoader worldLoader;
         public static ConditionalWeakTable<World, WorldSession> map = new();
+
+        
+        
+        /// <summary>
+        /// A centralized coroutine helper that waits for a WorldSession's participants to clear before proceeding.
+        /// It enforces a 5-second safety timeout to prevent softlocks (deadlocks) if entities fail to remove.
+        /// </summary>
+        /// <param name="session">The WorldSession currently transitioning.</param>
+        /// <param name="extraWaitCondition">Optional: An additional condition that must remain true to keep waiting (e.g., !newWorldSession.isAvailable). Pass null if not needed.</param>
+        /// <param name="onComplete">The action/method to execute once the wait finishes or times out (e.g., orig(self, ...)).</param>
+        public static System.Collections.IEnumerator WaitAndExecuteSession(
+            WorldSession session, 
+            System.Func<bool> extraWaitCondition, 
+            System.Action onComplete)
+        {
+            float startTime = UnityEngine.Time.time;
+            float timeoutSeconds = 5f;
+            session.transitionInProgress = true;
+
+            if (OnlineManager.lobby.gameMode is not MeadowGameMode) {
+                while (session.participants.Count > 0 && 
+                    (extraWaitCondition == null || extraWaitCondition()) && 
+                    (UnityEngine.Time.time - startTime < timeoutSeconds))
+                {
+                    RainMeadow.Debug($"Waiting for {session.participants.Count} to leave...");
+                    yield return null;
+                }
+            } else
+            {
+                 while ((extraWaitCondition == null || extraWaitCondition()) && 
+                    (UnityEngine.Time.time - startTime < timeoutSeconds))
+                {
+                    RainMeadow.Debug($"Waiting for {session.participants.Count} to leave...");
+                    yield return null;
+                }
+            }
+
+            if (UnityEngine.Time.time - startTime >= timeoutSeconds)
+            {
+                RainMeadow.Debug("WaitLoop timed out after 5 seconds. Proceeding anyway to prevent deadlock.");
+            }
+            else
+            {
+                RainMeadow.Debug("Entities removed. Proceeding...");
+            }
+
+            session.transitionInProgress = false;
+            onComplete?.Invoke();
+        }
         public Dictionary<string, RoomSession> roomSessions = new();
         public World World => world;
         public OverworldSession overworldSession => (OverworldSession)super;

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
-
 namespace RainMeadow
 {
     public partial class WorldSession : OnlineResource


### PR DESCRIPTION
- Fixes desynced entity ID
- Fixes state reads during regional transitions for any game mode 
- This solves state reading problems with high object counts that would normally lock us up

- [x] See if I can use one coroutine definition instead of separate params for same behavior 
- [x] Meadow mode needs a world release still since I removed that from the bottom 