### PR TITLE
Disable unwanted room specific scripts in meadow mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@
 - Impossibly high ripple levels (6+) no longer crash the game when viewed.
 
 ## Meadow
-- Fixed a number of story-related handlers loading into meadow mode when they shouldn't:
-	- The pounce tutorial barrier in SU_A43 no longer loads in.
-	- The jetfish tutorial (and its jetfish) in SL_C12 no longer load in.
-	- Slugcats can now pass SB_D03 (depths guardian room) even if remix's "Vanilla Exploits" is disabled.
+- Slugcats can now enter the lower depths regardless of remix's "Vanilla Exploits".
+- MS_CORE and Saint's intro rooms should no longer break the rain timer and/or game.
+- The pounce tutorial and SU_PMPSTATION01 barriers no longer load in.
+- The guaranteed jetfish in SL, and the three guaranteed scav corpses in Artificer's GW no longer load in.
+- Many different room-specific tooltips across all campaigns are now disabled.
 
 # Release 1.12.0
 ## Arena

--- a/Meadow/RainMeadow.MeadowHooks.cs
+++ b/Meadow/RainMeadow.MeadowHooks.cs
@@ -432,15 +432,40 @@ namespace RainMeadow
         }
         private void Meadow_RoomSpecificScript_AddRoomSpecificScript(On.RoomSpecificScript.orig_AddRoomSpecificScript orig, Room room)
         {
-            if (OnlineManager.lobby.gameMode is MeadowGameMode)
+            if (OnlineManager.lobby.gameMode is MeadowGameMode) //Blacklist problematic scripts
             {
                 switch (room.abstractRoom.name)
                 {
-                    case "SL_C12": return;
-                    case "SB_D03": return;
-                    case "SU_A43": return;
+                    case "SU_A43": return; //Pounce tutorial
+                    case "SL_C12": return; //Jetfish tutorial
+                    case "SB_D03": return; //Depths guardian room exit lock
+
+                    case "LF_A03": return; //Hunter mechanics tutorial
+                }
+                if (ModManager.MSC)
+                {
+                    switch (room.abstractRoom.name)
+                    {
+                        case "SU_PMPSTATION01": return; //One-way water tunnel blocking SU to OE
+                        case "MS_CORE":         return; //Submerged Superstructure rarefaction cell cutscene
+
+                        case "OE_FINAL03":      return; //Outer Expanse ending trigger
+
+                        case "GW_C05":          return; //Artificer explosive jump tooltip #1
+                        case "GW_EDGE02":       return; //Artificer explosive jump tooltip #2
+                        case "GW_EDGE03":       return; //Artificer guaranteed scav corpse #1
+                        case "GW_TOWER01":      return; //Artificer guaranteed scav corpse #2
+                        case "GW_PIPE02":       return; //Artificer guaranteed scav corpse #3
+
+                        case "SU_INTRO01":      return; //Spearmaster needle pull tooltip
+                        case "SU_CAVE_02":      return; //Spearmaster feeding tooltip
+
+                        case "SI_SAINTINTRO":   return; //Saint tongue tutorial
+                        case "SI_C02":          return; //Saint heat tutorial
+                    }
                 }
             }
+
             orig(room);
         }
     }


### PR DESCRIPTION
Fixes a lot of leftover story-related triggers still appearing in meadow mode. Should mostly be straight-forward, the only weird one is removing the SU_PMPSTATION01 one-way barrier; my logic is that Meadow is for exploration, so it seems weird to keep an unneeded one-way, especially when it's so easy to remove. Can easily revert if wanted.

This does _not_ fix certain triggers that need to exist but still cause problems, namely the outskirts starting room tutorial, certain puppet behaviors, and the OE transition to facility roots.