### PR TITLE
Fit the main menu exit button in the first column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added scarfs(?)
 - Added Ownership view to Dev Tools.
   - Pressing '-' will allow you to view a list of players showing which objects they own and how many.
+- Fixed the exit button on the main menu getting pushed over to the second column if Expedition is enabled
 ### Modders
 - Added `MatchmakingManager.OnLobbyLeaving` event.
 - Added `ScrollableConfirmDialog` menu object

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -691,15 +691,15 @@ namespace RainMeadow
             try
             {
                 ILCursor cursor = new(il);
-                int maxCount = 0;
-                if (!cursor.TryGotoNext(code => code.MatchStloc(1)) ||
-                    !cursor.TryGotoPrev(MoveType.After, code => code.MatchLdcI4(out maxCount)))
-                {
-                    Warn("failed to increase main menu button limit");
-                    return;
-                }
-                cursor.Emit(OpCodes.Pop);
-                cursor.Emit(OpCodes.Ldc_I4, maxCount + 1);
+                const int maxCountLoc = 1; // int, max amount of buttons in a column
+
+                // int maxCount = _;
+                cursor.GotoNext(code => code.MatchStloc(maxCountLoc));
+                cursor.GotoPrev(MoveType.After, code => code.MatchLdcI4(out _));
+
+                // int maxCount = _ + 1;
+                cursor.Emit(OpCodes.Ldc_I4, 1);
+                cursor.Emit(OpCodes.Add);
             }
             catch (Exception ex)
             {

--- a/Menu/RainMeadow.MenuHooks.cs
+++ b/Menu/RainMeadow.MenuHooks.cs
@@ -19,6 +19,7 @@ namespace RainMeadow
     {
         private void EssentialMenuHooks()
         {
+            IL.Menu.MainMenu.AddMainMenuButton += IL_MainMenu_AddMainMenuButton;
             On.Menu.MainMenu.ctor += MainMenu_ctor;
         }
 
@@ -683,6 +684,28 @@ namespace RainMeadow
                 }
             }
             orig(self, ID);
+        }
+
+        private static void IL_MainMenu_AddMainMenuButton(ILContext il)
+        {
+            try
+            {
+                ILCursor cursor = new(il);
+                int maxCount = 0;
+                if (!cursor.TryGotoNext(code => code.MatchStloc(1)) ||
+                    !cursor.TryGotoPrev(MoveType.After, code => code.MatchLdcI4(out maxCount)))
+                {
+                    Warn("failed to increase main menu button limit");
+                    return;
+                }
+                cursor.Emit(OpCodes.Pop);
+                cursor.Emit(OpCodes.Ldc_I4, maxCount + 1);
+            }
+            catch (Exception ex)
+            {
+                Warn("failed to increase main menu button limit");
+                Error(ex);
+            }
         }
 
         private bool showed_no_steam_warning = false;


### PR DESCRIPTION
increases the limit of the vertical button columns on the main menu by 1 to fit in the meadow button without pushing exit to the second column
i'm not sure whether this is change desirable at this point but this patch is simple enough that its fine if this doesnt get merged
also not sure whether the hook should go in EssentialMenuHooks or MenuHooks, lmk if i should move it

| before | after |
|--------|--------|
| <img width="1368" height="800" alt="image" src="https://github.com/user-attachments/assets/2bf6867a-5e6c-4f79-956d-c28ceb12714a" /> | <img width="1368" height="800" alt="image" src="https://github.com/user-attachments/assets/fd362879-5557-43fe-ab68-dd0b170e07d5" />  |
