### PR TITLE
Fixed Gourmand not being exhausted remotely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fixed parried spears not being deflected on late parries.
 - Fixed explosive spears still damaging the player when parried.
 - Fixed sound/visual cue of parrying being inconsistant.
+- Fixed gourmand not being shown as exhausted when throwing a spear
 ## Meadow
 - Fixed creatures being able to get injured.
 ### Modders

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -129,6 +129,38 @@ public partial class RainMeadow
         // IL.Player.ReleaseObject += Player_SynchronizeSocialEventDrop;
 
         On.Player.ProcessDebugInputs += Player_ProcessDebugInputs;
+
+        IL.Player.ClassMechanicsGourmand += Player_ClassMechanicsGourmand_GourmandRemoteExhaustFix;
+    }
+
+    private void Player_ClassMechanicsGourmand_GourmandRemoteExhaustFix(ILContext il)
+    {
+        try
+        {
+            ILCursor cursor = new ILCursor(il);
+            ILLabel label = cursor.DefineLabel();
+
+            if (cursor.TryGotoNext(MoveType.Before, 
+                x => x.MatchLdarg(0),
+                x => x.MatchLdfld<Player>(nameof(Player.gourmandExhausted))))
+            {
+                // Skip the gourmand exhausted check if the player is remote. RealizedPlayerState will do the job.
+                label = cursor.MarkLabel();
+                cursor.Index = 0;
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate((Player player) => player.abstractCreature?.GetOnlineCreature()?.isMine is false);
+                cursor.Emit(OpCodes.Brfalse, cursor.Next);
+                cursor.Emit(OpCodes.Br, label);
+            }
+            else
+            {
+                 RainMeadow.Error("Couldn't find where to hook :<");
+            }
+        }
+        catch (Exception e)
+        {
+            RainMeadow.Error("Exception while hooking :" +e);
+        }
     }
 
     private void Player_ProcessDebugInputs(On.Player.orig_ProcessDebugInputs orig, Player self)

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -129,38 +129,6 @@ public partial class RainMeadow
         // IL.Player.ReleaseObject += Player_SynchronizeSocialEventDrop;
 
         On.Player.ProcessDebugInputs += Player_ProcessDebugInputs;
-
-        IL.Player.ClassMechanicsGourmand += Player_ClassMechanicsGourmand_GourmandRemoteExhaustFix;
-    }
-
-    private void Player_ClassMechanicsGourmand_GourmandRemoteExhaustFix(ILContext il)
-    {
-        try
-        {
-            ILCursor cursor = new ILCursor(il);
-            ILLabel label = cursor.DefineLabel();
-
-            if (cursor.TryGotoNext(MoveType.Before, 
-                x => x.MatchLdarg(0),
-                x => x.MatchLdfld<Player>(nameof(Player.gourmandExhausted))))
-            {
-                // Skip the gourmand exhausted check if the player is remote. RealizedPlayerState will do the job.
-                label = cursor.MarkLabel();
-                cursor.Index = 0;
-                cursor.Emit(OpCodes.Ldarg_0);
-                cursor.EmitDelegate((Player player) => player.abstractCreature?.GetOnlineCreature()?.isMine is false);
-                cursor.Emit(OpCodes.Brfalse, cursor.Next);
-                cursor.Emit(OpCodes.Br, label);
-            }
-            else
-            {
-                 RainMeadow.Error("Couldn't find where to hook :<");
-            }
-        }
-        catch (Exception e)
-        {
-            RainMeadow.Error("Exception while hooking :" +e);
-        }
     }
 
     private void Player_ProcessDebugInputs(On.Player.orig_ProcessDebugInputs orig, Player self)

--- a/Online/State/RealizedPlayerState.cs
+++ b/Online/State/RealizedPlayerState.cs
@@ -157,6 +157,8 @@ namespace RainMeadow
         private Vector2? pointingDir;
         [OnlineFieldHalf]
         public float rippleDeathIntensity;
+        [OnlineFieldHalf]
+        public float aerobicLevel;
 
         public RealizedPlayerState() { }
         public RealizedPlayerState(OnlineCreature onlineEntity) : base(onlineEntity)
@@ -174,6 +176,7 @@ namespace RainMeadow
             glowing = p.glowing;
             lungsExhausted = p.lungsExhausted;
             rippleDeathIntensity = p.rippleDeathIntensity;
+            aerobicLevel = p.aerobicLevel;
 
             var extras = RainMeadow.playerExtras.GetOrCreateValue(p);
             afkSleep = extras.afkSleep;
@@ -293,6 +296,7 @@ namespace RainMeadow
             p.flipDirection = flipDirection ? 1 : -1;
             p.glowing = glowing;
             p.lungsExhausted = lungsExhausted;
+            p.aerobicLevel = aerobicLevel;
 
             var extras = RainMeadow.playerExtras.GetOrCreateValue(p);
             extras.afkSleep = afkSleep;


### PR DESCRIPTION
This one is surprisingly tricky, but was fixed easily.
From the code, it really looked like gourmand exhaust should have been synced fine, but it can be clearly proven false by throwing a spear as gourmand and observing that the otehrs will not see a tired beast.
Since `aerobicLevel` is not synced in Meadow, Gourmand was always resetting its `gourmandExhausted` to false (unless you also got your aerobic level to go down remotely, by jumping or drowning for example), so my fix was to simply... skip this part of the code if it's a remote player.

I've done minimal testing, the hook didn't crash and seems to show the expected behaviour

Cheers !