### PR TITLE
fix specator menu go outside of the screen

### DIFF
--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -12,67 +12,67 @@ namespace RainMeadow
         public static float ButtonSize => 30;
         public static Vector2 MenuShift => new(-186f, 171f);
         private Vector2 ScreenSize => manager.rainWorld.options.ScreenSize;
-        public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
+        // public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
         public SpectatorOverlay(ProcessManager manager, RainWorldGame game, RoomCamera camera) : base(manager, RainMeadow.Ext_ProcessID.SpectatorMode)
         {
             this.game = game;
             this.camera = camera;
             selectedObject = null;
 
-            playerScroller = null!;
-        }
-        private bool UpdateList()
-        {
-            List<PlayerButton> playerButtons = PlayerButtons;
-            List<OnlinePlayer> newPlayers = [.. OnlineManager.players.OrderBy(onlineP => onlineP.isMe ? 0 : 1)]; // will keep this logic for LAN
-            List<OnlineCreature> realizedPlayers = [.. OnlineManager.lobby.playerAvatars.Select(kv => kv.Value.FindEntity(true)).OfType<OnlineCreature>().OrderBy(opo => opo.isMine ? 0 : 1)];
-            if (newPlayers.Count == playerButtons.Count) return false; // race condition that will Never Happen(TM)
-
-            for (int i = playerButtons.Count - 1; i >= 0; i--)
-            {
-                PlayerButton button = playerButtons[i];
-                if (newPlayers.Contains(button.player))
-                {
-                    newPlayers.Remove(button.player);
-                    button.avatars = realizedPlayers.Where(x => x.owner == button.player).ToList();
-                    continue;
-                }
-                playerScroller.RemoveButton(button, false);
-            }
-            foreach (OnlinePlayer player in newPlayers)
-            {
-                PlayerButton playerButton = new(this, playerScroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), playerScroller.GetIdealPosWithScrollForButton(playerScroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
-                playerScroller.AddScrollObjects(playerButton);
-            }
-            playerScroller.ConstrainScroll();
-            return true;
-        }
-        public override void Init()
-        {
             Page page = new(this, null, "spectator", 0);
             pages.Add(page);
-
-            base.Init();
 
             var pos = new Vector2(ScreenSize.x, ScreenSize.y / 2) + MenuShift - page.pos;
 
             MenuLabel label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
             page.subObjects.Add(label);
 
-            playerScroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
-            page.subObjects.Add(playerScroller);
+            // playerScroller = null!;
+        }
+        private bool UpdateList()
+        {
+            // List<PlayerButton> playerButtons = PlayerButtons;
+            // List<OnlinePlayer> newPlayers = [.. OnlineManager.players.OrderBy(onlineP => onlineP.isMe ? 0 : 1)]; // will keep this logic for LAN
+            // List<OnlineCreature> realizedPlayers = [.. OnlineManager.lobby.playerAvatars.Select(kv => kv.Value.FindEntity(true)).OfType<OnlineCreature>().OrderBy(opo => opo.isMine ? 0 : 1)];
+            // if (newPlayers.Count == playerButtons.Count) return false; // race condition that will Never Happen(TM)
+
+            // for (int i = playerButtons.Count - 1; i >= 0; i--)
+            // {
+            //     PlayerButton button = playerButtons[i];
+            //     if (newPlayers.Contains(button.player))
+            //     {
+            //         newPlayers.Remove(button.player);
+            //         button.avatars = realizedPlayers.Where(x => x.owner == button.player).ToList();
+            //         continue;
+            //     }
+            //     playerScroller.RemoveButton(button, false);
+            // }
+            // foreach (OnlinePlayer player in newPlayers)
+            // {
+            //     PlayerButton playerButton = new(this, playerScroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), playerScroller.GetIdealPosWithScrollForButton(playerScroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
+            //     playerScroller.AddScrollObjects(playerButton);
+            // }
+            // playerScroller.ConstrainScroll();
+            // return true;
+            return false;
+        }
+        public override void Init()
+        {
+
+            // playerScroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
+            // page.subObjects.Add(playerScroller);
         }
         public override void Update()
         {
             base.Update();
 
             UpdateList();
-            foreach (PlayerButton button in PlayerButtons)
-            {
-                var avatars = button.GetSpectableAvatars();
-                button.toggled = avatars.Contains(spectatee?.GetOnlineObject());
-                button.buttonBehav.greyedOut = avatars.Count() == 0;
-            }
+            // foreach (PlayerButton button in PlayerButtons)
+            // {
+            //     var avatars = button.GetSpectableAvatars();
+            //     button.toggled = avatars.Contains(spectatee?.GetOnlineObject());
+            //     button.buttonBehav.greyedOut = avatars.Count() == 0;
+            // }
             if (forceNonMouseSelectFreeze && !manager.menuesMouseMode)
             {
                 selectedObject = null;
@@ -99,7 +99,7 @@ namespace RainMeadow
         public AbstractCreature? spectatee;
         public RainWorldGame game;
         public RoomCamera camera;
-        public ButtonScroller playerScroller;
+        // public ButtonScroller playerScroller;
         public bool forceNonMouseSelectFreeze = false;
         public class PlayerButton : ButtonScroller.ScrollerButton //makes sense to just remove the pos property
         {

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -13,7 +13,7 @@ namespace RainMeadow
         public static float ButtonSize => 30;
         public static Vector2 MenuShift => new(-186f, 553f);
         private int ScreenWidth => (int)manager.rainWorld.options.ScreenSize.x;
-        public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
+        public List<PlayerButton> PlayerButtons => scroller.GetSpecificButtons<PlayerButton>();
         public SpectatorOverlay(ProcessManager manager, RainWorldGame game, RoomCamera camera) : base(manager, RainMeadow.Ext_ProcessID.SpectatorMode)
         {
             this.game = game;
@@ -26,8 +26,8 @@ namespace RainMeadow
             label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
             page.subObjects.Add(label);
 
-            playerScroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
-            page.subObjects.Add(playerScroller);
+            scroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
+            page.subObjects.Add(scroller);
 
             pages.Add(page);
         }
@@ -47,14 +47,14 @@ namespace RainMeadow
                     button.avatars = realizedPlayers.Where(x => x.owner == button.player).ToList();
                     continue;
                 }
-                playerScroller.RemoveButton(button, false);
+                scroller.RemoveButton(button, false);
             }
             foreach (OnlinePlayer player in newPlayers)
             {
-                PlayerButton playerButton = new(this, playerScroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), playerScroller.GetIdealPosWithScrollForButton(playerScroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
-                playerScroller.AddScrollObjects(playerButton);
+                PlayerButton playerButton = new(this, scroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), scroller.GetIdealPosWithScrollForButton(scroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
+                scroller.AddScrollObjects(playerButton);
             }
-            playerScroller.ConstrainScroll();
+            scroller.ConstrainScroll();
             return true;
         }
         public override void Update()
@@ -76,7 +76,7 @@ namespace RainMeadow
             var page = pages[0];
             var pos = new Vector2(ScreenWidth, 0) + MenuShift - page.pos;
             label.pos = pos;
-            playerScroller.pos = new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)); // ugly: repeating the code :3
+            scroller.pos = new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)); // ugly: repeating the code :3
         }
         public override string UpdateInfoText()
         {
@@ -99,7 +99,7 @@ namespace RainMeadow
         public RainWorldGame game;
         public RoomCamera camera;
         public MenuLabel label;
-        public ButtonScroller playerScroller;
+        public ButtonScroller scroller; // previously "playerScroller"
         public bool forceNonMouseSelectFreeze = false;
         public class PlayerButton : ButtonScroller.ScrollerButton //makes sense to just remove the pos property
         {

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -49,10 +49,10 @@ namespace RainMeadow
         }
         public override void Init()
         {
-            base.Init();
-
             Page page = new(this, null, "spectator", 0);
             pages.Add(page);
+
+            base.Init();
 
             var pos = new Vector2(ScreenSize.x, ScreenSize.y / 2) + MenuShift - page.pos;
 
@@ -65,6 +65,7 @@ namespace RainMeadow
         public override void Update()
         {
             base.Update();
+
             UpdateList();
             foreach (PlayerButton button in PlayerButtons)
             {

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -12,14 +12,14 @@ namespace RainMeadow
         public static float ButtonSize => 30;
         public static Vector2 MenuShift => new(-186f, 553f);
         private int ScreenWidth => (int)manager.rainWorld.options.ScreenSize.x;
-        public List<PlayerButton> PlayerButtons => scroller.GetSpecificButtons<PlayerButton>();
+        public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
         public SpectatorOverlay(ProcessManager manager, RainWorldGame game, RoomCamera camera) : base(manager, RainMeadow.Ext_ProcessID.SpectatorMode)
         {
             this.game = game;
             this.camera = camera;
             selectedObject = null;
 
-            scroller = null!;
+            playerScroller = null!;
         }
         private bool UpdateList()
         {
@@ -37,14 +37,14 @@ namespace RainMeadow
                     button.avatars = realizedPlayers.Where(x => x.owner == button.player).ToList();
                     continue;
                 }
-                scroller.RemoveButton(button, false);
+                playerScroller.RemoveButton(button, false);
             }
             foreach (OnlinePlayer player in newPlayers)
             {
-                PlayerButton playerButton = new(this, scroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), scroller.GetIdealPosWithScrollForButton(scroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
-                scroller.AddScrollObjects(playerButton);
+                PlayerButton playerButton = new(this, playerScroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), playerScroller.GetIdealPosWithScrollForButton(playerScroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
+                playerScroller.AddScrollObjects(playerButton);
             }
-            scroller.ConstrainScroll();
+            playerScroller.ConstrainScroll();
             return true;
         }
         public override void Init()
@@ -59,8 +59,8 @@ namespace RainMeadow
             MenuLabel label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
             page.subObjects.Add(label);
 
-            scroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
-            page.subObjects.Add(scroller);
+            playerScroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
+            page.subObjects.Add(playerScroller);
         }
         public override void Update()
         {
@@ -98,7 +98,7 @@ namespace RainMeadow
         public AbstractCreature? spectatee;
         public RainWorldGame game;
         public RoomCamera camera;
-        public ButtonScroller scroller; // previously "playerScroller"
+        public ButtonScroller playerScroller;
         public bool forceNonMouseSelectFreeze = false;
         public class PlayerButton : ButtonScroller.ScrollerButton //makes sense to just remove the pos property
         {

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -11,20 +11,25 @@ namespace RainMeadow
         public static int MaxVisibleOnList => 8;
         public static float ButtonSpacingOffset => 8;
         public static float ButtonSize => 30;
-        private int ScreenWidth => (int)Math.Min(manager.rainWorld.options.ScreenSize.x, 1366);
+        public static Vector2 MenuShift => new(-186f, 553f);
+        private int ScreenWidth => (int)manager.rainWorld.options.ScreenSize.x;
         public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
         public SpectatorOverlay(ProcessManager manager, RainWorldGame game, RoomCamera camera) : base(manager, RainMeadow.Ext_ProcessID.SpectatorMode)
         {
             this.game = game;
             this.camera = camera;
-
-            pages.Add(new(this, null, "spectator", 0));
             selectedObject = null;
-            float xPos = ScreenWidth - 186f;
-            Vector2 pos = new(xPos, 553f);
-            pages[0].subObjects.Add(new MenuLabel(this, pages[0], Translate("PLAYERS"), pos, new(110, 30), true));
-            playerScroller = new(this, pages[0], new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
-            pages[0].subObjects.Add(playerScroller);
+
+            Page page = new(this, null, "spectator", 0);
+
+            var pos = new Vector2(ScreenWidth, 0) + MenuShift;
+            label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
+            page.subObjects.Add(label);
+
+            playerScroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
+            page.subObjects.Add(playerScroller);
+
+            pages.Add(page);
         }
         private bool UpdateList()
         {
@@ -67,6 +72,11 @@ namespace RainMeadow
                 selectedObject = null;
 
             }
+
+            var page = pages[0];
+            var pos = new Vector2(ScreenWidth, 0) + MenuShift - page.pos;
+            label.pos = pos;
+            playerScroller.pos = new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)); // ugly: repeating the code :3
         }
         public override string UpdateInfoText()
         {
@@ -88,6 +98,7 @@ namespace RainMeadow
         public AbstractCreature? spectatee;
         public RainWorldGame game;
         public RoomCamera camera;
+        public MenuLabel label;
         public ButtonScroller playerScroller;
         public bool forceNonMouseSelectFreeze = false;
         public class PlayerButton : ButtonScroller.ScrollerButton //makes sense to just remove the pos property

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using Menu;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -10,7 +11,7 @@ namespace RainMeadow
         public static int MaxVisibleOnList => 8;
         public static float ButtonSpacingOffset => 8;
         public static float ButtonSize => 30;
-        private int ScreenWidth => (int)manager.rainWorld.options.ScreenSize.x;
+        private int ScreenWidth => (int)Math.Min(manager.rainWorld.options.ScreenSize.x, 1366);
         public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
         public SpectatorOverlay(ProcessManager manager, RainWorldGame game, RoomCamera camera) : base(manager, RainMeadow.Ext_ProcessID.SpectatorMode)
         {
@@ -19,7 +20,7 @@ namespace RainMeadow
 
             pages.Add(new(this, null, "spectator", 0));
             selectedObject = null;
-            float xPos = ScreenWidth - 186f; 
+            float xPos = ScreenWidth - 186f;
             Vector2 pos = new(xPos, 553f);
             pages[0].subObjects.Add(new MenuLabel(this, pages[0], Translate("PLAYERS"), pos, new(110, 30), true));
             playerScroller = new(this, pages[0], new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -12,67 +12,67 @@ namespace RainMeadow
         public static float ButtonSize => 30;
         public static Vector2 MenuShift => new(-186f, 171f);
         private Vector2 ScreenSize => manager.rainWorld.options.ScreenSize;
-        // public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
+        public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
         public SpectatorOverlay(ProcessManager manager, RainWorldGame game, RoomCamera camera) : base(manager, RainMeadow.Ext_ProcessID.SpectatorMode)
         {
             this.game = game;
             this.camera = camera;
             selectedObject = null;
 
+            playerScroller = null!;
+        }
+        private bool UpdateList()
+        {
+            List<PlayerButton> playerButtons = PlayerButtons;
+            List<OnlinePlayer> newPlayers = [.. OnlineManager.players.OrderBy(onlineP => onlineP.isMe ? 0 : 1)]; // will keep this logic for LAN
+            List<OnlineCreature> realizedPlayers = [.. OnlineManager.lobby.playerAvatars.Select(kv => kv.Value.FindEntity(true)).OfType<OnlineCreature>().OrderBy(opo => opo.isMine ? 0 : 1)];
+            if (newPlayers.Count == playerButtons.Count) return false; // race condition that will Never Happen(TM)
+
+            for (int i = playerButtons.Count - 1; i >= 0; i--)
+            {
+                PlayerButton button = playerButtons[i];
+                if (newPlayers.Contains(button.player))
+                {
+                    newPlayers.Remove(button.player);
+                    button.avatars = realizedPlayers.Where(x => x.owner == button.player).ToList();
+                    continue;
+                }
+                playerScroller.RemoveButton(button, false);
+            }
+            foreach (OnlinePlayer player in newPlayers)
+            {
+                PlayerButton playerButton = new(this, playerScroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), playerScroller.GetIdealPosWithScrollForButton(playerScroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
+                playerScroller.AddScrollObjects(playerButton);
+            }
+            playerScroller.ConstrainScroll();
+            return true;
+        }
+        public override void Init()
+        {
             Page page = new(this, null, "spectator", 0);
             pages.Add(page);
+
+            base.Init();
 
             var pos = new Vector2(ScreenSize.x, ScreenSize.y / 2) + MenuShift - page.pos;
 
             MenuLabel label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
             page.subObjects.Add(label);
 
-            // playerScroller = null!;
-        }
-        private bool UpdateList()
-        {
-            // List<PlayerButton> playerButtons = PlayerButtons;
-            // List<OnlinePlayer> newPlayers = [.. OnlineManager.players.OrderBy(onlineP => onlineP.isMe ? 0 : 1)]; // will keep this logic for LAN
-            // List<OnlineCreature> realizedPlayers = [.. OnlineManager.lobby.playerAvatars.Select(kv => kv.Value.FindEntity(true)).OfType<OnlineCreature>().OrderBy(opo => opo.isMine ? 0 : 1)];
-            // if (newPlayers.Count == playerButtons.Count) return false; // race condition that will Never Happen(TM)
-
-            // for (int i = playerButtons.Count - 1; i >= 0; i--)
-            // {
-            //     PlayerButton button = playerButtons[i];
-            //     if (newPlayers.Contains(button.player))
-            //     {
-            //         newPlayers.Remove(button.player);
-            //         button.avatars = realizedPlayers.Where(x => x.owner == button.player).ToList();
-            //         continue;
-            //     }
-            //     playerScroller.RemoveButton(button, false);
-            // }
-            // foreach (OnlinePlayer player in newPlayers)
-            // {
-            //     PlayerButton playerButton = new(this, playerScroller, player, realizedPlayers.Where(x => x.owner == player).ToList(), playerScroller.GetIdealPosWithScrollForButton(playerScroller.buttons.Count), OnlineManager.lobby.isOwner && !player.isMe);
-            //     playerScroller.AddScrollObjects(playerButton);
-            // }
-            // playerScroller.ConstrainScroll();
-            // return true;
-            return false;
-        }
-        public override void Init()
-        {
-
-            // playerScroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
-            // page.subObjects.Add(playerScroller);
+            playerScroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
+            page.subObjects.Add(playerScroller);
         }
         public override void Update()
         {
             base.Update();
 
             UpdateList();
-            // foreach (PlayerButton button in PlayerButtons)
-            // {
-            //     var avatars = button.GetSpectableAvatars();
-            //     button.toggled = avatars.Contains(spectatee?.GetOnlineObject());
-            //     button.buttonBehav.greyedOut = avatars.Count() == 0;
-            // }
+            foreach (PlayerButton button in PlayerButtons)
+            {
+                var avatars = button.GetSpectableAvatars();
+                button.toggled = avatars.Contains(spectatee?.GetOnlineObject());
+                button.buttonBehav.greyedOut = avatars.Count() == 0;
+            }
             if (forceNonMouseSelectFreeze && !manager.menuesMouseMode)
             {
                 selectedObject = null;
@@ -99,7 +99,7 @@ namespace RainMeadow
         public AbstractCreature? spectatee;
         public RainWorldGame game;
         public RoomCamera camera;
-        // public ButtonScroller playerScroller;
+        public ButtonScroller playerScroller;
         public bool forceNonMouseSelectFreeze = false;
         public class PlayerButton : ButtonScroller.ScrollerButton //makes sense to just remove the pos property
         {

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -19,16 +19,7 @@ namespace RainMeadow
             this.camera = camera;
             selectedObject = null;
 
-            Page page = new(this, null, "spectator", 0);
-
-            var pos = new Vector2(ScreenWidth, 0) + MenuShift;
-            label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
-            page.subObjects.Add(label);
-
-            scroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
-            page.subObjects.Add(scroller);
-
-            pages.Add(page);
+            scroller = null!;
         }
         private bool UpdateList()
         {
@@ -56,6 +47,21 @@ namespace RainMeadow
             scroller.ConstrainScroll();
             return true;
         }
+        public override void Init()
+        {
+            base.Init();
+
+            Page page = new(this, null, "spectator", 0);
+            pages.Add(page);
+
+            var pos = new Vector2(ScreenWidth, 0) + MenuShift - page.pos;
+
+            MenuLabel label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
+            page.subObjects.Add(label);
+
+            scroller = new(this, page, new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)), MaxVisibleOnList, 200, (ButtonSize, ButtonSpacingOffset));
+            page.subObjects.Add(scroller);
+        }
         public override void Update()
         {
             base.Update();
@@ -71,11 +77,6 @@ namespace RainMeadow
                 selectedObject = null;
 
             }
-
-            var page = pages[0];
-            var pos = new Vector2(ScreenWidth, 0) + MenuShift - page.pos;
-            label.pos = pos;
-            scroller.pos = new(pos.x, pos.y - 38 - ButtonScroller.CalculateHeightBasedOnAmtOfButtons(MaxVisibleOnList, ButtonSize, ButtonSpacingOffset)); // ugly: repeating the code :3
         }
         public override string UpdateInfoText()
         {
@@ -97,7 +98,6 @@ namespace RainMeadow
         public AbstractCreature? spectatee;
         public RainWorldGame game;
         public RoomCamera camera;
-        public MenuLabel label;
         public ButtonScroller scroller; // previously "playerScroller"
         public bool forceNonMouseSelectFreeze = false;
         public class PlayerButton : ButtonScroller.ScrollerButton //makes sense to just remove the pos property

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -10,8 +10,8 @@ namespace RainMeadow
         public static int MaxVisibleOnList => 8;
         public static float ButtonSpacingOffset => 8;
         public static float ButtonSize => 30;
-        public static Vector2 MenuShift => new(-186f, 553f);
-        private int ScreenWidth => (int)manager.rainWorld.options.ScreenSize.x;
+        public static Vector2 MenuShift => new(-186f, 171f);
+        private Vector2 ScreenSize => manager.rainWorld.options.ScreenSize;
         public List<PlayerButton> PlayerButtons => playerScroller.GetSpecificButtons<PlayerButton>();
         public SpectatorOverlay(ProcessManager manager, RainWorldGame game, RoomCamera camera) : base(manager, RainMeadow.Ext_ProcessID.SpectatorMode)
         {
@@ -54,7 +54,7 @@ namespace RainMeadow
             Page page = new(this, null, "spectator", 0);
             pages.Add(page);
 
-            var pos = new Vector2(ScreenWidth, 0) + MenuShift - page.pos;
+            var pos = new Vector2(ScreenSize.x, ScreenSize.y / 2) + MenuShift - page.pos;
 
             MenuLabel label = new(this, page, Translate("PLAYERS"), pos, new(110, 30), true);
             page.subObjects.Add(label);

--- a/OnlineUIComponents/SpectatorOverlay.cs
+++ b/OnlineUIComponents/SpectatorOverlay.cs
@@ -1,5 +1,4 @@
 ﻿using Menu;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;


### PR DESCRIPTION
so previously it behaved like this on "actual size" 1920x1080. you see it's unusable..
<img width="143" height="370" alt="RainWorld_926kqCsZvN" src="https://github.com/user-attachments/assets/1d575bb8-0894-4bfc-ac1e-b9bc748bedea" />
this is an actual cause of the PR :3

previously i had no clue why is it like that, but now i have a theory the page is centered with "fixed size" of original game (1366x760). i have no guaranteed proof of it, but here are images from my duck taping:

1. "bright zone" is 1366x760 vs "actual size" 1600x900, `pos.x` is 0
<img width="305" height="305" alt="image" src="https://github.com/user-attachments/assets/9e38b837-e228-4f2c-9104-62c48241f493" />

2. "bright zone" is 1366x760 vs "actual size" 1920x1080, `ScreenWidth` is fixed 1366
<img width="367" height="321" alt="2-wawa" src="https://github.com/user-attachments/assets/a562c8db-7108-4127-a82a-577932a5e755" />

all the two examples show that the zone might be centered with "fixed size" of 1366x760

fuck formatting