### PR TITLE
fix: defer deregistration to prevent null entity but present states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Release 1.14.0
+
+# Engine
+- Fixed a scenario where transferring entities could lead to deadlocks
+
 # Release 1.13.1
 ## General
 - Fixed Hunter_Illness IL Hook

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -252,7 +252,8 @@ namespace RainMeadow
             }
             if (primaryResource == null && !isPending)
             {
-                Deregister();
+                // let those last state packets come in first
+                OnlineManager.RunDeferred(() => Deregister());
             }
         }
 
@@ -395,33 +396,33 @@ namespace RainMeadow
 
         public virtual void ReadState(EntityState entityState, OnlineResource inResource)
         {
-                lastStates[inResource] = entityState;
-                StateProfiler.Instance?.Push(entityState.GetType());
-                entityState.ReadTo(this);
-                StateProfiler.Instance?.Pop(entityState.GetType());
+            lastStates[inResource] = entityState;
+            StateProfiler.Instance?.Push(entityState.GetType());
+            entityState.ReadTo(this);
+            StateProfiler.Instance?.Pop(entityState.GetType());
 
         }
 
-        public virtual bool CanReadTo(EntityState entityState, OnlineResource inResource, uint tick) 
+        public virtual bool CanReadTo(EntityState entityState, OnlineResource inResource, uint tick)
         {
             var entity = entityState.entityId.FindEntity();
             if (entity == null)
             {
                 RainMeadow.Error($"CanReadTo: Entity state cannot readto. Reason: entity.FindEntity() is null: {entityState.from}, {entityState.entityId}");
                 return false;
-            } 
+            }
 
             var localState = entity.GetState(tick, inResource);
             if (localState == null)
             {
                 RainMeadow.Error($"CanReadTo: Entity state cannot readto. Reason: localState.GetState() is null");
                 return false;
-            } 
+            }
 
 
             if (!entityState.GetType().IsAssignableFrom(localState.GetType()))
             {
-            RainMeadow.Error($"CanReadTo: Is not assignable EntityState: {entityState.GetType()}, localState: {localState.GetType()}:  {entityState.GetType().IsAssignableFrom(localState.GetType())}");
+                RainMeadow.Error($"CanReadTo: Is not assignable EntityState: {entityState.GetType()}, localState: {localState.GetType()}:  {entityState.GetType().IsAssignableFrom(localState.GetType())}");
             }
 
             return entityState.GetType().IsAssignableFrom(localState.GetType());

--- a/Online/Entity/OnlineEntity.cs
+++ b/Online/Entity/OnlineEntity.cs
@@ -252,8 +252,16 @@ namespace RainMeadow
             }
             if (primaryResource == null && !isPending)
             {
-                // let those last state packets come in first
-                OnlineManager.RunDeferred(() => Deregister());
+                if (inResource is WorldSession or RoomSession)
+                {
+                    // let those last state packets come in first
+                    OnlineManager.RunDeferred(() => Deregister());
+                }
+                else
+                {
+                    Deregister();
+                }
+
             }
         }
 


### PR DESCRIPTION
- [x] Playtest


After a number of playtests, This seems to work well enough to manage soft locks where the entity is null when an in-game resource is removed. 

Would like your thoughts on it. 