### PR TITLE
Fix resetting spectator on menu ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed meadow abyss respawns and arena/story abyss death messages failing if the player entered WallCling between -250y and -500y.
 - Fixed neuron glow not using players' selected body color.
 - Fixed infinite tinnitus for real this time.
+- Fixed your spectated scug resetting every time you opened the spectate menu.
 ## Arena
 - If MSC is enabled, closed dens will mirror challenge mode by eventually forcing players out, and completely blocking reentry attempts.
 - Added More Slugcat's "Challenges" to Arena! 

--- a/OnlineUIComponents/SpectatorHud.cs
+++ b/OnlineUIComponents/SpectatorHud.cs
@@ -36,6 +36,7 @@ namespace RainMeadow
                 {
                     RainMeadow.Debug("Creating spectator overlay");
                     spectatorOverlay = new SpectatorOverlay(game.manager, game, camera);
+                    spectatorOverlay.spectatee = spectatee;
                     if (SpecialEvents.IsSpecialEventInLobby)
                     {
                         holidayStoreOverlay = new HolidayStoreOverlay(game.manager, game);
@@ -164,6 +165,7 @@ namespace RainMeadow
             }
 
             OnlineManager.mePlayer.isActuallySpectating = spectatee != null && !spectatee.IsLocal();
+            RainMeadow.Warn((spectatorOverlay == null ? "null" : spectatorOverlay.spectatee) + " " + (spectatee == null ? "null" : spectatee));
             if (spectatee != null)
             {
                 camera.followAbstractCreature = spectatee;


### PR DESCRIPTION
Fixed an issue where opening the spectator menu would stop spectating anyone, if you weren't already spectating yourself.