### PR TITLE
fix: grabbedBy removing list item during iteration

### DIFF
--- a/Online/Entity/OnlinePhysicalObject.cs
+++ b/Online/Entity/OnlinePhysicalObject.cs
@@ -438,7 +438,8 @@ namespace RainMeadow
 
             if (apo.realizedObject is PhysicalObject po)
             {
-                foreach (Creature.Grasp grabbedBy in po.grabbedBy)
+                // Release removes the grasp from grabbedBy list, so we can't directly enumerate the list
+                foreach (Creature.Grasp grabbedBy in po.grabbedBy.ToList())
                 {
                     grabbedBy.Release();
                 }


### PR DESCRIPTION
Not sure this matters much as I haven't directly linked it to any problems during gameplay, but the error in the logs is really annoying me.

If performance is a concern, then the list can also be manually iterated through backwards, but it seems unnecessary considering how infrequently it gets run anyways and this way is more readable.