### PR TITLE
Improve arena timers

### DIFF
--- a/Arena/ArenaTimer.cs
+++ b/Arena/ArenaTimer.cs
@@ -32,6 +32,7 @@ namespace RainMeadow
             arena.arenaPrepTimer = this;
             session = arenaGameSession;
             arena.trackSetupTime = arena.externalArenaGameMode.SetTimer(arena);
+            arena.timerTicks = 0;
             matchMode = TimerMode.Waiting;
 
             timerLabel = new FLabel(Custom.GetFont(), FormatTime(0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fixed sound/visual cue of parrying being inconsistant.
 - Fixed gourmand not being shown as exhausted when throwing a spear
 - Added score tracker to in-game UI; can be toggled on & off. Check Meadow Arena Remix page
+- Slightly improved timer accuracy
 ### Watcher
 - Gave summoned Ameobas the Watcher's body color
 ### Modders

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -137,6 +137,8 @@ namespace RainMeadow
         // host needs time to do scoring for everyone else before they load the overlay
         public bool hostLoadedOverlay;
 
+        public uint timerTicks;
+
         public ArenaPrepTimer arenaPrepTimer;
         public int setupTime = RainMeadow.rainMeadowOptions.ArenaCountDownTimer.Value;
         public int lobbyCountDown;
@@ -1162,6 +1164,7 @@ namespace RainMeadow
         {
             setupTime = RainMeadow.rainMeadowOptions.ArenaCountDownTimer.Value;
             trackSetupTime = setupTime;
+            timerTicks = 0;
         }
 
         public void ResetPlayersEntered()
@@ -1290,8 +1293,6 @@ namespace RainMeadow
             return true;
         }
 
-        private int previousSecond = -1;
-
         public override void LobbyTick(uint tick)
         {
             if (leaveToRestart)
@@ -1303,9 +1304,8 @@ namespace RainMeadow
             base.LobbyTick(tick);
             if (OnlineManager.lobby.isOwner)
             {
-                DateTime currentTime = DateTime.UtcNow;
-                int currentSecond = currentTime.Second;
-                if (currentSecond != previousSecond)
+                timerTicks++;
+                if (timerTicks >= OnlineManager.instance.framesPerSecond)
                 {
                     if (forceReadyCountdownTimer > 0)
                     {
@@ -1323,7 +1323,7 @@ namespace RainMeadow
                             setupTime = externalArenaGameMode.TimerDirection(this, setupTime);
                         }
                     }
-                    previousSecond = currentSecond;
+                    timerTicks = 0;
                 }
             }
         }

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -270,6 +270,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
             if (Arena.lobbyCountDown > 0)
             {
                 Arena.initiateLobbyCountdown = true;
+                Arena.timerTicks = 0;
                 return;
             }
         }


### PR DESCRIPTION
fixes the timers sometimes starting off a bit too fast by slightly changing the timer logic

before this change the timers were based off the host's system time and advanced every time the second changed, which means that if the host starts the match at, say, 10:42:15.500, the match would start at 10:42:20.000 (in 4.5 seconds) instead of 10:42:20.500 (in 5 seconds, like intended)

after this change the timers are based off the lobbys update cycle, advancing every time the tick counter counts past `framesPerSecond` and resetting the counter every time a timer is started, which means timers properly count starting from the time they were started at (unless there are somehow a lobby countdown and a setup timer running at the same time)

this solution isnt perfect but this is way easier to implement into the current system than a solution based off syncing timer start/end timestamps instead of incrementing/decrementing timer variables every second manually