### PR TITLE
fix: reset client remix settings on new lobby owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Arena
 - Restored custom Team Names
 
+## General
+- Re-synced Remix settings on Lobby owner change
+
 # Release 1.11.1
 ## Engine 
 - Fixed an issue where transitioning regions led to disappearing players

--- a/GameModes/OnlineGameMode.cs
+++ b/GameModes/OnlineGameMode.cs
@@ -32,6 +32,7 @@ namespace RainMeadow
 
         public static (Dictionary<string, bool> hostBoolSettings, Dictionary<string, float> hostFloatSettings, Dictionary<string, int> hostIntSettings) GetHostRemixSettings(OnlineGameMode mode)
         {
+            RainMeadowModManager.Reset();
             Dictionary<string, bool> configurableBools = new();
             Dictionary<string, float> configurableFloats = new();
             Dictionary<string, int> configurableInts = new();

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -1,10 +1,25 @@
 ﻿using System;
 using System.Linq;
+using System.Collections.Generic;
+
 
 namespace RainMeadow
 {
     public static class RPCs
     {
+
+        [RPCMethod]
+        public static void ResetClientRemixSettings(RPCEvent rPC)
+        {
+            if (OnlineManager.lobby != null && OnlineManager.lobby.state is Lobby.LobbyState ls)
+            {
+                OnlineManager.lobby.configurableBools = ls.onlineBoolRemixSettings;
+                OnlineManager.lobby.configurableInts = ls.onlineIntRemixSettings;
+                OnlineManager.lobby.configurableFloats = ls.onlineFloatRemixSettings;
+                RainMeadow.Debug($"Reset client remix settings");
+            }
+        }
+
         [RPCMethod]
         public static void DeathRain(RPCEvent rpc, GlobalRain.DeathRain.DeathRainMode deathRainMode, 
             float timeInThisMode, float calmBeforeStornSunlight)

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -16,6 +16,7 @@ namespace RainMeadow
                 OnlineManager.lobby.configurableBools = ls.onlineBoolRemixSettings;
                 OnlineManager.lobby.configurableInts = ls.onlineIntRemixSettings;
                 OnlineManager.lobby.configurableFloats = ls.onlineFloatRemixSettings;
+                OnlineGameMode.SetClientRemixSettings(OnlineManager.lobby.configurableBools, OnlineManager.lobby.configurableFloats, OnlineManager.lobby.configurableInts);
                 RainMeadow.Debug($"Reset client remix settings");
             }
         }

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -1,25 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.Collections.Generic;
-
+﻿using System.Linq;
 
 namespace RainMeadow
 {
     public static class RPCs
     {
-
-        [RPCMethod]
-        public static void ResetClientRemixSettings(RPCEvent rPC)
-        {
-            if (OnlineManager.lobby != null && OnlineManager.lobby.state is Lobby.LobbyState ls)
-            {
-                OnlineManager.lobby.configurableBools = ls.onlineBoolRemixSettings;
-                OnlineManager.lobby.configurableInts = ls.onlineIntRemixSettings;
-                OnlineManager.lobby.configurableFloats = ls.onlineFloatRemixSettings;
-                OnlineGameMode.SetClientRemixSettings(OnlineManager.lobby.configurableBools, OnlineManager.lobby.configurableFloats, OnlineManager.lobby.configurableInts);
-                RainMeadow.Debug($"Reset client remix settings");
-            }
-        }
 
         [RPCMethod]
         public static void DeathRain(RPCEvent rpc, GlobalRain.DeathRain.DeathRainMode deathRainMode, 

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -448,6 +448,16 @@ namespace RainMeadow
             {
                 RainMeadow.Debug($"Lobby owner {player} left!!!");
                 NewOwner(MatchmakingManager.currentInstance.GetLobbyOwner());
+                if (OnlineManager.lobby != null && OnlineManager.lobby.isOwner)
+                    {
+                        for (int i =0; i< OnlineManager.players.Count; i++)
+                        {
+                            if (OnlineManager.players[i] != null && !OnlineManager.players[i].isMe)
+                            {
+                                OnlineManager.players[i].InvokeOnceRPC(RPCs.ResetClientRemixSettings);
+                            }
+                        }
+                    }
             }
 
             // first transfer recursivelly, then remove recursivelly

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -448,13 +448,23 @@ namespace RainMeadow
             {
                 RainMeadow.Debug($"Lobby owner {player} left!!!");
                 NewOwner(MatchmakingManager.currentInstance.GetLobbyOwner());
-                if (OnlineManager.lobby != null && OnlineManager.lobby?.state is Lobby.LobbyState ls && !OnlineManager.lobby.isOwner)
-                {
-                    OnlineManager.lobby.configurableBools = ls.onlineBoolRemixSettings;
-                    OnlineManager.lobby.configurableInts = ls.onlineIntRemixSettings;
-                    OnlineManager.lobby.configurableFloats = ls.onlineFloatRemixSettings;
-                    OnlineGameMode.SetClientRemixSettings(OnlineManager.lobby.configurableBools, OnlineManager.lobby.configurableFloats, OnlineManager.lobby.configurableInts);
-                    RainMeadow.Debug($"Reset client remix settings");
+                if (OnlineManager.lobby != null && OnlineManager.lobby?.state is Lobby.LobbyState ls) {
+                    // Getting and Setting is expensive, do this as a one time instead of relying on lobby state syncs? 
+                    if (OnlineManager.lobby.isOwner)
+                    {
+                            (var configurableBools, var configurableFloats, var configurableInts) = OnlineGameMode.GetHostRemixSettings(OnlineManager.lobby.gameMode);
+                            ls.onlineBoolRemixSettings = configurableBools;
+                            ls.onlineFloatRemixSettings = configurableFloats;
+                            ls.onlineIntRemixSettings = configurableInts;
+                    }
+                    else 
+                    { 
+                        OnlineManager.lobby.configurableBools = ls.onlineBoolRemixSettings;
+                        OnlineManager.lobby.configurableInts = ls.onlineIntRemixSettings;
+                        OnlineManager.lobby.configurableFloats = ls.onlineFloatRemixSettings;
+                        OnlineGameMode.SetClientRemixSettings(OnlineManager.lobby.configurableBools, OnlineManager.lobby.configurableFloats, OnlineManager.lobby.configurableInts);
+                        RainMeadow.Debug($"Reset client remix settings");
+                    }
                 }
 
             }

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -443,21 +443,20 @@ namespace RainMeadow
 
         public void OnPlayerDisconnect(OnlinePlayer player)
         {
-            //RainMeadow.Debug(this);
+            RainMeadow.Debug(this);
             if (this is Lobby lobby && owner == player) // lobby owner has left
             {
                 RainMeadow.Debug($"Lobby owner {player} left!!!");
                 NewOwner(MatchmakingManager.currentInstance.GetLobbyOwner());
-                if (OnlineManager.lobby != null && OnlineManager.lobby.isOwner)
-                    {
-                        for (int i =0; i< OnlineManager.players.Count; i++)
-                        {
-                            if (OnlineManager.players[i] != null && !OnlineManager.players[i].isMe)
-                            {
-                                OnlineManager.players[i].InvokeOnceRPC(RPCs.ResetClientRemixSettings);
-                            }
-                        }
-                    }
+                if (OnlineManager.lobby != null && OnlineManager.lobby?.state is Lobby.LobbyState ls && !OnlineManager.lobby.isOwner)
+                {
+                    OnlineManager.lobby.configurableBools = ls.onlineBoolRemixSettings;
+                    OnlineManager.lobby.configurableInts = ls.onlineIntRemixSettings;
+                    OnlineManager.lobby.configurableFloats = ls.onlineFloatRemixSettings;
+                    OnlineGameMode.SetClientRemixSettings(OnlineManager.lobby.configurableBools, OnlineManager.lobby.configurableFloats, OnlineManager.lobby.configurableInts);
+                    RainMeadow.Debug($"Reset client remix settings");
+                }
+
             }
 
             // first transfer recursivelly, then remove recursivelly


### PR DESCRIPTION
- [x] Call SetClientRemixSettings
- [x] We don't need RPC everyone runs this 
- [x] Need to call ModManager.Reset() to read from disk for host 