### PR TITLE
Ghost Spear Fix (hopefully)

### DIFF
--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -59,6 +59,7 @@ namespace RainMeadow
             IL.VultureGrub.InitiateSignal += PhysicalObject_Trigger;
 
             On.Spear.Spear_makeNeedle += Spear_makeNeedle;
+            On.Spear.resetHorizontalBeamState += Spear_resetHorizontalBeamState;
 
             On.AbstractPhysicalObject.AbstractObjectStick.ctor += AbstractObjectStick_ctor;
             On.Creature.SwitchGrasps += Creature_SwitchGrasps;
@@ -76,6 +77,17 @@ namespace RainMeadow
             On.Vulture.AccessSkyGate += Vulture_AccessSkyGate;
         }
 
+        // Sends an RPC to potentially remove beam left by the spear on other clients
+        private static void Spear_resetHorizontalBeamState(On.Spear.orig_resetHorizontalBeamState orig, Spear self)
+        {
+            if (self?.abstractPhysicalObject?.GetOnlineObject() is OnlinePhysicalObject onlinePhysicalObject && self.stuckInWall != null)
+            {
+                onlinePhysicalObject.BroadcastRPCInRoom(RPCs.RemovePoleStateForSpear, 
+                    onlinePhysicalObject, self.stuckInWall, self.abstractSpear.stuckInWallCycles, self.wasHorizontalBeam);
+            }
+            orig(self);
+        }
+        
         // Prevent ammo from duping
         private void JokeRifle_Use(ILContext il)
         {

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -234,5 +234,40 @@ namespace RainMeadow
             }
             DeathMessage.CreatureKillPlayer(myKiller, myTarget);
         }
+        
+        [RPCMethod]
+        public static void RemovePoleStateForSpear(RPCEvent rpc, OnlinePhysicalObject onlineSpear, Vector2 stuckInWall, int stuckInWallCycles, bool[] wasHorizontalBeam)
+        {
+            if (onlineSpear?.apo?.realizedObject is Spear spear)
+            {
+                spear.abstractSpear.stuckInWallCycles = stuckInWallCycles;
+                spear.wasHorizontalBeam = wasHorizontalBeam;
+    
+                if (spear.abstractSpear.stuckInWallCycles > 0) // from Spear.resetHorizontalBeamState()
+                {
+                    spear.room.GetTile(stuckInWall.Value).horizontalBeam = spear.wasHorizontalBeam[1];
+                    for (int i = -1; i < 2; i += 2)
+                    {
+                        if (!spear.room.GetTile(stuckInWall.Value + new Vector2(20f * i, 0f)).Solid)
+                        {
+                            spear.room.GetTile(stuckInWall.Value + new Vector2(20f * i, 0f)).horizontalBeam = spear.wasHorizontalBeam[i + 1];
+                        }
+                    }
+                }
+                else
+                {
+                    spear.room.GetTile(stuckInWall.Value).verticalBeam = spear.wasHorizontalBeam[1];
+                    for (int j = -1; j < 2; j += 2)
+                    {
+                        if (!spear.room.GetTile(stuckInWall.Value + new Vector2(0f, 20f * j)).Solid)
+                        {
+                            spear.room.GetTile(stuckInWall.Value + new Vector2(0f, 20f * j)).verticalBeam = spear.wasHorizontalBeam[j + 1];
+                        }
+                    }
+                }
+                spear.hasHorizontalBeamState = false;
+                spear.abstractSpear.stuckInWallCycles = 0;
+            }
+        }
     }
 }

--- a/Online/State/RealizedSpearState.cs
+++ b/Online/State/RealizedSpearState.cs
@@ -56,7 +56,7 @@ namespace RainMeadow
             spear.stuckInWall = stuckInWall;
             spear.abstractSpear.stuckInWallCycles = stuckInWallCycles;
             spear.spearDamageBonus = spearDamageBonus;
-            spear.addPoles = stuckInWall.HasValue;
+            // spear.addPoles = stuckInWall.HasValue; <- not good
 
             spear.spearmasterNeedle_hasConnection = needleActive;
 


### PR DESCRIPTION
So, it's been 2 hours and a half, I have no clue why I even though about trying to fix that but here I am.
I've been recommended to not set `spear.addPoles` with an RPC, and since I can do quite limited testing on my own (I don't realy know how to compile Meadow), I've put every modification I did for my testings BUT that.
It shouldn't cause issues, the main issue with ghost spear is that `spear.addPoles` was set to true every frame of it being embedded, while it needed to be set only once. As long as `spear.addPoles` is not set twice or more, there shouldn't be ghost spear issues.
I've put an RPC to remove the pole added by the spear anyway. It might be actually useless in practice when the above bug is remove, but we never know. Should be 100% safe even if the spear is long gone by the time the RPC reach the client, but of course it's Meadow, we never know.

So here is my code that I couldn't test fully but could test enough to actually make a PR about it. Enjoy !