### PR TITLE
fix: compress only the bytes the state wrote

### DIFF
--- a/Online/Serialization/DeflateState.cs
+++ b/Online/Serialization/DeflateState.cs
@@ -1,4 +1,5 @@
 ﻿using Ionic.Zlib;
+using System;
 using System.IO;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -34,10 +35,21 @@ namespace RainMeadow
         private static byte[] Compress(Stream input, int len)
         {
             using (var compressStream = new MemoryStream())
-            using (var compressor = new DeflateStream(compressStream, CompressionMode.Compress))
             {
-                input.CopyTo(compressor, len);
-                compressor.Close();
+                using (var compressor = new DeflateStream(compressStream, CompressionMode.Compress))
+                {
+
+
+                    var chunk = new byte[8192];
+                    int remaining = len;
+                    while (remaining > 0)
+                    {
+                        int read = input.Read(chunk, 0, Math.Min(chunk.Length, remaining));
+                        if (read <= 0) break;
+                        compressor.Write(chunk, 0, read);
+                        remaining -= read;
+                    }
+                }
                 return compressStream.ToArray();
             }
         }


### PR DESCRIPTION
Fixes painful bug Watcher exposed where a large state dirties the serializer so any state over zipTreshold could never be sent. A dropped state never becomes the acked baseline, so the subscription fell back to sending a full state every tick, leading to a death loop. 

This was tested across all modes for many hours