### PR TITLE
Minor UI/SFX fixes

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -3394,16 +3394,25 @@ namespace RainMeadow
             Menu.ArenaOverlay self
         )
         {
-            if (isArenaMode(out var arena))
+            if (!isArenaMode(out _))
             {
-                if (!OnlineManager.lobby.isOwner)
-                {
-                    self.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Player_Ready);
-                    return;
-                }
+                orig(self);
+                return;
             }
 
-            orig(self);
+            foreach (OnlinePlayer player in OnlineManager.players.Where(x => x != OnlineManager.mePlayer))
+                player.InvokeRPC(ArenaRPCs.Arena_ReadyForNextRound);
+            if (OnlineManager.lobby.isOwner)
+            {
+                foreach (ArenaSitting.ArenaPlayer player in self.ArenaSitting.players)
+                    player.readyForNextRound = true;
+                self.PlaySound(SoundID.UI_Multiplayer_All_Players_Ready);
+                self.countdownToNextRound = self.countdownToNextRound == -1 ? 10 : Math.Min(self.countdownToNextRound, 10);
+            }
+            else
+            {
+                self.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Player_Ready);
+            }
         }
 
         public void ArenaGameSession_Update(

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -3075,6 +3075,12 @@ namespace RainMeadow
 
                 self.continueButton.menuLabel.text = self.Translate("TO LOBBY");
 
+                foreach (FSprite sprite in self.continueButton.roundedRect.sprites)
+                    sprite.MoveToFront();
+                foreach (FSprite sprite in self.continueButton.selectRect.sprites)
+                    sprite.MoveToFront();
+                self.continueButton.menuLabel.label.MoveToFront();
+
                 var exitButton = new Menu.SimpleButton(
                     self,
                     self.pages[0],

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -603,7 +603,7 @@ namespace RainMeadow
                 c.GotoNext(
                     MoveType.After,
                     i => i.MatchLdfld<PlayerResultMenu>(nameof(PlayerResultMenu.result)),
-                    i => i.MatchCallvirt(typeof(List<ArenaSitting.ArenaPlayer>).GetProperty(nameof(List<>.Count))!.GetGetMethod())
+                    i => i.MatchCallvirt(typeof(List<ArenaSitting.ArenaPlayer>).GetProperty(nameof(List<ArenaSitting.ArenaPlayer>.Count))!.GetGetMethod())
                 );
                 c.EmitDelegate(() => isArenaMode(out _));
                 c.Emit(OpCodes.Brfalse, skipIfNotArenaMode);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -3400,19 +3400,9 @@ namespace RainMeadow
                 return;
             }
 
-            foreach (OnlinePlayer player in OnlineManager.players.Where(x => x != OnlineManager.mePlayer))
+            ArenaRPCs.Arena_ReadyForNextRound();
+            foreach (OnlinePlayer player in OnlineManager.players.Where(x => !x.isMe))
                 player.InvokeRPC(ArenaRPCs.Arena_ReadyForNextRound);
-            if (OnlineManager.lobby.isOwner)
-            {
-                foreach (ArenaSitting.ArenaPlayer player in self.ArenaSitting.players)
-                    player.readyForNextRound = true;
-                self.PlaySound(SoundID.UI_Multiplayer_All_Players_Ready);
-                self.countdownToNextRound = self.countdownToNextRound == -1 ? 10 : Math.Min(self.countdownToNextRound, 10);
-            }
-            else
-            {
-                self.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Player_Ready);
-            }
         }
 
         public void ArenaGameSession_Update(

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -72,7 +72,6 @@ namespace RainMeadow
 
             On.HUD.HUD.InitMultiplayerHud += HUD_InitMultiplayerHud;
 
-            On.Menu.ArenaOverlay.PlayerPressedContinue += ArenaOverlay_PlayerPressedContinue;
             On.Menu.ArenaOverlay.Update += ArenaOverlay_Update;
             On.Menu.FinalResultbox.ctor += FinalResultbox_ctor;
             On.Menu.PlayerResultBox.ctor += PlayerResultBox_ctor;
@@ -598,6 +597,19 @@ namespace RainMeadow
                     c.Emit(Mono.Cecil.Cil.OpCodes.Ret);
                     c.MarkLabel(continueAsNormal);
                 }
+
+                c.Index = 0;
+                ILLabel skipIfNotArenaMode = c.DefineLabel();
+                c.GotoNext(
+                    MoveType.After,
+                    i => i.MatchLdfld<PlayerResultMenu>(nameof(PlayerResultMenu.result)),
+                    i => i.MatchCallvirt(typeof(List<ArenaSitting.ArenaPlayer>).GetProperty(nameof(List<>.Count))!.GetGetMethod())
+                );
+                c.EmitDelegate(() => isArenaMode(out _));
+                c.Emit(OpCodes.Brfalse, skipIfNotArenaMode);
+                c.Emit(OpCodes.Pop);
+                c.Emit(OpCodes.Ldc_I4, 0);
+                c.MarkLabel(skipIfNotArenaMode);
             }
             catch (Exception e)
             {
@@ -1316,6 +1328,21 @@ namespace RainMeadow
             orig(self);
             if (isArenaMode(out var arena))
             {
+                if (self.allResultBoxesInPlaceCounter > 10)
+                {
+                    int playerNumber = ArenaHelpers.FindOnlinePlayerNumber(arena, OnlineManager.mePlayer);
+                    if (playerNumber != -1 && !self.result[playerNumber].readyForNextRound)
+                    {
+                        Player.InputPackage myInputPackage = RWInput.PlayerInput(0);
+                        if (myInputPackage.jmp || myInputPackage.thrw || myInputPackage.pckp || myInputPackage.mp)
+                        {
+                            ArenaRPCs.Arena_ReadyForNextRound();
+                            foreach (OnlinePlayer player in OnlineManager.players.Where(x => !x.isMe))
+                                player.InvokeRPC(ArenaRPCs.Arena_ReadyForNextRound);
+                        }
+                    }
+                }
+
                 if (arena.leaveForNextLevel)
                 {
                     string loadingString;
@@ -3387,22 +3414,6 @@ namespace RainMeadow
             {
                 return orig(self, shortcutVessel);
             }
-        }
-
-        public void ArenaOverlay_PlayerPressedContinue(
-            On.Menu.ArenaOverlay.orig_PlayerPressedContinue orig,
-            Menu.ArenaOverlay self
-        )
-        {
-            if (!isArenaMode(out _))
-            {
-                orig(self);
-                return;
-            }
-
-            ArenaRPCs.Arena_ReadyForNextRound();
-            foreach (OnlinePlayer player in OnlineManager.players.Where(x => !x.isMe))
-                player.InvokeRPC(ArenaRPCs.Arena_ReadyForNextRound);
         }
 
         public void ArenaGameSession_Update(

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -3395,13 +3395,6 @@ namespace RainMeadow
                     self.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Player_Ready);
                     return;
                 }
-                else
-                {
-                    for (int i = 0; i < self.result.Count; i++)
-                    {
-                        self.result[i].readyForNextRound = true;
-                    }
-                }
             }
 
             orig(self);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1187,6 +1187,8 @@ namespace RainMeadow
             int index
         )
         {
+            MenuMicrophone menuMic = owner.menu.manager.menuMic;
+
             if (isArenaMode(out var arena))
             {
 
@@ -1204,8 +1206,11 @@ namespace RainMeadow
                     arena.ReadFromStats(player, pl);
                 }
 
+                // prevents UI_Multiplayer_Player_Result_Box_Bump playing for every single player in the lobby at once
+                owner.menu.manager.menuMic = null;
             }
             orig(self, resultPage, owner, player, index);
+            owner.menu.manager.menuMic = menuMic;
         }
 
         public List<ArenaSitting.ArenaPlayer> ArenaSitting_FinalSittingResult(
@@ -3065,6 +3070,9 @@ namespace RainMeadow
             orig(self, manager);
             if (isArenaMode(out var arena))
             {
+                // play once per menu instead of per every FinalResultbox
+                manager.menuMic.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Bump);
+
                 self.continueButton.menuLabel.text = self.Translate("TO LOBBY");
 
                 var exitButton = new Menu.SimpleButton(

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1222,9 +1222,9 @@ namespace RainMeadow
 
             // after the constructor this list is only used for detecting ready input from the player
             // and whether all players are readied, limiting this list to just the local player after the ctor
-            // and not calling PlayerPressedContinue for non-host makes it so that
-            // a. the input is only registered for the current player, preventing the sfx from playing multiple times
-            // b. non-host readying doing nothing while host readying continuing the game, which is exactly what we want
+            // makes it so that the input is only registered for the current player,
+            // making PlayerPressedContinue only get called once,
+            // allowing us to write our own logic on readyForNextRound
             list.RemoveAll(x => ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, x.playerNumber)?.isMe != true);
         }
 

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1219,6 +1219,13 @@ namespace RainMeadow
 
             session.game.arenaOverlay = new Menu.ArenaOverlay(session.game.manager, self, list);
             session.game.manager.sideProcesses.Add(session.game.arenaOverlay);
+
+            // after the constructor this list is only used for detecting ready input from the player
+            // and whether all players are readied, limiting this list to just the local player after the ctor
+            // and not calling PlayerPressedContinue for non-host makes it so that
+            // a. the input is only registered for the current player, preventing the sfx from playing multiple times
+            // b. non-host readying doing nothing while host readying continuing the game, which is exactly what we want
+            list.RemoveAll(x => ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, x.playerNumber)?.isMe != true);
         }
 
         public virtual List<ArenaSitting.ArenaPlayer> FinalSittingResult(ArenaMode arena,

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1219,13 +1219,6 @@ namespace RainMeadow
 
             session.game.arenaOverlay = new Menu.ArenaOverlay(session.game.manager, self, list);
             session.game.manager.sideProcesses.Add(session.game.arenaOverlay);
-
-            // after the constructor this list is only used for detecting ready input from the player
-            // and whether all players are readied, limiting this list to just the local player after the ctor
-            // makes it so that the input is only registered for the current player,
-            // making PlayerPressedContinue only get called once,
-            // allowing us to write our own logic on readyForNextRound
-            list.RemoveAll(x => ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, x.playerNumber)?.isMe != true);
         }
 
         public virtual List<ArenaSitting.ArenaPlayer> FinalSittingResult(ArenaMode arena,

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -328,24 +328,29 @@ namespace RainMeadow
 
 
         [RPCMethod]
-        public static void Arena_ReadyForNextLevel()
+        public static void Arena_ReadyForNextRound(RPCEvent rpcEvent)
         {
-            if (RainMeadow.isArenaMode(out var arena))
+            if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arena))
+                return;
+            if (Custom.rainWorld.processManager.currentMainLoop is not RainWorldGame game)
+                return;
+            if (game.manager.upcomingProcess is not null)
+                return;
+            List<ArenaSitting.ArenaPlayer> players = game.GetArenaGameSession.arenaSitting.players;
+            if (rpcEvent.from == OnlineManager.lobby.owner)
             {
-                var lobby = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as ArenaLobbyMenu);
-                var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
-                if (game.manager.upcomingProcess != null)
-                {
-                    return;
-                }
-                for (int i = 0; i < game.arenaOverlay.resultBoxes.Count; i++)
-                {
-                    game.arenaOverlay.result[i].readyForNextRound = true;
-                }
-                game.arenaOverlay.nextLevelCall = true;
-
+                foreach (ArenaSitting.ArenaPlayer player in game.GetArenaGameSession.arenaSitting.players)
+                    player.readyForNextRound = true;
+                game.arenaOverlay.PlaySound(SoundID.UI_Multiplayer_All_Players_Ready);
             }
-
+            else
+            {
+                int index = ArenaHelpers.FindOnlinePlayerNumber(arena, rpcEvent.from);
+                if (index < 0 || index >= players.Count)
+                    return;
+                players[index].readyForNextRound = true;
+                game.arenaOverlay.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Player_Ready);
+            }
         }
 
 

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -1,3 +1,4 @@
+using System;
 using Menu;
 using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using UnityEngine;
@@ -328,7 +329,7 @@ namespace RainMeadow
 
 
         [RPCMethod]
-        public static void Arena_ReadyForNextRound(RPCEvent rpcEvent)
+        public static void Arena_ReadyForNextRound()
         {
             if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arena))
                 return;
@@ -336,19 +337,25 @@ namespace RainMeadow
                 return;
             if (game.manager.upcomingProcess is not null)
                 return;
-            List<ArenaSitting.ArenaPlayer> players = game.GetArenaGameSession.arenaSitting.players;
-            if (rpcEvent.from == OnlineManager.lobby.owner)
+            OnlinePlayer readyPlayer = RPCEvent.currentRPCEvent?.from ?? OnlineManager.mePlayer;
+            List<ArenaSitting.ArenaPlayer> arenaPlayers = game.GetArenaGameSession.arenaSitting.players;
+            if (readyPlayer == OnlineManager.lobby.owner)
             {
-                foreach (ArenaSitting.ArenaPlayer player in game.GetArenaGameSession.arenaSitting.players)
-                    player.readyForNextRound = true;
+                foreach (ArenaSitting.ArenaPlayer arenaPlayer in game.GetArenaGameSession.arenaSitting.players)
+                    arenaPlayer.readyForNextRound = true;
                 game.arenaOverlay.PlaySound(SoundID.UI_Multiplayer_All_Players_Ready);
+                if (readyPlayer.isMe)
+                {
+                    game.arenaOverlay.countdownToNextRound = game.arenaOverlay.countdownToNextRound == -1 ? 10 :
+                        Math.Min(game.arenaOverlay.countdownToNextRound, 10);
+                }
             }
             else
             {
-                int index = ArenaHelpers.FindOnlinePlayerNumber(arena, rpcEvent.from);
-                if (index < 0 || index >= players.Count)
+                int index = ArenaHelpers.FindOnlinePlayerNumber(arena, readyPlayer);
+                if (index < 0 || index >= arenaPlayers.Count)
                     return;
-                players[index].readyForNextRound = true;
+                arenaPlayers[index].readyForNextRound = true;
                 game.arenaOverlay.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Player_Ready);
             }
         }

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -338,10 +338,9 @@ namespace RainMeadow
             if (game.manager.upcomingProcess is not null)
                 return;
             OnlinePlayer readyPlayer = RPCEvent.currentRPCEvent?.from ?? OnlineManager.mePlayer;
-            List<ArenaSitting.ArenaPlayer> arenaPlayers = game.GetArenaGameSession.arenaSitting.players;
             if (readyPlayer == OnlineManager.lobby.owner)
             {
-                foreach (ArenaSitting.ArenaPlayer arenaPlayer in game.GetArenaGameSession.arenaSitting.players)
+                foreach (ArenaSitting.ArenaPlayer arenaPlayer in game.arenaOverlay.result)
                     arenaPlayer.readyForNextRound = true;
                 game.arenaOverlay.PlaySound(SoundID.UI_Multiplayer_All_Players_Ready);
                 if (readyPlayer.isMe)
@@ -353,9 +352,9 @@ namespace RainMeadow
             else
             {
                 int index = ArenaHelpers.FindOnlinePlayerNumber(arena, readyPlayer);
-                if (index < 0 || index >= arenaPlayers.Count)
+                if (index < 0 || index >= game.arenaOverlay.result.Count)
                     return;
-                arenaPlayers[index].readyForNextRound = true;
+                game.arenaOverlay.result[index].readyForNextRound = true;
                 game.arenaOverlay.PlaySound(SoundID.UI_Multiplayer_Player_Result_Box_Player_Ready);
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added scarfs(?)
 - Added Ownership view to Dev Tools.
   - Pressing '-' will allow you to view a list of players showing which objects they own and how many.
+- Fixed nametags visibly moving towards the correct position over a few frames when the nametag's on screen position instantly changes
 ### Modders
 - Added `MatchmakingManager.OnLobbyLeaving` event.
 - Added `ScrollableConfirmDialog` menu object
@@ -44,6 +45,9 @@
 - Fixed sound/visual cue of parrying being inconsistant.
 - Fixed gourmand not being shown as exhausted when throwing a spear
 - Added score tracker to in-game UI; can be toggled on & off. Check Meadow Arena Remix page
+- Fixed the result box bump sound effect on the final results screen playing per player instead of just once
+- Synced the players' ready state on the overlay results screen
+- Fixed the "TO LOBBY" button on the final results screen drawing behind result boxes
 ### Watcher
 - Gave summoned Ameobas the Watcher's body color
 ### Modders
@@ -52,6 +56,7 @@
 - Fixed creatures being able to get injured.
 ## Story
 - Allow players to spectate their own corpses as long as they still exist
+- Fixed players readied on the sleep screen hearing the continue sound many times in a row after the host continues
 ### Watcher
 - Fixed watcher warp not working when warping from a world for the second time in the cycle
 - Fixed prince's duplication

--- a/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -204,8 +204,10 @@ namespace RainMeadow
                 if (!player.isMe && !isTeammate)
                 {
                     show = false;
-                    pos.x = -1000;
-                    this.alpha = 0f;
+                    pos.x = -1000f;
+                    lastPos.x = -1000f;
+                    alpha = 0f;
+                    lastAlpha = 0f;
                 }
             }
 
@@ -225,7 +227,7 @@ namespace RainMeadow
                     this.pos = owner.drawpos;
                     if (owner.pointDir == Vector2.down) pos += new Vector2(0f, 45f);
 
-                    if (this.lastAlpha == 0) this.lastPos = pos;
+                    if (this.lastAlpha == 0 || owner.shouldSkipDrawposLerp || lastPos.x <= -999f) this.lastPos = pos;
 
                     if (owner.PlayerConsideredDead) this.alpha = Mathf.Min(this.alpha, 0.5f);
 
@@ -263,7 +265,8 @@ namespace RainMeadow
                 }
                 else
                 {
-                    pos.x = -1000;
+                    pos.x = -1000f;
+                    lastPos.x = -1000f;
                 }
 
                 this.counter++;

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -34,6 +34,7 @@ namespace RainMeadow
         public RoomCamera camera;
         private Rect camrect;
         public Vector2 drawpos;
+        public bool shouldSkipDrawposLerp;
         public bool found;
         public Vector2 pointDir;
         internal bool needed;
@@ -153,6 +154,11 @@ namespace RainMeadow
                 this.playerDisplay = new OnlinePlayerDisplay(this, customization, clientSettings.owner);
                 this.parts.Add(this.playerDisplay);
             }
+
+            shouldSkipDrawposLerp =
+                abstractPlayer.pos.room != lastWorldPos.room ||
+                camera.currentCameraPosition != lastCameraPos ||
+                camera.room.abstractRoom.index != lastAbstractRoom;
 
             Vector2 rawPos = new();
             // in this room

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -2045,7 +2045,11 @@ namespace RainMeadow
                 {
                     self.continueButton.signalText = "CONTINUE";
                     self.continueButton.menuLabel.text = self.Translate("CONTINUE");
-                    if (self.continueButton.toggled) self.Singal(self.continueButton, "CONTINUE");
+                    if (self.continueButton.toggled)
+                    {
+                        self.Singal(self.continueButton, "CONTINUE");
+                        self.continueButton.toggled = false;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
- fixed a bug in arena where after transitioning to MultiplayerResults, the result box bump sound effect would play for each player instead of just once, so the more players there are in the lobby the louder the sound, being potentially disturbing or dangerous in large lobbies
  - this is actually a vanilla bug but there the limit is 4 players so it isnt that much of a problem, this PR fixes it only for rain meadow
- fixed a bug in arena where making an input on the results overlay screen would call PlayerPressedContinue for each player, causing the ready sfx to play for each player as well instead of just once
  - the ui itself doesnt affect anything here since non-host players cant ready or unready when already in a match anyway (though it looks like it was intended to actually be implemented at some point?)
- fixed a bug in story where on the sleep screen if a non-host player readies up, then the host continues to the game, the sleep screen of the non-host player would try to switch to the game process every update, causing sfx spam
- fixed the "to lobby" button in MultiplayerResults in arena drawing behind the result boxes
  - visible if you scroll up enough or if there are enough players
- fixed a bug in story and arena where nametags can visibly "jump" instead of instantly teleporting when the camera moves or the player enters a pipe, etc.
  - by just setting lastPos/lastAlpha in spots where changes must be instant
  - this type of bug and this type of fix for it are very common in vanilla rain world too because of the way its programmed