### PR TITLE
undo:  rollback scav animation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - ⚠️ BREAKING: Moved all arena `arena.Killing` to reside inside of `arena.ExternalGameMode` and removed the `playerIndex` param
 ## Story
 - Fixed the "Wait for others to rescue you" death prompt blocking pause inputs.
+- Rolled back Scavenger animation sync to prevent major desync scenarios
 ### Watcher
 - Impossibly high ripple levels (6+) no longer crash the game when viewed.
 

--- a/Online/State/RealizedScavengerState.cs
+++ b/Online/State/RealizedScavengerState.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace RainMeadow
 {
-    
+
     public class RealizedScavengerState : RealizedCreatureState
     {
 
@@ -141,7 +141,7 @@ namespace RainMeadow
 
         public abstract class AttentiveAnimationState : AnimationState
         {
-            
+
             [OnlineField(group = "attentiveAnim", nullable = true)]
             public OnlineEntity.EntityId? creature;
 
@@ -175,7 +175,7 @@ namespace RainMeadow
                 {
                     anim.creatureRep = scavenger.AI.tracker.RepresentationForCreature(critter.abstractCreature, true);
                 }
-                
+
             }
         }
 
@@ -198,7 +198,7 @@ namespace RainMeadow
                 {
                     rep = scavenger.AI.tracker.RepresentationForCreature(critter.creature, true);
                 }
-                
+
                 return new Scavenger.LookAnimation(scavenger, rep, point, prio, stop);
             }
 
@@ -252,7 +252,7 @@ namespace RainMeadow
                 {
                     rep = scavenger.AI.tracker.RepresentationForCreature(critter.creature, true);
                 }
-                
+
                 List<Tracker.CreatureRepresentation> groupRep = new(group.list.Select(x => x.FindEntity()).OfType<OnlineCreature>().Select(x => scavenger.AI.tracker.RepresentationForCreature(x.creature, true)));
                 return new Scavenger.GeneralPointAnimation(scavenger, rep, point, groupRep);
             }
@@ -301,7 +301,7 @@ namespace RainMeadow
                 {
                     rep = scavenger.AI.tracker.RepresentationForCreature(critter.creature, true);
                 }
-                
+
                 return new Scavenger.BackOffAnimation(scavenger, rep, point);
             }
 
@@ -343,7 +343,7 @@ namespace RainMeadow
             {
                 wantID = animation.desiredItem?.abstractPhysicalObject.GetOnlineObject()?.id;
             }
-            
+
 
             public override Scavenger.ScavengerAnimation.ID GetAnimationID() => Scavenger.ScavengerAnimation.ID.WantToTrade;
             public override Scavenger.ScavengerAnimation? ConstructAnimation(Scavenger scavenger)
@@ -369,7 +369,7 @@ namespace RainMeadow
         public class PrepareToJumpAnimationState : AnimationState
         {
             [OnlineField]
-            byte filler = 0; 
+            byte filler = 0;
 
             public PrepareToJumpAnimationState() { }
             public PrepareToJumpAnimationState(Scavenger.PrepareToJumpAnimation animation) : base(animation) { }
@@ -386,7 +386,7 @@ namespace RainMeadow
         public class JumpingAnimationState : AnimationState
         {
             [OnlineField]
-            byte filler = 0; 
+            byte filler = 0;
 
             public JumpingAnimationState() { }
             public JumpingAnimationState(Scavenger.JumpingAnimation animation) : base(animation)
@@ -424,8 +424,8 @@ namespace RainMeadow
         private Scavenger.MovementMode? movementMode;
 
 
-        [OnlineField(polymorphic = true, nullable = true)]
-        private AnimationState? animationState;
+        // [OnlineField(polymorphic = true, nullable = true)]
+        // private AnimationState? animationState;
 
         [OnlineField(group = "look")]
         Vector2 lookPoint;
@@ -442,7 +442,7 @@ namespace RainMeadow
             this.flip = scav.flip;
             this.kingWaiting = scav.kingWaiting;
             this.movementMode = scav.movMode;
-            this.animationState = AnimationState.GetAnimationState(scav.animation);
+            //this.animationState = AnimationState.GetAnimationState(scav.animation);
             this.swingClimbCounter = (byte)scav.swingClimbCounter;
             this.swingArm = (byte)scav.swingArm;
 
@@ -452,7 +452,7 @@ namespace RainMeadow
             {
                 this.lookAtEntity = critter.id;
             }
-            
+
         }
 
         public override void ReadTo(OnlineEntity onlineEntity)
@@ -470,25 +470,25 @@ namespace RainMeadow
 
                 // for some reason king's direct away from throne animation uses the Back off id despite being a different animation
                 // thanks MSC
-                if (animationState != null)
-                {
-                    if (!kingWaiting)
-                    {
-                        if (scav.animation is null || (scav.animation?.id != animationState.GetAnimationID()))
-                        {
-                            scav.animation = animationState.ConstructAnimation(scav);
-                        }
+                // if (animationState != null)
+                // {
+                //     if (!kingWaiting)
+                //     {
+                //         if (scav.animation is null || (scav.animation?.id != animationState.GetAnimationID()))
+                //         {
+                //             scav.animation = animationState.ConstructAnimation(scav);
+                //         }
 
-                        if (scav.animation is not null)
-                        {
-                            animationState.ReadTo(scav, scav.animation);
-                        }
-                    }
-                }
-                else
-                {
-                    scav.animation = null;
-                }
+                //         if (scav.animation is not null)
+                //         {
+                //             animationState.ReadTo(scav, scav.animation);
+                //         }
+                //     }
+                // }
+                // else
+                // {
+                //     scav.animation = null;
+                // }
 
                 if (scav.critLooker is not null)
                 {


### PR DESCRIPTION
Problem: Delta tries to cast for animation state, fails when there's a animation state mismatch, this creates a major  network disruption.   


```
[Error  :RainMeadow] System.InvalidCastException: Specified cast is not valid.
  at (wrapper dynamic-method) 
...

  at RainMeadow.Generics.DynamicIdentifiablesPrimaryDeltaList4+<>c__DisplayClass7_0[T,U,W,Imp].<Delta>b__0 (T e) [0x00000] in /Online/Serialization/Generics.cs:432 
  at System.Linq.Enumerable+SelectListIterator2[TSource,TResult].MoveNext ()
```

This leads back to Generics.cs:

```
        public Imp Delta(Imp baseline)
        {
            if (baseline == null) { return (Imp)this; }
            Imp delta = new();
            delta.list = list.Select(e => baseline.lookup.TryGetValue(e.ID, out var b) ? (T)e.Delta(b) : e).Where(sl => !sl.IsEmptyDelta).ToList();
            delta.removed = baseline.list.Select(e => e.ID).Where(e => !lookup.ContainsKey(e)).ToList();
            delta.BuildLookup();
            return (delta.list.Count == 0 && delta.removed.Count == 0) ? null : delta;
        }
```

this bubbles up into AbstractCreatureStateState and RoomState and can lead to major game disruption.

I don't know how to fix this at the moment, so I'm proposing removing its implementation until a solution can be found while preserving invalid's work and restoring general functionality with Scavengers in the meantime.