### PR TITLE
Adding Jolly Coop as high impact

### DIFF
--- a/ModManager/RainMeadowModInfoManager.cs
+++ b/ModManager/RainMeadowModInfoManager.cs
@@ -9,6 +9,10 @@ namespace RainMeadow;
 public static class RainMeadowModInfoManager
 {
     private static string ModInfoFileName => "rainmeadow.json";
+    
+    public static List<string> ForcedHighImpactModsID { get; private set; } = new(){
+        "jollycoop"
+    };
 
     /// <summary>
     /// All the loaded Rain Meadow modinfos merged together, so that all information can be accessed at once.
@@ -104,7 +108,7 @@ public static class RainMeadowModInfoManager
         var modInfo = new RainMeadowModInfo();
 
         // TODO: consider mod.modifiesRegions
-        if (Directory.Exists(Path.Combine(mod.path, "modify", "world")))
+        if (Directory.Exists(Path.Combine(mod.path, "modify", "world")) || ForcedHighImpactModsID.Contains(mod.id))
         {
             modInfo.SyncRequiredMods.Add(mod.id);
         }


### PR DESCRIPTION
Since Jolly Coop do impact slugcats enum, and I've seen it lead to crash quite alot, I think making it high impact is fair game...? I struggled abit to find the right place where the high impact mods are marqued, and the system is quite neat ngl. (I hope I'm in the right place)

I've decided to create a list of string instead of putting a hardcoded id for 1 specific mod. It might be useful for y'all later on... or not. I'm unsure about if the List<string> should be fully private, or made another way. I leave the judgment to more competent coders.