### PR TITLE
Fixed Slugslot pseudo-random generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed irrelevant rooms not being unloaded while spectating other players that led to higher network throughput
 # Arena
 - Switched the input for banning slugcats from pckup to Shift+Click when using the mouse.
+- Fixed Slugslot pseudo-random generator
 
 # Release 1.14.1
 

--- a/Menu/Dialogs/SlugcatSelector.cs
+++ b/Menu/Dialogs/SlugcatSelector.cs
@@ -410,6 +410,7 @@ namespace RainMeadow.UI
             public SlugcatStats.Name[] slugcatList;
             public SlugcatColorableButton slugcatButton;
             public FLabel slugcatResult;
+            private static System.Random RandomGenerator = new();
 
             public SlugcatRandomizer(
                 Menu.Menu menu,
@@ -528,9 +529,8 @@ namespace RainMeadow.UI
                 rolling = false;
                 if (index == -1)
                 {
-                    System.Random random = new();
                     slugcatButton.LoadNewSlugcat(
-                        slugcatList[random.Next(slugcatList.Length)],
+                        slugcatList[RandomGenerator.Next(slugcatList.Length)],
                         false,
                         false
                     );


### PR DESCRIPTION
I didn't test it yet (my rw is... not available rn) but I mean it's 2 lines, there's no way it just breaks for no reason. 
Here, pseudo-random generator as a static variable, so slugslot isn't rigged anymore