### PR TITLE
fix: arena score curses

### DIFF
--- a/Arena/ArenaHelpers.cs
+++ b/Arena/ArenaHelpers.cs
@@ -307,10 +307,6 @@ namespace RainMeadow
                             .TryGetData<ArenaTeamClientSettings>(out var tb2)
                     )
                     {
-                        if (tb1.team == tb2.team && !arena.friendlyFire)
-                        {
-                            RainMeadow.Debug("Same team! No hits");
-                        }
                         return tb1.team == tb2.team
                             && !arena.friendlyFire
                             && creature.State.alive

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1907,6 +1907,7 @@ namespace RainMeadow
         {
             if (isArenaMode(out var arena))
             {
+                RainMeadow.DebugMe();
                 if (
                     self.sessionEnded
                     || self.GameTypeSetup.spearHitScore == 0
@@ -1930,16 +1931,18 @@ namespace RainMeadow
                     )
                     {
                         RainMeadow.Error("Could not get PlayerLandSpear player");
+                        continue;
                     }
                     var onlineArenaPlayer = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(
                         arena,
                         self.arenaSitting.players[i].playerNumber
                     );
 
-                    if (op.owner != onlineArenaPlayer)
+                    if (op.owner != onlineArenaPlayer || onlineArenaPlayer == null)
                     {
                         continue;
                     }
+                    RainMeadow.Debug("ArenaGameSession_PlayerLandSpear: Executing");
                     arena.externalArenaGameMode.LandSpear(
                         arena,
                         self,

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -131,8 +131,12 @@ namespace RainMeadow
             [OnlineField(group = "arenaSetup")]
             public bool enableOverseer;
 
+
             [OnlineField(group = "arenaSetup")]
-            public int spearScore;
+            public int spearHitScore;
+
+            [OnlineField(group = "arenaSetup")]
+            public int killScore;
 
             [OnlineField(group = "arenaSetup")]
             public int aliveScore;
@@ -264,7 +268,9 @@ namespace RainMeadow
                 friendlyFire = arena.friendlyFire;
                 enableOverseer = arena.enableOverseer;
 
-                spearScore = arena.spearScore;
+                spearHitScore = arena.spearHitScore;
+
+                killScore = arena.killScore;
                 aliveScore = arena.aliveScore;
                 denRule = arena.denEntryRule;
                 denScore = arena.denScore;
@@ -354,7 +360,9 @@ playerNumberWithTrophiesPerRound;
                 (lobby.gameMode as ArenaOnlineGameMode).friendlyFire = friendlyFire;
                 (lobby.gameMode as ArenaOnlineGameMode).enableOverseer = enableOverseer;
 
-                (lobby.gameMode as ArenaOnlineGameMode).spearScore = spearScore;
+                (lobby.gameMode as ArenaOnlineGameMode).spearHitScore = spearHitScore;
+
+                (lobby.gameMode as ArenaOnlineGameMode).killScore = killScore;
                 (lobby.gameMode as ArenaOnlineGameMode).aliveScore = aliveScore;
                 (lobby.gameMode as ArenaOnlineGameMode).denEntryRule = denRule;
                 (lobby.gameMode as ArenaOnlineGameMode).denScore = denScore;

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -57,7 +57,7 @@ namespace RainMeadow
         {
             self.foodScore = 1;
             self.survivalScore = arena.aliveScore;
-            self.spearHitScore = arena.spearScore;
+            self.spearHitScore = arena.spearHitScore;
             self.repeatSingleLevelForever = false;
             self.savingAndLoadingSession = true;
             self.denEntryRule = arena.denEntryRule;
@@ -210,7 +210,7 @@ namespace RainMeadow
 
             }
             // 6. Handle Scoring 
-            int scoreToAdd = arena.spearScore; // Default fallback
+            int scoreToAdd = arena.killScore; // Default fallback
             if (arena.externalArenaGameMode is ArenaChallengeMode)
             {
                 int index = MultiplayerUnlocks.SandboxUnlockForSymbolData(iconSymbolData).Index;
@@ -219,20 +219,11 @@ namespace RainMeadow
 
             // this is set locally because we return if the victim is not ours, so we need to notify everyone of this update
             self.arenaSitting.players[targetPlayerNumber].score += scoreToAdd;
-
             if (isLobbyOwner) // host creature was killed
             {
 
                 arena.playerNumberWithScore[lobbyId] += scoreToAdd;
-
-                for (int x = 0; x < rs.participants.Count; x++)
-                {
-                    if (rs.participants[x].isMe)
-                    {
-                        continue;
-                    }
-                    rs.participants[x].InvokeOnceRPC(ArenaRPCs.UpdatePlayerScore, targetPlayerNumber, arena.playerNumberWithScore[lobbyId]);
-                }
+                onlineKilledCreature.BroadcastRPCInRoomExceptOwners(ArenaRPCs.UpdatePlayerScore, targetPlayerNumber, arena.playerNumberWithScore[lobbyId]);
             }
             else // my creature, not host - tell the room
             {
@@ -276,7 +267,33 @@ namespace RainMeadow
             Creature target,
             ArenaSitting.ArenaPlayer aPlayer
         )
-        { }
+        {
+
+            if (target is Player pl && pl.State is PlayerState st && st.permanentDamageTracking >= 1)
+            {
+                RainMeadow.Warn("Player_LandSpearPlayer is going to die and this will corrupt killing score, returning");
+                return;
+            }
+            aPlayer.AddSandboxScore(arena.spearHitScore);
+            if (OnlineManager.lobby.isOwner)
+            {
+
+                OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, aPlayer.playerNumber);
+                if (onlinePlayer == null)
+                {
+                    return;
+                }
+                if (arena.playerNumberWithScore[onlinePlayer.inLobbyId] < aPlayer.score)
+                {
+                    arena.playerNumberWithScore[onlinePlayer.inLobbyId] += aPlayer.score;
+                }
+                player.abstractCreature.GetOnlineCreature()?.BroadcastRPCInRoomExceptOwners(ArenaRPCs.UpdatePlayerScore, aPlayer.playerNumber, arena.playerNumberWithScore[onlinePlayer.inLobbyId]);
+            }
+            else
+            {
+                player.abstractCreature.GetOnlineCreature()?.BroadcastRPCInRoom(ArenaRPCs.UpdatePlayerScore, aPlayer.playerNumber, aPlayer.score);
+            }
+        }
 
         public virtual void HUD_InitMultiplayerHud(
             ArenaOnlineGameMode arena,

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -274,6 +274,12 @@ namespace RainMeadow
                 RainMeadow.Warn("Player_LandSpearPlayer is going to die and this will corrupt killing score, returning");
                 return;
             }
+            if (TeamBattleMode.isTeamBattleMode(arena, out _) && ArenaHelpers.CheckSameTeam(player.abstractCreature.GetOnlineCreature()?.owner, target.abstractCreature.GetOnlineCreature()?.owner))
+            {
+                RainMeadow.Warn("Player_LandSpearPlayer: Players on same team, returning");
+                return;
+            }
+
             aPlayer.AddSandboxScore(arena.spearHitScore);
             if (OnlineManager.lobby.isOwner)
             {

--- a/Arena/ArenaOnlineGameModes/Competitive.cs
+++ b/Arena/ArenaOnlineGameModes/Competitive.cs
@@ -104,17 +104,6 @@ namespace RainMeadow
             }
         }
 
-        public override void LandSpear(
-            ArenaOnlineGameMode arena,
-            ArenaGameSession self,
-            Player player,
-            Creature target,
-            ArenaSitting.ArenaPlayer aPlayer
-        )
-        {
-            aPlayer.AddSandboxScore(self.GameTypeSetup.spearHitScore);
-        }
-
         public override string AddIcon(
             ArenaOnlineGameMode arena,
             OnlinePlayerDisplay display,

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
@@ -210,6 +210,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                     );
                 }
             }
+            ClearSortingDictionaries();
         }
 
         public int CalculateTeamScoresAndWinner(

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
@@ -176,16 +176,6 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
             }
         }
 
-        public override void LandSpear(
-            ArenaOnlineGameMode arena,
-            ArenaGameSession self,
-            Player player,
-            Creature target,
-            ArenaSitting.ArenaPlayer aPlayer
-        )
-        {
-            aPlayer.AddSandboxScore(self.GameTypeSetup.spearHitScore);
-        }
 
         public override void ArenaSessionCtor(
             ArenaOnlineGameMode arena,

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -114,7 +114,6 @@ namespace RainMeadow
 
                 if (a.arenaSitting.players[playerNumber].score < newScore)
                 {
-
                     a.arenaSitting.players[playerNumber].score = newScore;
                     if (OnlineManager.lobby.isOwner)
                     {

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -34,6 +34,7 @@ namespace RainMeadow
         [RPCMethod]
         public static void DistributeEmptyKillScores(int excludedPlayerNumber)
         {
+            RainMeadow.DebugMe();
             if (!OnlineManager.lobby.isOwner) return;
 
             if (RWCustom.Custom.rainWorld.processManager.currentMainLoop is not RainWorldGame { session: ArenaGameSession session }) return;
@@ -89,6 +90,7 @@ namespace RainMeadow
         [RPCMethod]
         public static void UpdatePlayerScore(int playerNumber, int newScore)
         {
+            RainMeadow.DebugMe();
             if (!RainMeadow.isArenaMode(out var arena)) return;
 
             OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, playerNumber);

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -91,7 +91,10 @@ public class RainMeadowOptions : OptionInterface
     public readonly Configurable<Color> currentlyActiveCapeColor;
     public readonly Configurable<int> ChallengeID;
 
-    public readonly Configurable<int> ArenaSpearScore;
+
+    public readonly Configurable<int> ArenaSpearHitScore;
+    public readonly Configurable<int> ArenaKillScore;
+
     public readonly Configurable<int> ArenaAliveScore;
     public readonly Configurable<int> ArenaDenScore;
 
@@ -229,7 +232,9 @@ public class RainMeadowOptions : OptionInterface
         boughtGoldenCape = config.Bind("BoughtGoldenCape", false);
         boughtRainbowCape = config.Bind("BoughtRainbowCape", false);
         currentlyActiveCapeColor = config.Bind("CurrentlyActiveCapeColor", Color.red);
-        ArenaSpearScore = config.Bind("ArenaSpearScore", 0);
+
+        ArenaSpearHitScore = config.Bind("ArenaSpearHitScore", 0);
+        ArenaKillScore = config.Bind("ArenaKillScore", 0);
         ArenaAliveScore = config.Bind("ArenaAliveScore", 0);
         ArenaDenScore = config.Bind("ArenaDenScore", 0);
 

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -56,14 +56,16 @@ namespace RainMeadow
 
         public bool friendlyFire = RainMeadow.rainMeadowOptions.FriendlyFire.Value;
 
-        public int spearScore = RainMeadow.rainMeadowOptions.ArenaSpearScore.Value;
+        public int spearHitScore = RainMeadow.rainMeadowOptions.ArenaSpearHitScore.Value;
+
+        public int killScore = RainMeadow.rainMeadowOptions.ArenaKillScore.Value;
         public int aliveScore = RainMeadow.rainMeadowOptions.ArenaAliveScore.Value;
         public ArenaSetup.GameTypeSetup.DenEntryRule denEntryRule = RainMeadow.rainMeadowOptions.ArenaDenType.Value;
         public int denScore = RainMeadow.rainMeadowOptions.ArenaDenScore.Value;
 
         public int emptyKillTagScore = RainMeadow.rainMeadowOptions.ArenaDenScore.Value;
 
-        public bool winByScore => spearScore > 0 || aliveScore > 0 || emptyKillTagScore > 0 || externalArenaGameMode is ArenaChallengeMode;
+        public bool winByScore => killScore > 0 || aliveScore > 0 || emptyKillTagScore > 0 || spearHitScore > 0 || externalArenaGameMode is ArenaChallengeMode;
         public bool challengeDenEjection = RainMeadow.rainMeadowOptions.ChallengeDenEjection.Value;
 
         public string paincatName;
@@ -137,7 +139,7 @@ namespace RainMeadow
             .ArenaSaintAscendanceTimer
             .Value;
 
-        public int artiExplosionCount = MoreSlugcats.MoreSlugcats.cfgArtificerExplosionCapacity.Value;
+        public int artiExplosionCount = ModManager.MSC ? MoreSlugcats.MoreSlugcats.cfgArtificerExplosionCapacity.Value : 0;
         public int watcherCamoTimer = RainMeadow.rainMeadowOptions.ArenaWatcherCamoTimer.Value;
         public int watcherRippleLevel = RainMeadow.rainMeadowOptions.ArenaWatcherRippleLevel.Value;
         public int amoebaDuration = RainMeadow.rainMeadowOptions.AmoebaDuration.Value;
@@ -185,7 +187,8 @@ namespace RainMeadow
             leaveForNextLevel = false;
             lobbyCountDown = 5;
             initiateLobbyCountdown = false;
-            spearScore = 0;
+            spearHitScore = 0;
+            killScore = 0;
             aliveScore = 0;
             hostLoadedOverlay = false;
 

--- a/Menu/Components/ArenaBaseGamemodeTab.cs
+++ b/Menu/Components/ArenaBaseGamemodeTab.cs
@@ -16,8 +16,11 @@ namespace RainMeadow.UI.Components
         : RectangularMenuObject
     {
         public MenuTabWrapper tabWrapper;
-        public MenuLabel spearScoreLabel;
-        public OpTextBox spearScoreTextBox;
+
+        public MenuLabel spearHitScoreLabel;
+        public OpTextBox spearHitScoreTextBox;
+        public MenuLabel killScoreLabel;
+        public OpTextBox killScoreTextBox;
         public MenuLabel aliveScoreLabel;
         public OpTextBox aliveScoreTextBox;
         public MenuLabel denEntryRuleLabel;
@@ -62,32 +65,52 @@ namespace RainMeadow.UI.Components
             float rowHeight = 40f;
             float boxMargin = leftMargin + labelWidth + 50f; // The X-position for all boxes
 
-            // --- Row 1: Spear Score ---
-            spearScoreLabel = new(menu, this, menu.Translate("Kill Score:"),
-                new(leftMargin, topOffset), new(labelWidth, 20f), false);
-            spearScoreLabel.label.alignment = FLabelAlignment.Left;
+            // --- Row 0: Spear Hit Score ---
 
-            spearScoreTextBox = new(RainMeadow.rainMeadowOptions.ArenaSpearScore,
+            spearHitScoreLabel = new(menu, this, menu.Translate("Spear Hit Score:"),
+                new(leftMargin, topOffset), new(labelWidth, 20f), false);
+            spearHitScoreLabel.label.alignment = FLabelAlignment.Left;
+
+            spearHitScoreTextBox = new(RainMeadow.rainMeadowOptions.ArenaSpearHitScore,
                 new(boxMargin, topOffset - 2f), 60)
+            {
+                alignment = FLabelAlignment.Center,
+                description = menu.Translate("Points a spear is worth (non-lethal)"),
+                accept = OpTextBox.Accept.Int
+            };
+
+            spearHitScoreTextBox.OnValueUpdate += (config, value, oldValue) =>
+            {
+                if (spearHitScoreTextBox.valueInt < 0) spearHitScoreTextBox.valueInt = 0;
+                arena.spearHitScore = spearHitScoreTextBox.valueInt;
+            };
+
+            // --- Row 1: Kill Score ---
+            killScoreLabel = new(menu, this, menu.Translate("Kill Score:"),
+                new(leftMargin, topOffset - rowHeight), new(labelWidth, 20f), false);
+            killScoreLabel.label.alignment = FLabelAlignment.Left;
+
+            killScoreTextBox = new(RainMeadow.rainMeadowOptions.ArenaKillScore,
+                new(boxMargin, topOffset - rowHeight - 2f), 60)
             {
                 alignment = FLabelAlignment.Center,
                 description = menu.Translate("Points a kill is worth"),
                 accept = OpTextBox.Accept.Int
             };
 
-            spearScoreTextBox.OnValueUpdate += (config, value, oldValue) =>
+            killScoreTextBox.OnValueUpdate += (config, value, oldValue) =>
             {
-                if (spearScoreTextBox.valueInt < 0) spearScoreTextBox.valueInt = 0;
-                arena.spearScore = spearScoreTextBox.valueInt;
+                if (killScoreTextBox.valueInt < 0) killScoreTextBox.valueInt = 0;
+                arena.killScore = killScoreTextBox.valueInt;
             };
 
             // --- Row 2: Win Score ---
             aliveScoreLabel = new(menu, this, menu.Translate("Survival Score:"),
-                new(leftMargin, topOffset - rowHeight), new(labelWidth, 20f), false);
+                new(leftMargin, topOffset - (rowHeight * 2)), new(labelWidth, 20f), false);
             aliveScoreLabel.label.alignment = FLabelAlignment.Left;
 
             aliveScoreTextBox = new(RainMeadow.rainMeadowOptions.ArenaAliveScore,
-                new(boxMargin, topOffset - rowHeight - 2f), 60)
+               new(boxMargin, topOffset - (rowHeight * 2) - 2f), 60)
             { alignment = FLabelAlignment.Center, description = menu.Translate("Points for surviving inside the shelter"), accept = OpTextBox.Accept.Int };
 
             aliveScoreTextBox.OnValueUpdate += (config, value, oldValue) =>
@@ -96,17 +119,30 @@ namespace RainMeadow.UI.Components
                 arena.aliveScore = aliveScoreTextBox.valueInt;
             };
 
+            emptyKillTagScoreLabel = new(menu, this, menu.Translate("Empty Kill Score:"),
+                new(leftMargin, topOffset - rowHeight * 3), new(labelWidth, 20f), false);
+            emptyKillTagScoreLabel.label.alignment = FLabelAlignment.Left;
+
+            emptyKillTagScore = new(RainMeadow.rainMeadowOptions.ArenaEmptyKillTagScore,
+            new(boxMargin, topOffset - (rowHeight * 3)), 60)
+            { alignment = FLabelAlignment.Center, description = menu.Translate("Points for other players if someone dies without a killer"), accept = OpTextBox.Accept.Int };
+
+            emptyKillTagScore.OnValueUpdate += (config, value, oldValue) =>
+            {
+                if (emptyKillTagScore.valueInt < 0) emptyKillTagScore.valueInt = 0;
+                arena.emptyKillTagScore = emptyKillTagScore.valueInt;
+            };
 
             // --- Row 3: Den Score ---
-            denScoreLabel = new(menu, this, menu.Translate("Den Score:"),
-                    new(leftMargin, topOffset - (rowHeight * 2)), new(labelWidth, 20f), false);
+            denScoreLabel = new(menu, this, menu.Translate("Unlock Dens:"),
+                    new(leftMargin, topOffset - (rowHeight * 4)), new(labelWidth, 20f), false);
             denScoreLabel.label.alignment = FLabelAlignment.Left;
 
             denScoreTextBox = new(RainMeadow.rainMeadowOptions.ArenaDenScore,
-                new(boxMargin, topOffset - (rowHeight * 2) - 2f), 60) // FIXED: Added '- (rowHeight * 2)'
+                new(boxMargin, topOffset - (rowHeight * 4) - 2f), 60) // FIXED: Added '- (rowHeight * 2)'
             {
                 alignment = FLabelAlignment.Center,
-                description = menu.Translate("Points required to open dens"),
+                description = menu.Translate("Points required to unlock dens"),
                 accept = OpTextBox.Accept.Int
             };
 
@@ -118,7 +154,7 @@ namespace RainMeadow.UI.Components
 
             // --- Row 4: Den Entry ---
             denEntryRuleLabel = new(menu, this, menu.Translate("Den Entry:"),
-                new(leftMargin, topOffset - (rowHeight * 3)), new(labelWidth, 20f), false);
+                new(leftMargin, topOffset - (rowHeight * 5)), new(labelWidth, 20f), false);
             denEntryRuleLabel.label.alignment = FLabelAlignment.Left;
 
             var denRuleItems = OpResourceSelector.GetEnumNames(null, typeof(ArenaSetup.GameTypeSetup.DenEntryRule))
@@ -130,7 +166,7 @@ namespace RainMeadow.UI.Components
 
             denEntryRule = new OpComboBox2(
                 RainMeadow.rainMeadowOptions.ArenaDenType,
-                new(boxMargin, topOffset - (rowHeight * 3) - 2f),
+                new(boxMargin, topOffset - (rowHeight * 5) - 2f),
                 110,
                 denRuleItems
             )
@@ -146,27 +182,12 @@ namespace RainMeadow.UI.Components
 
 
 
-            emptyKillTagScoreLabel = new(menu, this, menu.Translate("Empty Kill Score:"),
-                new(leftMargin, topOffset - rowHeight * 4), new(labelWidth, 20f), false);
-            emptyKillTagScoreLabel.label.alignment = FLabelAlignment.Left;
-
-            emptyKillTagScore = new(RainMeadow.rainMeadowOptions.ArenaEmptyKillTagScore,
-            new(boxMargin, topOffset - (rowHeight * 4)), 60)
-            { alignment = FLabelAlignment.Center, description = menu.Translate("Points for other players if someone dies without a killer"), accept = OpTextBox.Accept.Int };
-
-            emptyKillTagScore.OnValueUpdate += (config, value, oldValue) =>
-            {
-                if (emptyKillTagScore.valueInt < 0) emptyKillTagScore.valueInt = 0;
-                arena.emptyKillTagScore = emptyKillTagScore.valueInt;
-            };
-
-
 
             challengeDenEjectionLabel = new(menu, this, menu.Translate("Den Ejection:"),
-                new(leftMargin, topOffset - rowHeight * 5), new(labelWidth, 20f), false);
+                new(leftMargin, topOffset - rowHeight * 6), new(labelWidth, 20f), false);
             challengeDenEjectionLabel.label.alignment = FLabelAlignment.Left;
 
-            challengeDenEjectionCheckbox = new(RainMeadow.rainMeadowOptions.ChallengeDenEjection, boxMargin, topOffset - (rowHeight * 5));
+            challengeDenEjectionCheckbox = new(RainMeadow.rainMeadowOptions.ChallengeDenEjection, boxMargin, topOffset - (rowHeight * 6));
 
             challengeDenEjectionCheckbox.OnValueUpdate += (config, value, oldValue) =>
             {
@@ -180,10 +201,10 @@ namespace RainMeadow.UI.Components
 
 
             arenaImportExportLabel = new(menu, this, menu.Translate("Playlist:"),
-                new(leftMargin, topOffset - rowHeight * 6), new(labelWidth, 20f), false);
+                new(leftMargin, topOffset - rowHeight * 7), new(labelWidth, 20f), false);
             arenaImportExportLabel.label.alignment = FLabelAlignment.Left;
 
-            arenaPlaylistExportButton = new(new Vector2(boxMargin, topOffset - (rowHeight * 6) - 2f), new Vector2(180f, 30f), this.menu.Translate("Copy playlist to clipboard"));
+            arenaPlaylistExportButton = new(new Vector2(boxMargin, topOffset - (rowHeight * 7) - 2f), new Vector2(180f, 30f), this.menu.Translate("Copy playlist to clipboard"));
             arenaPlaylistExportButton.OnClick += (_) =>
             {
                 try
@@ -206,7 +227,7 @@ namespace RainMeadow.UI.Components
                 }
             };
 
-            arenaPlaylistImportButton = new(new Vector2(boxMargin, topOffset - (rowHeight * 7) - 2f), new Vector2(180f, 30f), this.menu.Translate("Import playlist from clipboard"));
+            arenaPlaylistImportButton = new(new Vector2(boxMargin, topOffset - (rowHeight * 8) - 2f), new Vector2(180f, 30f), this.menu.Translate("Import playlist from clipboard"));
             arenaPlaylistImportButton.OnClick += (_) =>
             {
                 try
@@ -248,7 +269,8 @@ namespace RainMeadow.UI.Components
 
             this.SafeAddSubobjects(
                 tabWrapper,
-                spearScoreLabel,
+                spearHitScoreLabel,
+                killScoreLabel,
                 aliveScoreLabel,
                 denEntryRuleLabel,
                 denScoreLabel,
@@ -256,7 +278,9 @@ namespace RainMeadow.UI.Components
                 challengeDenEjectionLabel,
                 arenaImportExportLabel
             );
-            new PatchedUIelementWrapper(tabWrapper, spearScoreTextBox);
+            new PatchedUIelementWrapper(tabWrapper, spearHitScoreTextBox);
+
+            new PatchedUIelementWrapper(tabWrapper, killScoreTextBox);
             new PatchedUIelementWrapper(tabWrapper, denEntryRule);
             new PatchedUIelementWrapper(tabWrapper, aliveScoreTextBox);
             new PatchedUIelementWrapper(tabWrapper, denScoreTextBox);
@@ -296,7 +320,8 @@ namespace RainMeadow.UI.Components
         {
             if (!(OnlineManager.lobby?.isOwner == true))
                 return;
-            RainMeadow.rainMeadowOptions.ArenaSpearScore.Value = arena.spearScore;
+            RainMeadow.rainMeadowOptions.ArenaSpearHitScore.Value = arena.spearHitScore;
+            RainMeadow.rainMeadowOptions.ArenaKillScore.Value = arena.killScore;
             RainMeadow.rainMeadowOptions.ArenaAliveScore.Value = arena.aliveScore;
             RainMeadow.rainMeadowOptions.ArenaDenType.Value = arena.denEntryRule;
             RainMeadow.rainMeadowOptions.ArenaDenScore.Value = arena.denScore;
@@ -327,15 +352,29 @@ namespace RainMeadow.UI.Components
         public override void Update()
         {
             base.Update();
-            if (spearScoreTextBox != null)
+            if (spearHitScoreTextBox != null)
             {
-                spearScoreTextBox.held = spearScoreTextBox._KeyboardOn;
-                if (!spearScoreTextBox.held)
+                spearHitScoreTextBox.held = spearHitScoreTextBox._KeyboardOn;
+                if (!spearHitScoreTextBox.held)
                 {
-                    spearScoreTextBox.valueInt = arena.spearScore;
+                    if (!ModManager.MSC && arena.spearHitScore > 0) // reset
+                    {
+                        arena.spearHitScore = 0;
+                    }
+                    spearHitScoreTextBox.valueInt = arena.spearHitScore;
                 }
 
-                spearScoreTextBox.greyedOut = OwnerSettingsDisabled;
+                spearHitScoreTextBox.greyedOut = OwnerSettingsDisabled || !ModManager.MSC;
+            }
+            if (killScoreTextBox != null)
+            {
+                killScoreTextBox.held = killScoreTextBox._KeyboardOn;
+                if (!killScoreTextBox.held)
+                {
+                    killScoreTextBox.valueInt = arena.killScore;
+                }
+
+                killScoreTextBox.greyedOut = OwnerSettingsDisabled;
             }
             if (aliveScoreTextBox != null)
             {


### PR DESCRIPTION
- The base-game function for tracking hits is called,` "ArenaGameSession_LandSpear"`
- However, this function is only  found in the  `Spear` class
- However, the hook point for this is  `ArenaGameSession`
- The specific problem is that the base-game never added support for persistent damage tracking. Every spear hit would count as a kill.
- But in MSC, monk in arena does "half-damage", and this is managed via `persistentDamageTracking` field.
- So in order to prevent granting score for a hit AND a kill and instead it be a non-lethal hit OR a kill, I have to do a DLC check for the base-game character's behavior to function properly because vanilla arena is a lie

If anyone reads this, just know this caused me pain.

- [x] Prevent teams from getting points from team hits
- [x] Remove the team hits debug log