### PR TITLE
fix: dont transfer amoebas

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -800,8 +800,11 @@ namespace RainMeadow
             Vector2 B
         )
         {
-            if (isArenaMode(out _))
+            if (isArenaMode(out var arena))
+            {
+                if (ArenaHelpers.GetArenaClientSettings(OnlineManager.mePlayer)?.playingAs == RainMeadow.Ext_SlugcatStatsName.OnlineOverseerSpectator) return 1;
                 return 1 * self.playerGlowVision; //keep it visible to creator
+            }
             return orig(self, A, B);
         }
 

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -440,12 +440,12 @@ namespace RainMeadow
             return orig(self);
         }
 
-                public void Player_SpawnDynamicWarpPoint(
-            On.Player.orig_SpawnDynamicWarpPoint orig,
-            Player self,
-            string forcedDestination,
-            Vector2? forcedDestinationPosition
-        )
+        public void Player_SpawnDynamicWarpPoint(
+    On.Player.orig_SpawnDynamicWarpPoint orig,
+    Player self,
+    string forcedDestination,
+    Vector2? forcedDestinationPosition
+)
         {
             if (!isArenaMode(out var arena))
             {
@@ -579,6 +579,9 @@ namespace RainMeadow
                     if (playerTeam != null && playerTeam.team == arena.arenaTeamClientSettings.team)
                         continue;
                 }
+
+                if (player.realizedCreature != null && player.realizedCreature.State.dead)
+                    continue;
 
                 int foundPlayerPriority = GetPriority(arena, voidSpawn, foundPlayer);
                 int playerPriority = GetPriority(arena, voidSpawn, realizedPlayer);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -440,7 +440,7 @@ namespace RainMeadow
             return orig(self);
         }
 
-        public void Player_SpawnDynamicWarpPoint(
+                public void Player_SpawnDynamicWarpPoint(
             On.Player.orig_SpawnDynamicWarpPoint orig,
             Player self,
             string forcedDestination,
@@ -469,6 +469,8 @@ namespace RainMeadow
                 return;
 
             var room = self.room;
+
+            RainMeadow.sSpawningNonTransferable = true;
             AbstractPhysicalObject apo = new(
                 room.world,
                 Watcher.WatcherEnums.AbstractObjectType.RippleSpawn,
@@ -487,6 +489,8 @@ namespace RainMeadow
             };
             voidSpawn.behavior = new VoidSpawn.ChasePlayer(voidSpawn, room);
             room.abstractRoom.AddEntity(apo);
+            RainMeadow.sSpawningNonTransferable = false;
+
             voidSpawn.abstractPhysicalObject.Realize();
             voidSpawn.abstractPhysicalObject.realizedObject.PlaceInRoom(room);
             voidSpawn.PlaceInRoom(room);

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -166,13 +166,13 @@ namespace RainMeadow
 
             if (!playerFound || !RoomSession.map.TryGetValue(self.room.abstractRoom, out var rs)) return;
             if (!killedCrit.abstractCreature.IsLocal()) return;
+            if (TeamBattleMode.isTeamBattleMode(arena, out _) && ArenaHelpers.CheckSameTeam(absPlayerCreature.owner, onlineKilledCreature.owner)) return;
 
 
             ushort lobbyId = absPlayerCreature.owner.inLobbyId;
             bool isLobbyOwner = OnlineManager.lobby.isOwner;
 
             // 4. Handle Trophies
-            // TOOD: Client can sometimes get wrong amount of trophies from one kill
             if (earnsTrophy)
             {
                 if (isLobbyOwner)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ## Chat
 - Fixed events not displaying while Global Mute was toggled
 - Fixed username color not updating between Arena games
+
+## Arena
+- Fixed Watcher Amoebas not appearing under certain conditions
+
 # Release 1.14.0
 
 ## Engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Arena
 - Fixed Watcher Amoebas not appearing under certain conditions
+- Fixed score being granted for killing teammates 
 
 # Release 1.14.0
 

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -17,6 +17,7 @@ namespace RainMeadow;
 public partial class RainMeadow
 {
     public static bool sSpawningAvatar;
+    public static bool sSpawningNonTransferable;
     public void PlayerHooks()
     {
         On.RainWorldGame.SpawnPlayers_bool_bool_bool_bool_WorldCoordinate += RainWorldGame_SpawnPlayers_bool_bool_bool_bool_WorldCoordinate; // Personas are set as non-transferable

--- a/Online/Entity/OnlinePhysicalObject.cs
+++ b/Online/Entity/OnlinePhysicalObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -110,7 +110,7 @@ namespace RainMeadow
 
         public static OnlinePhysicalObject NewFromApo(AbstractPhysicalObject apo)
         {
-            bool transferable = !RainMeadow.sSpawningAvatar || !RainMeadow.sSpawningNonTransferable;
+            bool transferable = !RainMeadow.sSpawningAvatar && !RainMeadow.sSpawningNonTransferable;
 
             EntityId entityId = new OnlineEntity.EntityId(OnlineManager.mePlayer.inLobbyId, EntityId.IdType.apo, apo.ID.number);
             if (OnlineManager.recentEntities.ContainsKey(entityId))


### PR DESCRIPTION
Worked with 3 local players. 

- Added `sSpawningNonTransferable` to specifically prevent non-avatar OPOs from transferring. There's not many use-cases here, but Void Amoebas spawned in Arena, which have a timed lifespan, should not be transferred.

- This implementation is short lived and acts as a safe patch for the tourney. InvalidUnits has a draft PR open to deprecate the use of the static vars in a future release