### PR TITLE
fix: fetch capes asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - This update also fixes Dev Tools item spawning, restricting it to just the player spawning the item, and teleporting to exits trying to teleport everyone instead of just the local player.
 - Replaced dropdown menu for Cape Colors with a textbox that accepts a hexcode of any possible color
 - Added a checkbox for Rainbow Cape that's only active during events
+- Cape Fetching is ran asynchronously which will improve startup times on slow internet connections.
 ## Arena
 - Added new gamemode: Drown! Kill and survive to buy your escape. Cooperative or Competitive
 - Scoring update: Empty kills and friendly fire now subtract from the user (in Teams, the killer loses the points). Points are no longer granted to everyone else.

--- a/Game/CustomCosmetics/SlugcatCape.cs
+++ b/Game/CustomCosmetics/SlugcatCape.cs
@@ -212,8 +212,6 @@ namespace RainMeadow
                 {
 
                     return new SolidCapeColor(new Color(r, g, b));
-
-
                 }
             }
             else

--- a/Game/CustomCosmetics/SlugcatCape.cs
+++ b/Game/CustomCosmetics/SlugcatCape.cs
@@ -68,33 +68,36 @@ namespace RainMeadow
     static class CapeManager
     {
         const string capes_latest_commit = "https://github.com/invalidunits/MeadowCosmetics16.git/info/refs?service=git-upload-pack";
-        static string getRemoteLatestCommit()
+        static void getRemoteLatestCommit(Action<string> onComplete)
         {
             using (WebClient client = new WebClient())
             {
-                string response = client.DownloadString(capes_latest_commit);
-
-                // Split by lines
-                var lines = response.Split('\n');
-
-                foreach (var line in lines)
+                client.DownloadStringCompleted += (s, a) =>
                 {
-                    if (line.Contains("refs/heads/master"))
+                    if (a.Error != null || a.Cancelled) throw new Exception("We couldn't find the remote hash");
+
+                    // Split by lines
+                    var lines = a.Result.Split('\n');
+
+                    foreach (var line in lines)
                     {
-                        RainMeadow.Debug(line);
-                        // Line format: <length><sha1> refs/heads/master
-                        // Strip off the first 4 chars (pkt-line length)
-                        string trimmed = line.Length > 4 ? line.Substring(4) : line;
-                        string[] parts = trimmed.Split(' ');
-                        if (parts.Length > 0)
+                        if (line.Contains("refs/heads/master"))
                         {
-                            RainMeadow.Debug($"recieved the hash latest commit: {parts[0]}");
-                            return parts[0];
+                            RainMeadow.Debug(line);
+                            // Line format: <length><sha1> refs/heads/master
+                            // Strip off the first 4 chars (pkt-line length)
+                            string trimmed = line.Length > 4 ? line.Substring(4) : line;
+                            string[] parts = trimmed.Split(' ');
+                            if (parts.Length > 0)
+                            {
+                                RainMeadow.Debug($"recieved the hash latest commit: {parts[0]}");
+                                onComplete?.Invoke(parts[0]);
+                            }
                         }
                     }
-                }
+                };
 
-                throw new Exception("We couldn't find the remote hash");
+                client.DownloadStringAsync(new(capes_latest_commit));
             }
         }
 
@@ -104,77 +107,96 @@ namespace RainMeadow
         {
             try
             {
-                using (WebClient client = new WebClient())
+
+                var cape_hash_file = Path.Combine(ModManager.GetModById("henpemaz_rainmeadow").path, "capes_hash.txt");
+                var capes_txt = Path.Combine(ModManager.GetModById("henpemaz_rainmeadow").path, "capes.txt");
+
+                // Download remote commit hash async.
+                getRemoteLatestCommit(commithash =>
                 {
-                    var cape_hash_file = Path.Combine(ModManager.GetModById("henpemaz_rainmeadow").path, "capes_hash.txt");
-                    var capes_txt = Path.Combine(ModManager.GetModById("henpemaz_rainmeadow").path, "capes.txt");
-
-                    // Download remote commit hash.
-                    string commithash = getRemoteLatestCommit();
-
-                    // Read local commit hash from file.
-                    string commithashlocal = string.Empty;
-                    if (File.Exists(cape_hash_file))
+                    using (WebClient client = new WebClient())
                     {
-                        using (FileStream stream = File.OpenRead(cape_hash_file))
-                        using (StreamReader reader = new(stream))
+
+                        // Read local commit hash from file.
+                        string commithashlocal = string.Empty;
+                        if (File.Exists(cape_hash_file))
                         {
-                            commithashlocal = reader.ReadLine();
+                            using (FileStream stream = File.OpenRead(cape_hash_file))
+                            using (StreamReader reader = new(stream))
+                            {
+                                commithashlocal = reader.ReadLine();
+                            }
+                        }
+
+                        // Only download the new capes when we hashes don't match.
+                        if (commithash != commithashlocal)
+                        {
+                            RainMeadow.Debug("Local hash doesn't match, downloading remote.");
+                            using (FileStream stream = File.Create(cape_hash_file))
+                            using (StreamWriter writer = new(stream))
+                            {
+                                writer.WriteLine(commithash);
+                            }
+
+                            client.DownloadStringCompleted += (s, a) =>
+                            {
+                                using (FileStream stream = File.Create(capes_txt))
+                                using (StreamWriter writer = new(stream))
+                                {
+                                    writer.WriteLine(a.Result);
+                                }
+
+                                // Wait for a download before processing
+                                ProcessFile();
+                            };
+
+                            client.DownloadStringAsync(new(capes_remote_txt));
+                        }
+                        else
+                        {
+                            // Process file without downloading.
+                            ProcessFile();
                         }
                     }
-
-
-                    // Only download the new capes when we hashes don't match.
-                    if (commithash != commithashlocal)
-                    {
-                        RainMeadow.Debug("Local hash doesn't match, downloading remote.");
-                        using (FileStream stream = File.Create(cape_hash_file))
-                        using (StreamWriter writer = new(stream))
-                        {
-                            writer.WriteLine(commithash);
-                        }
-                        string response = client.DownloadString(capes_remote_txt);
-                        using (FileStream stream = File.Create(capes_txt))
-                        using (StreamWriter writer = new(stream))
-                        {
-                            writer.WriteLine(response);
-                        }
-                    }
-
-                    entries.Clear();
-                    // process capes from file.
-                    using (FileStream capefile = File.OpenRead(capes_txt))
-                    using (StreamReader capestream = new StreamReader(capefile))
-                    {
-                        while (true)
-                        {
-                            var line = capestream.ReadLine();
-                            if (line == null) break;
-
-                            // Skip the header or empty lines
-                            if (string.IsNullOrWhiteSpace(line) || line.StartsWith("steamid64"))
-                                continue;
-
-                            // Split the line into parts
-                            string[] parts = line.Split(new[] { ',' }, 2, StringSplitOptions.RemoveEmptyEntries);
-                            if (parts.Length < 2) continue;
-
-                            string HashedsteamId64 = parts[0].Trim();
-                            string colorPart = parts[1].Split(';')[0].Trim(); // Extract only the color part
-                            string color = colorPart.Trim('(', ')'); // Remove parentheses around the color
-
-                            // Check if the color is a list of floats (RGB)
-                            ICapeColor capeColor = ParseCapeColor(color);
-
-                            // Add the parsed entry to the list
-                            if (!entries.ContainsKey(HashedsteamId64)) entries.Add(HashedsteamId64, capeColor);
-                        }
-                    }
-                }
+                });
             }
             catch (Exception except)
             {
                 RainMeadow.Error(except);
+            }
+        }
+
+        static public void ProcessFile()
+        {
+            var capes_txt = Path.Combine(ModManager.GetModById("henpemaz_rainmeadow").path, "capes.txt");
+            entries.Clear();
+            // process capes from file.
+            using (FileStream capefile = File.OpenRead(capes_txt))
+            using (StreamReader capestream = new StreamReader(capefile))
+            {
+                while (true)
+                {
+                    var line = capestream.ReadLine();
+                    if (line == null) break;
+
+                    // Skip the header or empty lines
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("steamid64"))
+                        continue;
+
+                    // Split the line into parts
+                    string[] parts = line.Split(new[] { ',' }, 2, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length < 2) continue;
+
+                    string HashedsteamId64 = parts[0].Trim();
+                    string colorPart = parts[1].Split(';')[0].Trim(); // Extract only the color part
+                    string color = colorPart.Trim('(', ')'); // Remove parentheses around the color
+
+                    // Check if the color is a list of floats (RGB)
+                    ICapeColor capeColor = ParseCapeColor(color);
+
+                    // Add the parsed entry to the list
+                    if (!entries.ContainsKey(HashedsteamId64)) entries.Add(HashedsteamId64, capeColor);
+                }
             }
         }
 

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -262,7 +262,7 @@ public class RainMeadowOptions : OptionInterface
 
         boughtGoldenSkin = config.Bind("BoughtGoldenSkin", false);
         boughtRainbowCape = config.Bind("BoughtRainbowCape", false);
-        currentlyActiveCapeColor = config.Bind("CurrentlyActiveCapeColor", "FF0000");
+        currentlyActiveCapeColor = config.Bind("CurrentlyActiveCapeColor", "");
 
         ArenaFoodScore = config.Bind("ArenaFoodScore", 1);
         ArenaSpearHitScore = config.Bind("ArenaSpearHitScore", 0);
@@ -503,16 +503,16 @@ public class RainMeadowOptions : OptionInterface
                 {
                     capeColor.value = value.Remove(6, value.Length - 6);
                 }
-                else if (value.Length < 6)
+                else if (value.Length < 6 && value.Length > 0)
                 {
                     capeColor.value = oldValue;
                 }
-                if (value.Any(c => !"0123456789abcdefABCDEF".Contains(c)))
+                if (value != "" && value.Any(c => !"0123456789abcdefABCDEF".Contains(c)))
                 {
                     capeColor.value = oldValue;
                 }
                 currentlyActiveCapeColor.Value = capeColor.value;
-                capeColorPreview.colorFill = Menu.MenuColorEffect.HexToColor(capeColor.value);
+                capeColorPreview.colorFill = Utils.SafeHexToColor(capeColor.value);
             };
             introroll.OnValueChanged += (UIconfig config, string value, string oldValue) =>
             {

--- a/GameModes/SlugcatCustomization.cs
+++ b/GameModes/SlugcatCustomization.cs
@@ -13,7 +13,7 @@ namespace RainMeadow
         public bool globalMute { get; set; } = RainMeadow.rainMeadowOptions.GlobalMute.Value;
 
         public bool wearingCape { get; set; } = RainMeadow.rainMeadowOptions.WearingCape.Value && RainMeadow.rainMeadowOptions.EnableMeadowCosmetics.Value;
-        public ICapeColor? eventCape { get; set; } = RainMeadow.rainMeadowOptions.wantsRainbowCape.Value ? (SpecialEvents.EventActiveInLobby<SpecialEvents.Anniversary>() ? new RainbowCapeColor() : new SolidCapeColor(Menu.MenuColorEffect.HexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value))) : new SolidCapeColor(Menu.MenuColorEffect.HexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value));
+        public ICapeColor? eventCape { get; set; } = RainMeadow.rainMeadowOptions.wantsRainbowCape.Value ? (SpecialEvents.EventActiveInLobby<SpecialEvents.Anniversary>() ? new RainbowCapeColor() : new SolidCapeColor(Utils.SafeHexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value))) : new SolidCapeColor(Utils.SafeHexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value));
         public Color bodyColor { get => currentColors[0]; set => currentColors[0] = value; }
         public Color eyeColor { get => currentColors[1]; set => currentColors[1] = value; }
         public bool fakePup { get; set; }

--- a/GameModes/SlugcatCustomization.cs
+++ b/GameModes/SlugcatCustomization.cs
@@ -13,7 +13,7 @@ namespace RainMeadow
         public bool globalMute { get; set; } = RainMeadow.rainMeadowOptions.GlobalMute.Value;
 
         public bool wearingCape { get; set; } = RainMeadow.rainMeadowOptions.WearingCape.Value && RainMeadow.rainMeadowOptions.EnableMeadowCosmetics.Value;
-        public ICapeColor? eventCape { get; set; } = RainMeadow.rainMeadowOptions.wantsRainbowCape.Value ? (SpecialEvents.EventActiveInLobby<SpecialEvents.Anniversary>() ? new RainbowCapeColor() : new SolidCapeColor(Utils.SafeHexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value))) : new SolidCapeColor(Utils.SafeHexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value));
+        public ICapeColor? eventCape { get; set; } = RainMeadow.rainMeadowOptions.wantsRainbowCape.Value ? (SpecialEvents.EventActiveInLobby<SpecialEvents.Anniversary>() ? new RainbowCapeColor() : (RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value == "" ? null : new SolidCapeColor(Utils.SafeHexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value)))) : (RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value == "" ? null : new SolidCapeColor(Utils.SafeHexToColor(RainMeadow.rainMeadowOptions.currentlyActiveCapeColor.Value)));
         public Color bodyColor { get => currentColors[0]; set => currentColors[0] = value; }
         public Color eyeColor { get => currentColors[1]; set => currentColors[1] = value; }
         public bool fakePup { get; set; }

--- a/Utils/Utils.cs
+++ b/Utils/Utils.cs
@@ -128,5 +128,16 @@ namespace RainMeadow
 
             return fromStart.Take(toTake).ToList();
         }
+
+        public static Color SafeHexToColor(string hex)
+        {
+            try
+            {
+                if (hex != "000000")
+                return Custom.hexToColor(hex);
+            }
+            catch (Exception) {}
+            return new Color(0.01f, 0.01f, 0.01f, 1f);
+        }
     }
 }


### PR DESCRIPTION
- Makes `CapeManager.FetchCapes` use async download calls and callbacks to prevent the main thread from being blocked when making web requests to github. 
- Fixes two bugs in cape PR 
   - Fixed having an invalid color causing an exception that'd prevent you from joining or creating lobbies.
   - Leaving the cape color value blank will default to whatever cape we've given you including custom capes.