### PR TITLE
Acquire public libs via NuGet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,34 +45,16 @@ Before you will be able to make a mod, you need the following:
 
 ### Assemblies
 
-Dependencies aren't included in the repo for several reasons. You will need to add the following assemblies to the `lib/` folder:
+Some BepInEx and Unity dependencies will be downloaded automatically, however you will need to add the following assemblies to the `lib/` folder:
 
 ```
-BepInEx/core/0Harmony.dll
-BepInEx/core/BepInEx.Harmony.dll
-BepInEx/core/BepInEx.dll
-BepInEx/core/HarmonyXInterop.dll
-BepInEx/core/Mono.Cecil.dll
-BepInEx/core/MonoMod.RuntimeDetour.dll
-BepInEx/core/MonoMod.Utils.dll
-BepInEx/core/MonoMod.dll
 BepInEx/plugins/HOOKS-Assembly-CSharp.dll
 BepInEx/utils/PUBLIC-Assembly-CSharp.dll
 RainWorld_Data/Managed/Assembly-CSharp-firstpass.dll
 RainWorld_Data/Managed/com.rlabrecque.steamworks.net.dll
-RainWorld_Data/Managed/Newtonsoft.Json.dll
 RainWorld_Data/Managed/Rewired.Runtime.dll
 RainWorld_Data/Managed/Rewired_Core.dll
 RainWorld_Data/Managed/Unity.Mathematics.dll
-RainWorld_Data/Managed/UnityEngine.AssetBundleModule.dll
-RainWorld_Data/Managed/UnityEngine.AudioModule.dll
-RainWorld_Data/Managed/UnityEngine.CoreModule.dll
-RainWorld_Data/Managed/UnityEngine.InputLegacyModule.dll
-RainWorld_Data/Managed/UnityEngine.ImageConversionModule.dll
-RainWorld_Data/Managed/UnityEngine.IMGUIModule.dll
-RainWorld_Data/Managed/UnityEngine.JSONSerializeModule.dll
-RainWorld_Data/Managed/UnityEngine.UnityWebRequestModule.dll
-RainWorld_Data/Managed/UnityEngine.dll
 ```
 
 ## Guidelines

--- a/Rain Meadow.csproj
+++ b/Rain Meadow.csproj
@@ -8,6 +8,10 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<Configurations>Debug;Release</Configurations>
 		<RootNamespace>RainMeadow</RootNamespace>
+		<RestoreAdditionalProjectSources>
+			https://nuget.bepinex.dev/v3/index.json;
+			https://nuget.samboy.dev/v3/index.json
+		</RestoreAdditionalProjectSources>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
@@ -22,6 +26,12 @@
 
 	<ItemGroup>
 		<Reference Include="lib\*.dll" Private="False" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="BepInEx.Core" Version="5.4.17" />
+	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+	  <PackageReference Include="UnityEngine.Modules" Version="2020.3.45" IncludeAssets="compile" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Rain Meadow.csproj
+++ b/Rain Meadow.csproj
@@ -8,6 +8,9 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<Configurations>Debug;Release</Configurations>
 		<RootNamespace>RainMeadow</RootNamespace>
+		<RestoreAdditionalProjectSources>
+			https://nuget.bepinex.dev/v3/index.json
+		</RestoreAdditionalProjectSources>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
@@ -19,6 +22,12 @@
 	<PropertyGroup>
 		<PathMap>$(MSBuildThisFileDirectory.Replace(',', ',,').Replace('=', '=='))=/</PathMap>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="BepInEx.Core" Version="5.4.17" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="UnityEngine.Modules" Version="2020.3.45" IncludeAssets="compile" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<Reference Include="lib\*.dll" Private="False" />


### PR DESCRIPTION
Modifies the project file to use package references to acquire BepInEx core libs, UnityEngine modules, and Newtonsoft.Json, which mirrors BepInEx plugin template behavior so only references to game specific code are manually included.
This change was primarily motivated by Newtonsoft.Json not being bundled in rain world anymore making it a bit tedious to setup the project initially. That main qualm has been solved and the bepinex and unity modules are nice extras, other public libraries the game uses are Steamworks.NET and Unity.Mathematics but I was unable to determine the versions in use by rain world to add those references, so this is fine for now.