### PR TITLE
Fix save state duplication on clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed clients not being sucked into warps
 ### Saint
 - Fixed some critical errors in Saint's ending
+- Fixed duplication of some save records when loading on clients. This should fix save bloating that caused load slowdown over time.
 ## General
 - Added Global Mute toggle to Meadow Remix's "Gameplay" tab
 - Fixed most cases of pearl strings duplicating. This should noticeably decrease latency

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -1765,6 +1765,17 @@ namespace RainMeadow
             return null;
         }
 
+        private static SaveState ApplyClientSaveState(SaveState host, SaveState client)
+        {
+            // Loading host on-top of client causes duplication of some fields, so let's target exact fields
+            host.deathPersistentSaveData.tutorialMessages = client.deathPersistentSaveData.tutorialMessages;
+            host.deathPersistentSaveData.songsPlayRecords = client.deathPersistentSaveData.songsPlayRecords;
+            host.deathPersistentSaveData.karmaFlowerPosition = client.deathPersistentSaveData.karmaFlowerPosition;
+            host.swallowedItems = client.swallowedItems;
+            host.unrecognizedSwallowedItems = client.unrecognizedSwallowedItems;
+            return host;
+        }
+
         private void SaveStateHandler(PlayerProgression self, StoryGameMode storyGameMode, RainWorldGame game)
         {
             RainMeadow.Debug("story: found loaded game state");
@@ -1776,8 +1787,10 @@ namespace RainMeadow
             }
             else
             {
-                // this already syncs the denpos
-                self.currentSaveState.LoadGame(InflateJoarXML(storyGameMode.saveStateString ?? ""), game);
+                // This already syncs the denpos
+                var hostSaveState = new SaveState(self.currentSaveState.saveStateNumber, self);
+                hostSaveState.LoadGame(InflateJoarXML(storyGameMode.saveStateString ?? ""), game);
+                self.currentSaveState = ApplyClientSaveState(hostSaveState, self.currentSaveState);
             }
 
             RainMeadow.Debug($"START DENPOS save:{self.currentSaveState.denPosition} last:{storyGameMode.myLastDenPos} lobby:{storyGameMode.defaultDenPos}");

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -1874,11 +1874,13 @@ namespace RainMeadow
                 }
                 else
                 {
+                    // Returns `self.currentSaveState` or `null`
                     SaveState saveState = self.LoadGameState(null, game, saveAsDeathOrQuit);
                     if (saveState != null)
                     {
+                        // Modifies `self.currentSaveState`, so `saveState` is invalid now
                         SaveStateHandler(self, storyGameMode, game);
-                        return saveState;
+                        return self.currentSaveState;
                     }
 
                     self.currentSaveState.LoadGame("", game);


### PR DESCRIPTION
Naively calling `self.currentSaveState.LoadGame()` a second doesn't actually overwrite the previous save, some lists are not cleared and retain the values from the original client save. I noticed particularly `SESSIONRECORDS`, `CONSUMEDFLOWERS`, and `imagesShown` were problems, gaining over 200,000 entries each throughout my survivor campaign with a friend. Once a save gets that bad, the game starts taking a *long* time to load (we timed 15 minutes).

The easiest way to reproduce this problem is to play a campaign, alternating between two people hosting. Each time the game loads, the host's lists will be appended to the client's list. If "Sync Save" is disabled, then it at least doesn't save the problematic file and the other person can simply re-join.

Currently marked as draft because this is currently untested, plus I don't know exactly which fields should be loaded from the client, so any feedback on that would be appreciated. Alternatively, the host's save state could simply fully overwrite the client's save state, but I think what is copied here is sensible? I tried to copy the original behaviour of the filtered host save state.