### PR TITLE
fixed watcher warp not working when warping from a world for the second time in the cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## General
 - Fixed irrelevant rooms not being unloaded while spectating other players that led to higher network throughput
-# Arena
+## Arena
 - Switched the input for banning slugcats from pckup to Shift+Click when using the mouse.
 - Fixed Slugslot pseudo-random generator
-# Story
+## Story
 - Allow players to spectate their own corpses as long as they still exist
+### Watcher
+- Fixed watcher warp not working when warping from a world for the second time in the cycle
 
 # Release 1.14.1
 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -564,8 +564,7 @@ namespace RainMeadow
                 oldWorldSession.NotNeeded(); // done? let go
             }
 
-            self.game.manager.rainWorld.StartCoroutine(Overworld_Loaded_WaitLoop(orig, self, warpUsed, oldWorldSession, newWorldSession, newWorld));
-            oldWorldSession.transitionInProgress = true;
+            self.game.manager.rainWorld.StartCoroutine(Overworld_Loaded_WaitLoop(orig, self, warpUsed, oldWorldSession, newWorldSession, newWorld));            
             return;
         }
         // world transition at gatesactiveEntities


### PR DESCRIPTION
So, if you warp out and back into any world, the second time you try to warp will fail

In watcher campaign, Overworld_Loaded_WaitLoop is synchronous because WaitAndExecuteSession doesnt hit the yield, so in the end, worldsession.transitionInProgress will be set as true and no other warp will be allowed from that world until the world state is reset. 

Also, there is no need to have worldsession.transitionInProgress set as true after the coroutine call, as it will be set internally before any yield