### PR TITLE
fix: watcher warping and serialization angry noises

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -102,9 +102,6 @@ namespace RainMeadow
                 }
             }
         }
-        /// ChangeRooms dereferences world.GetAbstractRoom for both the old and the new coordinate, and
-        /// either resolves to null once a coordinate names a room outside this world - which is routine
-        /// when a state arrives from a player who has already warped to another region.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CanChangeRoomsTo(this AbstractPhysicalObject apo, WorldCoordinate newCoord)
         {

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -21,16 +21,17 @@ namespace RainMeadow
             return new Color(((value >> 16) & 0xff) / 255f, ((value >> 8) & 0xff) / 255f, (value & 0xff) / 255f);
         }
 
+        // GetAbstractRoom returns null for a coord outside this world, AKA watcher
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static WorldSession? GetResource(this World world)
+        public static WorldSession? GetResource(this World? world)
         {
-            return WorldSession.map.TryGetValue(world, out var ws) ? ws : null;
+            return world is not null && WorldSession.map.TryGetValue(world, out var ws) ? ws : null;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static RoomSession? GetResource(this AbstractRoom room)
+        public static RoomSession? GetResource(this AbstractRoom? room)
         {
-            return RoomSession.map.TryGetValue(room, out var rs) ? rs : null;
+            return room is not null && RoomSession.map.TryGetValue(room, out var rs) ? rs : null;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -65,7 +66,7 @@ namespace RainMeadow
         public static bool IsLocal(this PhysicalObject po, out OnlinePhysicalObject? opo) => IsLocal(po.abstractPhysicalObject, out opo);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool CanMove(this AbstractPhysicalObject apo, WorldCoordinate? newCoord=null, bool quiet=false)
+        public static bool CanMove(this AbstractPhysicalObject apo, WorldCoordinate? newCoord = null, bool quiet = false)
         {
             if (!GetOnlineObject(apo, out var oe)) return true;
             if (!oe.isMine && !oe.beingMoved && (newCoord is null || oe.roomSession is null || oe.roomSession.absroom.index != newCoord.Value.room))
@@ -76,14 +77,16 @@ namespace RainMeadow
             return true;
         }
 
-        public static void MoveMovable(this AbstractPhysicalObject apo, WorldCoordinate newCoord) {
-            foreach (AbstractPhysicalObject obj in apo.GetAllConnectedObjects()) {
+        public static void MoveMovable(this AbstractPhysicalObject apo, WorldCoordinate newCoord)
+        {
+            foreach (AbstractPhysicalObject obj in apo.GetAllConnectedObjects())
+            {
                 if (obj.CanMove(newCoord, true))
-                {   
+                {
                     if (newCoord.CompareDisregardingTile(obj.pos)) return;
 
                     obj.timeSpentHere = 0;
-                    if (newCoord.room != obj.pos.room)
+                    if (newCoord.room != obj.pos.room && obj.CanChangeRoomsTo(newCoord))
                     {
                         obj.ChangeRooms(newCoord);
                     }
@@ -94,27 +97,50 @@ namespace RainMeadow
                     }
 
                     obj.pos = newCoord;
-                    obj.world.GetResource().ApoEnteringWorld(obj);
-                    obj.world.GetAbstractRoom(newCoord.room).GetResource()?.ApoEnteringRoom(obj, newCoord);
-                } 
+                    obj.world.GetResource()?.ApoEnteringWorld(obj);
+                    obj.world?.GetAbstractRoom(newCoord.room).GetResource()?.ApoEnteringRoom(obj, newCoord);
+                }
             }
         }
-        public static void MoveOnly(this AbstractPhysicalObject apo, WorldCoordinate newCoord) {
-            if (apo.CanMove(newCoord, true)) {
+        /// ChangeRooms dereferences world.GetAbstractRoom for both the old and the new coordinate, and
+        /// either resolves to null once a coordinate names a room outside this world - which is routine
+        /// when a state arrives from a player who has already warped to another region.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CanChangeRoomsTo(this AbstractPhysicalObject apo, WorldCoordinate newCoord)
+        {
+            return apo.world is not null
+                && apo.world.IsRoomInRegion(apo.pos.room)
+                && apo.world.IsRoomInRegion(newCoord.room);
+        }
+
+        public static void MoveOnly(this AbstractPhysicalObject apo, WorldCoordinate newCoord)
+        {
+            if (apo.CanMove(newCoord, true))
+            {
                 if (newCoord.CompareDisregardingTile(apo.pos)) return;
 
                 apo.timeSpentHere = 0;
                 if (newCoord.room != apo.pos.room)
                 {
-                    try {
-                        apo.ChangeRooms(newCoord);
-                    } catch (Exception except) {
-                        RainMeadow.Error(except);
-                        RainMeadow.Debug("Manually setting room");
+                    if (apo.CanChangeRoomsTo(newCoord))
+                    {
+                        try
+                        {
+                            apo.ChangeRooms(newCoord);
+                        }
+                        catch (Exception except)
+                        {
+                            RainMeadow.Error(except);
+                            RainMeadow.Debug("Manually setting room");
+                            apo.world?.GetAbstractRoom(apo.pos)?.RemoveEntity(apo);
+                            apo.world?.GetAbstractRoom(newCoord)?.AddEntity(apo);
+                        }
+                    }
+                    else // one end is in another region, place it by hand as far as we can
+                    {
                         apo.world?.GetAbstractRoom(apo.pos)?.RemoveEntity(apo);
                         apo.world?.GetAbstractRoom(newCoord)?.AddEntity(apo);
                     }
-                    
                 }
 
                 if (!newCoord.TileDefined && apo.pos.room == newCoord.room)
@@ -123,12 +149,12 @@ namespace RainMeadow
                 }
 
                 apo.pos = newCoord;
-                apo.world.GetResource().ApoEnteringWorld(apo);
-                apo.world.GetAbstractRoom(newCoord.room).GetResource()?.ApoEnteringRoom(apo, newCoord);
+                apo.world.GetResource()?.ApoEnteringWorld(apo);
+                apo.world?.GetAbstractRoom(newCoord.room).GetResource()?.ApoEnteringRoom(apo, newCoord);
             }
         }
 
-        public static bool RemoveFromShortcuts<T>(ref List<T> vessels, Creature creature, AbstractRoom? room = null) where T : ShortcutHandler.Vessel 
+        public static bool RemoveFromShortcuts<T>(ref List<T> vessels, Creature creature, AbstractRoom? room = null) where T : ShortcutHandler.Vessel
         {
             bool removefromallrooms = room is null;
             for (int i = 0; i < vessels.Count; i++)
@@ -150,7 +176,7 @@ namespace RainMeadow
             if (RemoveFromShortcuts(ref handler.transportVessels, creature, room)) found = true;
             if (RemoveFromShortcuts(ref handler.borderTravelVessels, creature, room)) found = true;
             if (RemoveFromShortcuts(ref handler.betweenRoomsWaitingLobby, creature, room)) found = true;
-            
+
             if (!found) RainMeadow.Debug("not found");
             return found;
         }
@@ -224,7 +250,7 @@ namespace RainMeadow
 
         public static T? GetValueOrDefault<T>(this IList<T> iList, int index, T? defaultVal)
         {
-            return iList != null && index >= 0 && iList.Count > index? iList[index] : defaultVal;
+            return iList != null && index >= 0 && iList.Count > index ? iList[index] : defaultVal;
         }
 
         public static bool CloseEnoughZeroSnap(this Vector2 a, Vector2 b, float sqrltol)
@@ -377,9 +403,9 @@ namespace RainMeadow
             {
                 WorkingObjects.Reverse();
             }
-            for (int i=0; i < WorkingObjects.Count - 1; i++)
+            for (int i = 0; i < WorkingObjects.Count - 1; i++)
             {
-                TryMutualBind(menu, WorkingObjects[i], WorkingObjects[i+1], leftRight, bottomTop);
+                TryMutualBind(menu, WorkingObjects[i], WorkingObjects[i + 1], leftRight, bottomTop);
             }
             if (loopLastIndex)
             {
@@ -391,11 +417,11 @@ namespace RainMeadow
         {
             //Clean up the lists
             List<MenuObject> ListA = fromObjectsList.Where(MenuObject => MenuObject != null).ToList(); //If our input lists contain null entries (such as uninitialized), just remove them and continue as if they don't exist.
-            List<MenuObject> ListB =   toObjectsList.Where(MenuObject => MenuObject != null).ToList();
+            List<MenuObject> ListB = toObjectsList.Where(MenuObject => MenuObject != null).ToList();
             if (ListA.Count < 1) { RainMeadow.Warn(" Tried to UI keybind to an empty or null fromObjects, cancelling operation. Is the list not yet populated?"); return; }
-            if (ListB.Count < 1) { RainMeadow.Warn(" Tried to UI keybind to an empty or null toObjects, cancelling operation. Is the list not yet populated?");   return; }
+            if (ListB.Count < 1) { RainMeadow.Warn(" Tried to UI keybind to an empty or null toObjects, cancelling operation. Is the list not yet populated?"); return; }
             if (reverseFromList) { ListA.Reverse(); }
-            if (reverseToList)   { ListB.Reverse(); }
+            if (reverseToList) { ListB.Reverse(); }
             if (swapLists) { (ListA, ListB) = (ListB, ListA); }
             //Create 2 button pointers, one for each list
             int NotSoLeastCommonMultiple = (ListA.Count - 1) * (ListB.Count - 1);
@@ -442,11 +468,11 @@ namespace RainMeadow
             //Find which direction we need to bind, then bind. Referencing the index of a division is conceptually sketchy, but the math checks out and has been throughly tested. Worst-case scenario it's integer division anyway.
             TryBind(
                 ListA[ListAStepper / Math.Max(1, ListB.Count - 1)],
-                ListB[TargetStep   / Math.Max(1, ListA.Count - 1)],
-                top:   !isTempSwap && areRows,
+                ListB[TargetStep / Math.Max(1, ListA.Count - 1)],
+                top: !isTempSwap && areRows,
                 bottom: isTempSwap && areRows,
                 right: !isTempSwap && areColumns,
-                left:   isTempSwap && areColumns
+                left: isTempSwap && areColumns
             );
         }
         /// <summary>Hybrid of TrySeqentualMutualBind() and TryParallelStitchBind(); find the best way to bind a list of lists together. Rain World handles MutualBinds from BOTTOM TO TOP, or left to right, use reverseListList if you want the readability.</summary>

--- a/GameModes/MeadowGameMode.cs
+++ b/GameModes/MeadowGameMode.cs
@@ -22,7 +22,7 @@ namespace RainMeadow
         public override List<string> nonGameplayRemixSettings
         {
             get => null;
-            set { }  
+            set { }
         }
 
 
@@ -137,7 +137,7 @@ namespace RainMeadow
 
         public override void PlayerLeftLobby(OnlinePlayer player)
         {
-            base.PlayerLeftLobby(player); 
+            base.PlayerLeftLobby(player);
             if (lobby.isOwner)
             {
                 var musicdata = lobby.GetData<MeadowMusic.LobbyMusicData>();
@@ -154,24 +154,20 @@ namespace RainMeadow
                 RainMeadow.Debug("Setting up region data");
                 MeadowRegionData regionData = overworld.GetData<MeadowRegionData>();
 
-                var totalRooms = 0;
-                var totalRegions = overworld.overWorld.regions.Length;
+                // Little update to accomodate which regions have actually been added to the Overworld worldSessions
+                var established = overworld.overWorld.regions.Where(r => overworld.worldSessions.ContainsKey(r.name)).ToArray();
+                var totalRegions = established.Length;
+                var totalRooms = established.Sum(r => r.numberOfRooms);
 
-                regionData.regionSpawnWeights = new float[totalRegions];
+                regionData.regionSpawnWeights = new float[overworld.overWorld.regions.Length];
                 if (overworld.isOwner)
                 {
                     RainMeadow.Debug($"Goal setup for {totalRegions} regions");
-                    regionData.regionRedTokensGoal = new ushort[totalRegions];
-                    regionData.regionBlueTokensGoal = new ushort[totalRegions];
-                    regionData.regionGoldTokensGoal = new ushort[totalRegions];
-                    regionData.regionGhostsGoal = new ushort[totalRegions];
+                    regionData.regionRedTokensGoal = new ushort[overworld.overWorld.regions.Length];
+                    regionData.regionBlueTokensGoal = new ushort[overworld.overWorld.regions.Length];
+                    regionData.regionGoldTokensGoal = new ushort[overworld.overWorld.regions.Length];
+                    regionData.regionGhostsGoal = new ushort[overworld.overWorld.regions.Length];
                 } // otherwise the above is initialized on state receive
-
-                for (int i = 0; i < totalRegions; i++)
-                {
-                    var region = overworld.overWorld.regions[i];
-                    totalRooms += region.numberOfRooms;
-                }
 
                 // around 60 per region, or 1 per room
                 regionData.redTokensGoal = (int)(16 * totalRegions + 0.4f * totalRooms);
@@ -181,20 +177,19 @@ namespace RainMeadow
                 // around 7 per region
                 regionData.ghostsGoal = (int)(5 * totalRegions + 0.05f * totalRooms);
 
-                for (int i = 0; i < totalRegions; i++)
+                foreach (var region in established)
                 {
-                    var region = overworld.overWorld.regions[i];
                     // weighted half by region plus half by relative number of rooms
                     var spawnWeight = 0.5f / totalRegions + 0.5f * region.numberOfRooms / (float)totalRooms;
 
-                    regionData.regionSpawnWeights[i] = spawnWeight;
+                    regionData.regionSpawnWeights[region.regionNumber] = spawnWeight;
                     if (overworld.isOwner)
                     {
                         // default starting values
-                        regionData.regionRedTokensGoal[i] = (ushort)(regionData.redTokensGoal * spawnWeight);
-                        regionData.regionBlueTokensGoal[i] = (ushort)(regionData.blueTokensGoal * spawnWeight);
-                        regionData.regionGoldTokensGoal[i] = (ushort)(regionData.goldTokensGoal * spawnWeight);
-                        regionData.regionGhostsGoal[i] = (ushort)(regionData.ghostsGoal * spawnWeight);
+                        regionData.regionRedTokensGoal[region.regionNumber] = (ushort)(regionData.redTokensGoal * spawnWeight);
+                        regionData.regionBlueTokensGoal[region.regionNumber] = (ushort)(regionData.blueTokensGoal * spawnWeight);
+                        regionData.regionGoldTokensGoal[region.regionNumber] = (ushort)(regionData.goldTokensGoal * spawnWeight);
+                        regionData.regionGhostsGoal[region.regionNumber] = (ushort)(regionData.ghostsGoal * spawnWeight);
                     } // otherwise received from owner
                 }
             }
@@ -331,7 +326,12 @@ namespace RainMeadow
                 weight += weights[i];
                 if (weight > rnd) return i;
             }
-            return weights.Length - 1; // exact 1 or fpe
+            // walk back to the last entry that could actually have been picked
+            for (int i = weights.Length - 1; i >= 0; i--)
+            {
+                if (weights[i] > 0f) return i;
+            }
+            return weights.Length - 1;
         }
 
         [RPCMethod]
@@ -339,16 +339,28 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby.overworld.isOwner && OnlineManager.lobby.overworld.isActive)
             {
-                RainMeadow.Debug($"Item consumed: {OnlineManager.lobby.overworld.subresources[region].Id()} {type} from {evt.from}");
+                var consumedIn = OnlineManager.lobby.overworld.SubresourceFromShortId(region);
+                if (consumedIn == null)
+                {
+                    RainMeadow.Error($"Item consumed in region {region}, which we never established");
+                    return;
+                }
+                RainMeadow.Debug($"Item consumed: {consumedIn.Id()} {type} from {evt.from}");
                 var lobbyData = OnlineManager.lobby.overworld.GetData<MeadowRegionData>();
                 var newRegion = RandomIndexFromWeightedList(lobbyData.regionSpawnWeights);
+                var spawnIn = OnlineManager.lobby.overworld.SubresourceFromShortId((ushort)newRegion);
+                if (spawnIn == null)
+                {
+                    RainMeadow.Error($"Picked region {newRegion} to respawn in, which isn't established");
+                    return;
+                }
                 if (type == RainMeadow.Ext_PhysicalObjectType.MeadowTokenRed)
                 {
                     if (lobbyData.regionRedTokensGoal[region] > 0)
                     {
                         lobbyData.regionRedTokensGoal[region] -= 1;
                         lobbyData.regionRedTokensGoal[newRegion] += 1;
-                        OnlineManager.lobby.overworld.subresources[newRegion].owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
+                        spawnIn.owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
                     }
                 }
                 else if (type == RainMeadow.Ext_PhysicalObjectType.MeadowTokenBlue)
@@ -357,7 +369,7 @@ namespace RainMeadow
                     {
                         lobbyData.regionBlueTokensGoal[region] -= 1;
                         lobbyData.regionBlueTokensGoal[newRegion] += 1;
-                        OnlineManager.lobby.overworld.subresources[newRegion].owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
+                        spawnIn.owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
                     }
                 }
                 else if (type == RainMeadow.Ext_PhysicalObjectType.MeadowTokenGold)
@@ -366,7 +378,7 @@ namespace RainMeadow
                     {
                         lobbyData.regionGoldTokensGoal[region] -= 1;
                         lobbyData.regionGoldTokensGoal[newRegion] += 1;
-                        OnlineManager.lobby.overworld.subresources[newRegion].owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
+                        spawnIn.owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
                     }
                 }
                 else if (type == RainMeadow.Ext_PhysicalObjectType.MeadowGhost)
@@ -375,7 +387,7 @@ namespace RainMeadow
                     {
                         lobbyData.regionGhostsGoal[region] -= 1;
                         lobbyData.regionGhostsGoal[newRegion] += 1;
-                        OnlineManager.lobby.overworld.subresources[newRegion].owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
+                        spawnIn.owner?.InvokeRPC(SpawnItem, (byte)newRegion, type);
                     }
                 }
             }
@@ -386,8 +398,13 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby.overworld.isActive)
             {
-                RainMeadow.Debug($"Item respawning: {OnlineManager.lobby.overworld.subresources[region].Id()} {type} from {evt.from}");
-                var ws = OnlineManager.lobby.overworld.subresources[region] as WorldSession;
+                var ws = OnlineManager.lobby.overworld.SubresourceFromShortId(region) as WorldSession;
+                if (ws == null)
+                {
+                    RainMeadow.Error($"Asked to respawn an item in region {region}, which isn't established");
+                    return;
+                }
+                RainMeadow.Debug($"Item respawning: {ws.Id()} {type} from {evt.from}");
                 if (ws.isActive && ws.isOwner)
                 {
                     var regionData = ws.GetData<MeadowWorldData>();

--- a/GameModes/OnlineGameMode.cs
+++ b/GameModes/OnlineGameMode.cs
@@ -288,17 +288,66 @@ namespace RainMeadow
             return true;
         }
 
+        // OverWorld.region calls Region.LoadAllRegions. 
+        // Vanilla == 11
+        // MSC == 22
+        // Watcher == 52
+        // We do not need to store that much crap at once for Watcher in our OverworldSession resource, it breaks WorldState zipping
         public virtual void EstablishWorlds(OverworldSession overworldSession)
         {
+            var reachable = ReachableRegions(overworldSession);
+            var skipped = new List<string>();
             foreach (Region region in overworldSession.overWorld.regions)
             {
-                overworldSession.EstablishWorld(region.name, checked((ushort)region.regionNumber));
+                if (reachable == null || reachable.Contains(region.name) || reachable.Any(r => Region.EquivalentRegion(r, region.name)))
+                {
+                    overworldSession.EstablishWorld(region.name, checked((ushort)region.regionNumber));
+                }
+                else
+                {
+                    skipped.Add(region.name);
+                }
             }
+            if (skipped.Count > 0) RainMeadow.Debug($"Established {overworldSession.worldSessions.Count}/{overworldSession.overWorld.regions.Length} regions, skipped: {string.Join(" ", skipped)}");
+        }
+
+        /// <summary>
+        /// The regions this session is able to load, or null to establish all
+        /// </summary>
+        protected virtual HashSet<string>? ReachableRegions(OverworldSession overworldSession)
+        {
+            return RegionsReachableBy(LoadWorldAs(overworldSession.overWorld.game));
+        }
+
+        protected static HashSet<string>? RegionsReachableBy(SlugcatStats.Name? slugcat)
+        {
+            if (slugcat == null) return null;
+            // rift warps can drop the Watcher into any region in the file
+            if (slugcat == Watcher.WatcherEnums.SlugcatStatsName.Watcher) return null;
+
+            var reachable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                reachable.UnionWith(SlugcatStats.SlugcatStoryRegions(slugcat));
+                reachable.UnionWith(SlugcatStats.SlugcatOptionalRegions(slugcat));
+            }
+            catch (Exception e) // a slugcat from another mod, who knows
+            {
+                RainMeadow.Error($"Couldn't determine reachable regions for {slugcat}, establishing all of them: " + e);
+                return null;
+            }
+
+
+            return reachable.Count > 0 ? reachable : null;
         }
 
         public virtual WorldSession LinkWorld(World world)
         {
-            OnlineManager.lobby.overworld.worldSessions.TryGetValue(world.region.name, out var worldSession);
+            if (!OnlineManager.lobby.overworld.worldSessions.TryGetValue(world.region.name, out var worldSession))
+            {
+                // log error
+                RainMeadow.Error($"No WorldSession established for region {world.region.name}, it will not be synced");
+            }
             return worldSession;
         }
 

--- a/GameModes/OnlineGameModeHelpers.cs
+++ b/GameModes/OnlineGameModeHelpers.cs
@@ -10,8 +10,8 @@ namespace RainMeadow
         {
             if (OnlineManager.lobby.overworld != null && OnlineManager.lobby.overworld.isAvailable)
             {
-                OnlineManager.lobby.overworld.Deactivate();
                 OnlineManager.lobby.overworld.NotNeeded();
+                OnlineManager.lobby.overworld.Deactivate();
             }
         }
         public HashSet<PlacedObject.Type> cosmeticItems = new()

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -176,6 +176,14 @@ namespace RainMeadow
             return game?.GetStorySession.saveState.currentTimelinePosition ?? SlugcatStats.SlugcatToTimeline(currentCampaign);
         }
 
+        protected override HashSet<string>? ReachableRegions(OverworldSession overworldSession)
+        {
+            var reachable = base.ReachableRegions(overworldSession); // LoadWorldAs == currentCampaign
+            // whatever region the lobby is currently sitting in
+            if (reachable != null && region != null) reachable.Add(region);
+            return reachable;
+        }
+
         public override bool ShouldSpawnFly(FliesWorldAI self, int spawnRoom)
         {
             if (OnlineManager.mePlayer.isActuallySpectating)
@@ -299,7 +307,6 @@ namespace RainMeadow
 
             if (MainAvatar is null) throw new InvalidProgrammerException("MainAvatar is null somehow");
             return MainAvatar;
-            return null;
         }
 
         public override void ConfigureAvatar(OnlineCreature onlineCreature)

--- a/Online/Serialization/DeflateState.cs
+++ b/Online/Serialization/DeflateState.cs
@@ -1,4 +1,5 @@
 ﻿using Ionic.Zlib;
+using System;
 using System.IO;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -34,10 +35,21 @@ namespace RainMeadow
         private static byte[] Compress(Stream input, int len)
         {
             using (var compressStream = new MemoryStream())
-            using (var compressor = new DeflateStream(compressStream, CompressionMode.Compress))
             {
-                input.CopyTo(compressor, len);
-                compressor.Close();
+                using (var compressor = new DeflateStream(compressStream, CompressionMode.Compress))
+                {
+
+
+                    var chunk = new byte[8192];
+                    int remaining = len;
+                    while (remaining > 0)
+                    {
+                        int read = input.Read(chunk, 0, Math.Min(chunk.Length, remaining));
+                        if (read <= 0) break;
+                        compressor.Write(chunk, 0, read);
+                        remaining -= read;
+                    }
+                }
                 return compressStream.ToArray();
             }
         }

--- a/Online/State/AbstractPhysicalObjectState.cs
+++ b/Online/State/AbstractPhysicalObjectState.cs
@@ -115,12 +115,17 @@ namespace RainMeadow
                 }
                 bool wasbeingmoved = onlineObject.beingMoved;
                 onlineObject.beingMoved = true;
-                if (wasPos.room != apo.pos.room) {
-                    if (apo.realizedObject != null && apo.realizedObject.room != null) {
+                if (wasPos.room != apo.pos.room)
+                {
+                    if (apo.realizedObject != null && apo.realizedObject.room != null)
+                    {
                         apo.realizedObject.room.RemoveObject(apo.realizedObject);
                     }
                 }
-                if (apo.world.IsRoomInRegion(apo.pos.room)) apo.MoveOnly(pos);
+                // check THE DESTINATION. The room we're told to move to isn't in this
+                // world when the sender has moved to another region and we haven' followed them
+                // This significantly helps Watcher warping which used to cause Null keys on MoveOnly
+                if (apo.world.IsRoomInRegion(pos.room)) apo.MoveOnly(pos);
                 onlineObject.beingMoved = false;
                 onlineObject.apo.pos = pos; // pos isn't updated if compareDisregardingTile, but please, do
             }


### PR DESCRIPTION
Henpe some of these changes may no longer be required post-compression fix will test later, just check DeflateStream.cs for now and lmk thoughts. I originally thought it was all linked but I'll split these into multiple PRs as needed 

- Improves watcher warping integrity by updating some logic in MoveOnly. 
- Fixed sub-optimal region loading. Overworld loads all regions by default. We store that in our overworld session. That led to a lot of unnecessary information being passed around. Instead OnlineGameMode just grabs the regions relative to the lobby (timeline, campaign) instead of adding in everything Watcher DLC adds (like 52 regions). 
- As a result, Meadow mode was updated to accommodate this. 
- Fixes serialization poisoning in the DeflateStrea's Compress().

TL;DR the Compress() of DeflateStream was using CopyTo and passing in the buffer size, not length. So every compressed packet had stale buffer data and was too big to send. So fixed to only copy what we wrote. 

The symptom of this was you'd join something that'd push the Serializer to the edge (Watcher) story, then you'd jump into a different story mode or even another game mode and the Serializer got poisoned by the massive 192Kb buffer story watcher savestate string and filled it with ~142Kb of data.

 And changing lobbies doesn't clean up the raw bytes, so other sessions kept hanging onto it, meaning even a low-impact gamemode like Meadow got hit.

These changes have been tested across all three game modes for 3 hours.
- Meadow had tokens and ghosts present across 3 different regions
- Story mode worked as expected
- Arena worked as expected