### PR TITLE
refactor: Simplify external arena game mode checks

### DIFF
--- a/Arena/ArenaHelpers.cs
+++ b/Arena/ArenaHelpers.cs
@@ -182,7 +182,6 @@ namespace RainMeadow
 
 
             OnlinePlayer? deadPlayer = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, excludedPlayerNumber);
-            bool isTeamBattle = TeamBattleMode.IsTeamBattleMode(out _);
             int[] allAlivePlayers = [];
 
             for (int i = 0; i < session.arenaSitting.players.Count; i++)
@@ -208,7 +207,7 @@ namespace RainMeadow
                 }
 
                 // EXCLUSION 3: Not on the same team
-                if (isTeamBattle && deadPlayer != null)
+                if (TeamBattleMode.IsTeamBattleMode(out _) && deadPlayer != null)
                 {
                     if (ArenaHelpers.CheckSameTeam(alivePlayer, deadPlayer)) continue;
                 }
@@ -484,10 +483,10 @@ namespace RainMeadow
         // Adding that function to hook for other mods
         public static Color GetAmoebaColor(OnlinePlayer owner, bool inOtherRipple = false)
         {
-            Color rawColor = (RainMeadow.isArenaMode(out var arena)
-                ? (TeamBattleMode.IsTeamBattleMode(out var tb)
+            Color rawColor = (RainMeadow.isArenaMode(out _)
+                ? (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle)
                         && OnlineManager.lobby.clientSettings[owner]?.TryGetData<ArenaTeamClientSettings>(out var tcs) is true
-                            ? tb.teamColors[tcs.team]
+                            ? teamBattle.teamColors[tcs.team]
                             : GetArenaClientSettings(owner)?.slugcatColor)
                 : null) ?? RainWorld.RippleColor;
             HSLColor hSLColor = rawColor.ToHSL();

--- a/Arena/ArenaHelpers.cs
+++ b/Arena/ArenaHelpers.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Menu;
 using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using UnityEngine;
-using MSCScene = MoreSlugcats.MoreSlugcatsEnums.MenuSceneID;
 
 namespace RainMeadow
 {
@@ -184,7 +182,7 @@ namespace RainMeadow
 
 
             OnlinePlayer? deadPlayer = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, excludedPlayerNumber);
-            bool isTeamBattle = TeamBattleMode.isTeamBattleMode(arena, out _);
+            bool isTeamBattle = TeamBattleMode.IsTeamBattleMode(out _);
             int[] allAlivePlayers = [];
 
             for (int i = 0; i < session.arenaSitting.players.Count; i++)
@@ -487,7 +485,7 @@ namespace RainMeadow
         public static Color GetAmoebaColor(OnlinePlayer owner, bool inOtherRipple = false)
         {
             Color rawColor = (RainMeadow.isArenaMode(out var arena)
-                ? (TeamBattleMode.isTeamBattleMode(arena, out var tb) 
+                ? (TeamBattleMode.IsTeamBattleMode(out var tb)
                         && OnlineManager.lobby.clientSettings[owner]?.TryGetData<ArenaTeamClientSettings>(out var tcs) is true
                             ? tb.teamColors[tcs.team]
                             : GetArenaClientSettings(owner)?.slugcatColor)

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -797,7 +797,7 @@ namespace RainMeadow
                 )
                     continue;
 
-                if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out var tb))
                 {
                     ArenaTeamClientSettings? playerTeam =
                         ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(oe!.owner);
@@ -1254,7 +1254,7 @@ namespace RainMeadow
                 {
                     arena.hostLoadedOverlay = true;
                 }
-                if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out var tb))
                 {
                     if (tb.winningTeam != -1)
                     {
@@ -2946,7 +2946,7 @@ namespace RainMeadow
                     {
                         userNameBackup = currentName.id.DisplayName;
                         self.playerNameLabel.text = userNameBackup;
-                        if (TeamBattleMode.isTeamBattleMode(arena, out var team))
+                        if (TeamBattleMode.IsTeamBattleMode(out var team))
                         {
                             if (
                                 OnlineManager
@@ -3119,7 +3119,7 @@ namespace RainMeadow
                 self.pages[0].subObjects.Add(exitButton);
 
                 string winnerName = "";
-                if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out var tb))
                 {
                     if (tb.winningTeam != -1)
                     {
@@ -3537,4 +3537,3 @@ namespace RainMeadow
         }
     }
 }
-

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -797,7 +797,7 @@ namespace RainMeadow
                 )
                     continue;
 
-                if (TeamBattleMode.IsTeamBattleMode(out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out _))
                 {
                     ArenaTeamClientSettings? playerTeam =
                         ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(oe!.owner);
@@ -1254,15 +1254,15 @@ namespace RainMeadow
                 {
                     arena.hostLoadedOverlay = true;
                 }
-                if (TeamBattleMode.IsTeamBattleMode(out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
                 {
-                    if (tb.winningTeam != -1)
+                    if (teamBattle.winningTeam != -1)
                     {
                         self.headingLabel.text = self.Translate("<TEAMNAME> WIN!")
                             .Replace(
                                 "<TEAMNAME>",
                                 MatchmakingManager.currentInstance.FilterTeamName(
-                                    tb.teamNames[tb.winningTeam].ToUpper()
+                                    teamBattle.teamNames[teamBattle.winningTeam].ToUpper()
                                 )
                             );
                     }
@@ -1272,13 +1272,11 @@ namespace RainMeadow
                         {
                             OnlinePlayer pl = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, box.player.playerNumber);
                             if (pl == null || box == null)
-                            {
                                 continue;
-                            }
+
                             if (OnlineManager.lobby.clientSettings.TryGetValue(pl, out var clientSettings) && clientSettings.TryGetData<ArenaTeamClientSettings>(out var teamSettings))
                             {
-                                box.player.score = tb.teamScores[teamSettings.team];
-
+                                box.player.score = teamBattle.teamScores[teamSettings.team];
                             }
                         }
                     }
@@ -2946,7 +2944,7 @@ namespace RainMeadow
                     {
                         userNameBackup = currentName.id.DisplayName;
                         self.playerNameLabel.text = userNameBackup;
-                        if (TeamBattleMode.IsTeamBattleMode(out var team))
+                        if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
                         {
                             if (
                                 OnlineManager
@@ -2955,7 +2953,7 @@ namespace RainMeadow
                             )
                             {
                                 self.playerNameLabel.text +=
-                                    $" -- {MatchmakingManager.currentInstance.FilterTeamName(team.teamNames[td.team].ToUpper())}";
+                                    $" -- {MatchmakingManager.currentInstance.FilterTeamName(teamBattle.teamNames[td.team].ToUpper())}";
                             }
 
                         }
@@ -3119,12 +3117,12 @@ namespace RainMeadow
                 self.pages[0].subObjects.Add(exitButton);
 
                 string winnerName = "";
-                if (TeamBattleMode.IsTeamBattleMode(out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
                 {
-                    if (tb.winningTeam != -1)
+                    if (teamBattle.winningTeam != -1)
                     {
                         winnerName = MatchmakingManager.currentInstance.FilterTeamName(
-                            tb.teamNames[tb.winningTeam].ToUpper()
+                            teamBattle.teamNames[teamBattle.winningTeam].ToUpper()
                         );
                         self.headingLabel.text = self.Translate("<TEAMNAME> WINS!")
                             .Replace("<TEAMNAME>",winnerName);
@@ -3141,7 +3139,7 @@ namespace RainMeadow
                             }
                             if (OnlineManager.lobby.clientSettings.TryGetValue(pl, out var clientSettings) && clientSettings.TryGetData<ArenaTeamClientSettings>(out var teamSettings))
                             {
-                                box.player.totScore = tb.teamScores[teamSettings.team];
+                                box.player.totScore = teamBattle.teamScores[teamSettings.team];
                             }
                         }
                     }

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -173,7 +173,7 @@ namespace RainMeadow
 
             if (!playerFound || !RoomSession.map.TryGetValue(self.room.abstractRoom, out var rs)) return;
             if (!killedCrit.abstractCreature.IsLocal()) return;
-            if (TeamBattleMode.isTeamBattleMode(arena, out _) && ArenaHelpers.CheckSameTeam(absPlayerCreature.owner, onlineKilledCreature.owner) && arena.killScore > 0)
+            if (TeamBattleMode.IsTeamBattleMode(out _) && ArenaHelpers.CheckSameTeam(absPlayerCreature.owner, onlineKilledCreature.owner) && arena.killScore > 0)
             {
                 // time for punishment
                 int badTeammateNumber = ArenaHelpers.FindOnlinePlayerNumber(arena, absPlayerCreature.owner);
@@ -321,7 +321,7 @@ namespace RainMeadow
                 return;
             }
 
-            if (TeamBattleMode.isTeamBattleMode(arena, out _) && ArenaHelpers.CheckSameTeam(player.abstractCreature.GetOnlineCreature()?.owner, target.abstractCreature.GetOnlineCreature()?.owner))
+            if (TeamBattleMode.IsTeamBattleMode(out _) && ArenaHelpers.CheckSameTeam(player.abstractCreature.GetOnlineCreature()?.owner, target.abstractCreature.GetOnlineCreature()?.owner))
             {
                 RainMeadow.Warn("Player_LandSpear: Players on same team, returning...");
                 return;
@@ -358,7 +358,7 @@ namespace RainMeadow
         {
             self.AddPart(new HUD.TextPrompt(self));
 
-            if (MatchmakingManager.currentInstance.canSendChatMessages 
+            if (MatchmakingManager.currentInstance.canSendChatMessages
                 && RMOverlayHUDMenu.TryGetOverlay(out var overlayHUD))
             {
                 if (overlayHUD.chatHud is null) overlayHUD.AddChatHUD(session.game.cameras[0]);
@@ -1058,7 +1058,7 @@ namespace RainMeadow
             List<ArenaSitting.ArenaPlayer> list = new List<ArenaSitting.ArenaPlayer>();
             int foodScore = self.gameTypeSetup.foodScore;
             bool countFood = foodScore != 0 && System.Math.Abs(foodScore) < 100;
-            bool isTeamMode = TeamBattleMode.isTeamBattleMode(arena, out var tb);
+            bool isTeamMode = TeamBattleMode.IsTeamBattleMode(out var tb);
 
             // 1. TALLY SCORES & SURVIVAL STATUS
             for (int i = 0; i < self.players.Count; i++)

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1058,7 +1058,7 @@ namespace RainMeadow
             List<ArenaSitting.ArenaPlayer> list = new List<ArenaSitting.ArenaPlayer>();
             int foodScore = self.gameTypeSetup.foodScore;
             bool countFood = foodScore != 0 && System.Math.Abs(foodScore) < 100;
-            bool isTeamMode = TeamBattleMode.IsTeamBattleMode(out var tb);
+            bool isTeamMode = TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle);
 
             // 1. TALLY SCORES & SURVIVAL STATUS
             for (int i = 0; i < self.players.Count; i++)
@@ -1129,7 +1129,7 @@ namespace RainMeadow
 
             if (isTeamMode)
             {
-                tb.winningTeam = tb.CalculateTeamScoresAndWinner(self.players, arena, arena.WinByScore, true, false);
+                teamBattle.winningTeam = teamBattle.CalculateTeamScoresAndWinner(self.players, arena, arena.WinByScore, true, false);
             }
 
             // 3. SORT PLAYERS (Using the newly cleaned, pure sort method)
@@ -1156,7 +1156,7 @@ namespace RainMeadow
             if (isTeamMode)
             {
                 // Everyone on the winning team wins, everyone else loses
-                if (tb.winningTeam != -1)
+                if (teamBattle.winningTeam != -1)
                 {
                     for (int x = 0; x < list.Count; x++)
                     {
@@ -1165,7 +1165,7 @@ namespace RainMeadow
 
                         if (OnlineManager.lobby.clientSettings[onlineP].TryGetData<ArenaTeamClientSettings>(out var teamInfo))
                         {
-                            list[x].winner = teamInfo.team == tb.winningTeam;
+                            list[x].winner = teamInfo.team == teamBattle.winningTeam;
                         }
                     }
                 }

--- a/Arena/ArenaOnlineGameModes/ChallengeMode/Challenge.cs
+++ b/Arena/ArenaOnlineGameModes/ChallengeMode/Challenge.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Linq;
 using Menu;
+using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using UnityEngine;
 
 namespace RainMeadow.Arena.ArenaOnlineGameModes.ArenaChallengeModeNS
@@ -27,21 +29,30 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.ArenaChallengeModeNS
             SandboxSettingsInterface.DefaultKillScores(ref self.killScores);
         }
 
-        public static bool isChallengeMode(
-            ArenaOnlineGameMode arena,
-            out ArenaChallengeMode challenge
-        )
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the online game mode is <see cref="ArenaOnlineGameMode"/>
+        /// and <see cref="ArenaChallengeMode"/> is not registered.
+        /// </exception>
+        public static bool IsChallengeMode(out ArenaChallengeMode challenge)
         {
-            challenge = null;
-            if (arena.currentGameMode == ChallengeMode.value)
+            challenge = null!;
+
+            if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arenaOnline))
+                return false;
+            if (!arenaOnline.registeredGameModes.TryGetValue(ChallengeMode.value, out ExternalArenaGameMode externalArena))
             {
-                challenge = (
-                    arena
-                        .registeredGameModes.FirstOrDefault(x => x.Key == ChallengeMode.value)
-                        .Value as ArenaChallengeMode
+                throw new InvalidOperationException(
+                    $"Could not find game mode. Registered: " +
+                    $"[ {string.Join(", ", arenaOnline.registeredGameModes.Keys)} ]."
                 );
+            }
+
+            if (arenaOnline.currentGameMode == ChallengeMode.value)
+            {
+                challenge = (ArenaChallengeMode)externalArena;
                 return true;
             }
+
             return false;
         }
 

--- a/Arena/ArenaOnlineGameModes/ChallengeMode/ChallengeLobbyData.cs
+++ b/Arena/ArenaOnlineGameModes/ChallengeMode/ChallengeLobbyData.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using RainMeadow.Arena.ArenaOnlineGameModes.ArenaChallengeModeNS;
-using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
-using UnityEngine;
 
 namespace RainMeadow
 {
@@ -25,29 +21,19 @@ namespace RainMeadow
 
             public State(ChallengeLobbyData arenaLobbyData, OnlineResource onlineResource)
             {
-                ArenaOnlineGameMode arena =
-                    (onlineResource as Lobby).gameMode as ArenaOnlineGameMode;
-                if (arena != null)
+                bool isCh = ArenaChallengeMode.IsChallengeMode(out var chMode);
+                if (isCh && chMode != null)
                 {
-                    bool isCh = ArenaChallengeMode.isChallengeMode(arena, out var chMode);
-                    if (isCh && chMode != null)
-                    {
-                        challengeID = chMode.challengeID;
-                    }
+                    challengeID = chMode.challengeID;
                 }
             }
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
             {
-                var lobby = (resource as Lobby);
-                var arena = (lobby.gameMode as ArenaOnlineGameMode);
-                if (arena != null)
+                bool isCh = ArenaChallengeMode.IsChallengeMode(out var chMode);
+                if (isCh && chMode != null)
                 {
-                    bool isCh = ArenaChallengeMode.isChallengeMode(arena, out var chMode);
-                    if (isCh && chMode != null)
-                    {
-                        chMode.challengeID = challengeID;
-                    }
+                    chMode.challengeID = challengeID;
                 }
             }
 

--- a/Arena/ArenaOnlineGameModes/ChallengeMode/ChallengeLobbyData.cs
+++ b/Arena/ArenaOnlineGameModes/ChallengeMode/ChallengeLobbyData.cs
@@ -19,22 +19,16 @@ namespace RainMeadow
 
             public State() { }
 
-            public State(ChallengeLobbyData arenaLobbyData, OnlineResource onlineResource)
+            public State(ChallengeLobbyData lobbyData, OnlineResource onlineResource)
             {
-                bool isCh = ArenaChallengeMode.IsChallengeMode(out var chMode);
-                if (isCh && chMode != null)
-                {
-                    challengeID = chMode.challengeID;
-                }
+                if (ArenaChallengeMode.IsChallengeMode(out ArenaChallengeMode challenge))
+                    challengeID = challenge.challengeID;
             }
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
             {
-                bool isCh = ArenaChallengeMode.IsChallengeMode(out var chMode);
-                if (isCh && chMode != null)
-                {
-                    chMode.challengeID = challengeID;
-                }
+                if (ArenaChallengeMode.IsChallengeMode(out ArenaChallengeMode challenge))
+                    challenge.challengeID = challengeID;
             }
 
             public override Type GetDataType() => typeof(TeamBattleLobbyData);

--- a/Arena/ArenaOnlineGameModes/Competitive.cs
+++ b/Arena/ArenaOnlineGameModes/Competitive.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using Menu;
-using RainMeadow;
 using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using UnityEngine;
 
@@ -17,17 +16,30 @@ namespace RainMeadow
         private int _timerDuration;
         public override ArenaSetup.GameTypeID GetGameModeId => FFA.FFAMode;
 
-        public static bool isFFA(ArenaOnlineGameMode arena, out FFA ffa)
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the online game mode is <see cref="ArenaOnlineGameMode"/>
+        /// and <see cref="FFA"/> is not registered.
+        /// </exception>
+        public static bool IsFfaMode(out FFA ffa)
         {
-            ffa = null;
-            if (arena.currentGameMode == FFAMode.value)
+            ffa = null!;
+
+            if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arenaOnline))
+                return false;
+            if (!arenaOnline.registeredGameModes.TryGetValue(FFAMode.value, out ExternalArenaGameMode externalArena))
             {
-                ffa = (
-                    arena.registeredGameModes.FirstOrDefault(x => x.Key == FFAMode.value).Value
-                    as FFA
+                throw new InvalidOperationException(
+                    $"Could not find game mode. Registered: " +
+                    $"[ {string.Join(", ", arenaOnline.registeredGameModes.Keys)} ]."
                 );
+            }
+
+            if (arenaOnline.currentGameMode == FFAMode.value)
+            {
+                ffa = (FFA)externalArena;
                 return true;
             }
+
             return false;
         }
 

--- a/Arena/ArenaOnlineGameModes/Drown/Drown.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/Drown.cs
@@ -288,7 +288,7 @@ namespace RainMeadow
         }
         public override void ArenaSessionEnded(ArenaOnlineGameMode arena, On.ArenaSitting.orig_SessionEnded orig, ArenaSitting self, ArenaGameSession session)
         {
-            if (IsDrownMode(out var drown))
+            if (IsDrownMode(out _))
             {
                 foreach (var player in self.players)
                 {
@@ -319,8 +319,7 @@ namespace RainMeadow
 
         public override void ArenaSessionUpdate(On.ArenaGameSession.orig_Update orig, ArenaGameSession self, ArenaOnlineGameMode arena)
         {
-
-            if (IsDrownMode(out var drown))
+            if (IsDrownMode(out DrownMode drown))
             {
                 if (!self.sessionEnded)
                 {

--- a/Arena/ArenaOnlineGameModes/Drown/Drown.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/Drown.cs
@@ -40,14 +40,30 @@ namespace RainMeadow
             return new DialogNotify(menu.LongTranslate("Kill & survive to buy your escape<LINE><LINE>Turn off Spear Hits for Co-Op"), new Vector2(500f, 400f), menu.manager, () => { menu.PlaySound(SoundID.MENU_Button_Standard_Button_Pressed); });
         }
 
-        public static bool isDrownMode(ArenaOnlineGameMode arena, out DrownMode mode)
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the online game mode is <see cref="ArenaOnlineGameMode"/>
+        /// and <see cref="DrownMode"/> is not registered.
+        /// </exception>
+        public static bool IsDrownMode(out DrownMode drown)
         {
-            mode = null;
-            if (arena.currentGameMode == Drown.value)
+            drown = null!;
+
+            if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arenaOnline))
+                return false;
+            if (!arenaOnline.registeredGameModes.TryGetValue(Drown.value, out ExternalArenaGameMode externalArena))
             {
-                mode = (arena.registeredGameModes.FirstOrDefault(x => x.Key == Drown.value).Value as DrownMode);
+                throw new InvalidOperationException(
+                    $"Could not find game mode. Registered: " +
+                    $"[ {string.Join(", ", arenaOnline.registeredGameModes.Keys)} ]."
+                );
+            }
+
+            if (arenaOnline.currentGameMode == Drown.value)
+            {
+                drown = (DrownMode)externalArena;
                 return true;
             }
+
             return false;
         }
 
@@ -272,7 +288,7 @@ namespace RainMeadow
         }
         public override void ArenaSessionEnded(ArenaOnlineGameMode arena, On.ArenaSitting.orig_SessionEnded orig, ArenaSitting self, ArenaGameSession session)
         {
-            if (isDrownMode(arena, out var drown))
+            if (IsDrownMode(out var drown))
             {
                 foreach (var player in self.players)
                 {
@@ -304,7 +320,7 @@ namespace RainMeadow
         public override void ArenaSessionUpdate(On.ArenaGameSession.orig_Update orig, ArenaGameSession self, ArenaOnlineGameMode arena)
         {
 
-            if (isDrownMode(arena, out var drown))
+            if (IsDrownMode(out var drown))
             {
                 if (!self.sessionEnded)
                 {

--- a/Arena/ArenaOnlineGameModes/Drown/DrownHooks.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/DrownHooks.cs
@@ -23,23 +23,20 @@ namespace RainMeadow
         public int ArenaGameSession_ScoreOfPlayerDrown(On.ArenaGameSession.orig_ScoreOfPlayer orig, ArenaGameSession self, Player player, bool inHands)
         {
             int score = orig(self, player, inHands);
-            if (DrownMode.IsDrownMode(out var d))
-            {
-                d.timerPoints = score;
-            }
+
+            if (DrownMode.IsDrownMode(out DrownMode drown))
+                drown.timerPoints = score;
+
             return score;
         }
 
         private void Player_checkInputDrown(On.Player.orig_checkInput orig, Player self)
         {
             orig(self);
-            if (DrownMode.IsDrownMode(out var _) && self.IsLocal())
+            if (DrownMode.IsDrownMode(out _) && self.IsLocal())
             {
                 if (ArenaHelpers.GetDataSettings<ArenaDrownClientSettings>(self.abstractCreature.GetOnlineCreature()?.owner)?.isInStore == true)
-                {
                     GameplayOverrides.StopPlayerMovement(self);
-                }
-
             }
         }
 
@@ -48,7 +45,7 @@ namespace RainMeadow
             // 1. ALWAYS run orig first. 
             int activeCount = orig(self, addToAliveTime, dontCountSandboxLosers);
 
-            if (DrownMode.IsDrownMode(out var drown))
+            if (DrownMode.IsDrownMode(out DrownMode drown))
             {
                 int canRespawnCount = 0;
                 bool teamWork = !self.GameTypeSetup.spearsHitPlayers;
@@ -119,7 +116,7 @@ namespace RainMeadow
                 c.Emit(OpCodes.Ldloc, 18);
                 c.EmitDelegate((Player self, PhysicalObject po) =>
                 {
-                    if (self.IsLocal() && isArenaMode(out ArenaOnlineGameMode arena) && DrownMode.IsDrownMode(out var drown))
+                    if (self.IsLocal() && isArenaMode(out ArenaOnlineGameMode arena) && DrownMode.IsDrownMode(out _))
                     {
                         try
                         {
@@ -159,13 +156,12 @@ namespace RainMeadow
         {
             orig(self, type, active);
             if (!self.IsLocal())
-            {
                 return;
-            }
-            if (RainMeadow.isArenaMode(out var arena) && DrownMode.IsDrownMode(out var drown))
+
+            if (isArenaMode(out ArenaOnlineGameMode arena) && DrownMode.IsDrownMode(out DrownMode drown))
             {
-                ArenaSitting sitting = self.room.game.GetArenaGameSession.arenaSitting;
-                sitting.players[ArenaHelpers.FindOnlinePlayerNumber(arena, OnlineManager.mePlayer)].score -= drown.spearCost;
+                ArenaSitting arenaSitting = self.room.game.GetArenaGameSession.arenaSitting;
+                arenaSitting.players[ArenaHelpers.FindOnlinePlayerNumber(arena, OnlineManager.mePlayer)].score -= drown.spearCost;
             }
 
         }

--- a/Arena/ArenaOnlineGameModes/Drown/DrownHooks.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/DrownHooks.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Drown;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
-using UnityEngine.SocialPlatforms.Impl;
 
 namespace RainMeadow
 {
@@ -25,7 +23,7 @@ namespace RainMeadow
         public int ArenaGameSession_ScoreOfPlayerDrown(On.ArenaGameSession.orig_ScoreOfPlayer orig, ArenaGameSession self, Player player, bool inHands)
         {
             int score = orig(self, player, inHands);
-            if (isArenaMode(out var arena) && DrownMode.isDrownMode(arena, out var d))
+            if (DrownMode.IsDrownMode(out var d))
             {
                 d.timerPoints = score;
             }
@@ -35,7 +33,7 @@ namespace RainMeadow
         private void Player_checkInputDrown(On.Player.orig_checkInput orig, Player self)
         {
             orig(self);
-            if (RainMeadow.isArenaMode(out var arena) && DrownMode.isDrownMode(arena, out var _) && self.IsLocal())
+            if (DrownMode.IsDrownMode(out var _) && self.IsLocal())
             {
                 if (ArenaHelpers.GetDataSettings<ArenaDrownClientSettings>(self.abstractCreature.GetOnlineCreature()?.owner)?.isInStore == true)
                 {
@@ -50,7 +48,7 @@ namespace RainMeadow
             // 1. ALWAYS run orig first. 
             int activeCount = orig(self, addToAliveTime, dontCountSandboxLosers);
 
-            if (RainMeadow.isArenaMode(out var arena) && DrownMode.isDrownMode(arena, out var drown))
+            if (DrownMode.IsDrownMode(out var drown))
             {
                 int canRespawnCount = 0;
                 bool teamWork = !self.GameTypeSetup.spearsHitPlayers;
@@ -121,7 +119,7 @@ namespace RainMeadow
                 c.Emit(OpCodes.Ldloc, 18);
                 c.EmitDelegate((Player self, PhysicalObject po) =>
                 {
-                    if (self.IsLocal() && RainMeadow.isArenaMode(out var arena) && DrownMode.isDrownMode(arena, out var drown))
+                    if (self.IsLocal() && isArenaMode(out ArenaOnlineGameMode arena) && DrownMode.IsDrownMode(out var drown))
                     {
                         try
                         {
@@ -164,7 +162,7 @@ namespace RainMeadow
             {
                 return;
             }
-            if (RainMeadow.isArenaMode(out var arena) && DrownMode.isDrownMode(arena, out var drown))
+            if (RainMeadow.isArenaMode(out var arena) && DrownMode.IsDrownMode(out var drown))
             {
                 ArenaSitting sitting = self.room.game.GetArenaGameSession.arenaSitting;
                 sitting.players[ArenaHelpers.FindOnlinePlayerNumber(arena, OnlineManager.mePlayer)].score -= drown.spearCost;

--- a/Arena/ArenaOnlineGameModes/Drown/DrownLobbyData.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/DrownLobbyData.cs
@@ -1,6 +1,4 @@
-using Drown;
 using System;
-using System.Linq;
 
 namespace RainMeadow
 {
@@ -52,8 +50,7 @@ namespace RainMeadow
             public State(DrownData drownLobbyData, OnlineResource onlineResource)
             {
 
-                ArenaOnlineGameMode arena = (onlineResource as Lobby).gameMode as ArenaOnlineGameMode;
-                var cachedDrown = DrownMode.isDrownMode(arena, out var drownData);
+                var cachedDrown = DrownMode.IsDrownMode(out var drownData);
 
                 if (cachedDrown)
                 {
@@ -77,8 +74,7 @@ namespace RainMeadow
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
             {
-                var lobby = (resource as Lobby);
-                var cachedDrown = DrownMode.isDrownMode((lobby.gameMode as ArenaOnlineGameMode), out var drownData);
+                var cachedDrown = DrownMode.IsDrownMode(out var drownData);
 
                 if (cachedDrown && drownData != null && (drownData as DrownMode != null))
                 {

--- a/Arena/ArenaOnlineGameModes/Drown/DrownLobbyData.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/DrownLobbyData.cs
@@ -47,49 +47,41 @@ namespace RainMeadow
             [OnlineField]
             bool densOpened;
             public State() { }
-            public State(DrownData drownLobbyData, OnlineResource onlineResource)
+            public State(DrownData lobbyData, OnlineResource onlineResource)
             {
-
-                var cachedDrown = DrownMode.IsDrownMode(out var drownData);
-
-                if (cachedDrown)
+                if (DrownMode.IsDrownMode(out DrownMode drown))
                 {
-                    currentWaveTimer = (drownData).currentWaveTimer;
-                    currentWave = drownData.currentWave;
-                    densOpened = drownData.openedDen;
-                    rockCost = drownData.rockCost;
-                    spearCost = drownData.spearCost;
-                    spearExplCost = drownData.spearExplCost;
-                    bombCost = drownData.bombCost;
-                    respCost = drownData.respCost;
-                    denCost = drownData.denCost;
-                    maxCreatures = drownData.maxCreatures;
-                    creatureCleanupWaves = drownData.creatureCleanupWaves;
-
+                    currentWaveTimer = drown.currentWaveTimer;
+                    currentWave = drown.currentWave;
+                    densOpened = drown.openedDen;
+                    rockCost = drown.rockCost;
+                    spearCost = drown.spearCost;
+                    spearExplCost = drown.spearExplCost;
+                    bombCost = drown.bombCost;
+                    respCost = drown.respCost;
+                    denCost = drown.denCost;
+                    maxCreatures = drown.maxCreatures;
+                    creatureCleanupWaves = drown.creatureCleanupWaves;
                 }
-
             }
 
             public override Type GetDataType() => typeof(DrownData);
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
             {
-                var cachedDrown = DrownMode.IsDrownMode(out var drownData);
-
-                if (cachedDrown && drownData != null && (drownData as DrownMode != null))
+                if (DrownMode.IsDrownMode(out DrownMode drown))
                 {
-                    (drownData).currentWaveTimer = currentWaveTimer;
-                    drownData.currentWave = currentWave;
-                    drownData.openedDen = densOpened;
-                    drownData.rockCost = rockCost;
-                    drownData.spearCost = spearCost;
-                    drownData.spearExplCost = spearExplCost;
-                    drownData.bombCost = bombCost;
-                    drownData.respCost = respCost;
-                    drownData.denCost = denCost;
-                    drownData.maxCreatures = maxCreatures;
-                    drownData.creatureCleanupWaves = creatureCleanupWaves;
-
+                    drown.currentWaveTimer = currentWaveTimer;
+                    drown.currentWave = currentWave;
+                    drown.openedDen = densOpened;
+                    drown.rockCost = rockCost;
+                    drown.spearCost = spearCost;
+                    drown.spearExplCost = spearExplCost;
+                    drown.bombCost = bombCost;
+                    drown.respCost = respCost;
+                    drown.denCost = denCost;
+                    drown.maxCreatures = maxCreatures;
+                    drown.creatureCleanupWaves = creatureCleanupWaves;
                 }
             }
         }

--- a/Arena/ArenaOnlineGameModes/Drown/DrownRPCS.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/DrownRPCS.cs
@@ -8,7 +8,7 @@ namespace RainMeadow
         [RPCMethod]
         public static void Arena_OpenDen(bool denOpen)
         {
-            if (DrownMode.IsDrownMode(out var drown))
+            if (DrownMode.IsDrownMode(out DrownMode drown))
             {
                 drown.openedDen = denOpen;
                 var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
@@ -37,7 +37,7 @@ namespace RainMeadow
         [RPCMethod]
         public static void Arena_RemoveAbstractCreatureFromList(RPCEvent e)
         {
-            if (DrownMode.IsDrownMode(out var drown))
+            if (DrownMode.IsDrownMode(out _))
             {
                 var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
                 if (game.manager.upcomingProcess != null)

--- a/Arena/ArenaOnlineGameModes/Drown/DrownRPCS.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/DrownRPCS.cs
@@ -1,7 +1,4 @@
 using Drown;
-using RainMeadow;
-using System;
-using System.Collections.Generic;
 
 namespace RainMeadow
 {
@@ -11,7 +8,7 @@ namespace RainMeadow
         [RPCMethod]
         public static void Arena_OpenDen(bool denOpen)
         {
-            if (RainMeadow.isArenaMode(out var arena) && DrownMode.isDrownMode(arena, out var drown))
+            if (DrownMode.IsDrownMode(out var drown))
             {
                 drown.openedDen = denOpen;
                 var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
@@ -40,7 +37,7 @@ namespace RainMeadow
         [RPCMethod]
         public static void Arena_RemoveAbstractCreatureFromList(RPCEvent e)
         {
-            if (RainMeadow.isArenaMode(out var arena) && DrownMode.isDrownMode(arena, out var drown))
+            if (DrownMode.IsDrownMode(out var drown))
             {
                 var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
                 if (game.manager.upcomingProcess != null)

--- a/Arena/ArenaOnlineGameModes/Drown/StoreOverlay.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/StoreOverlay.cs
@@ -56,9 +56,9 @@ namespace RainMeadow
                 (OpenDens, drown.denCost, RainMeadow.rainMeadowOptions.StoreItem8.Value)
             };
 
-            foreach (var itemData in storeItemsData)
+            if (DrownMode.IsDrownMode(out _))
             {
-                if (DrownMode.IsDrownMode(out var _))
+                foreach (var itemData in storeItemsData)
                 {
                     storeItemList.Add(new ArenaItemButton(this, pages[0], pos, itemData.name, itemData.cost, itemData.hotkey));
                     pos.y -= 40;
@@ -131,7 +131,7 @@ namespace RainMeadow
         {
             base.Update();
 
-            if (!RainMeadow.isArenaMode(out var arena) || !DrownMode.IsDrownMode(out var drownMode) || storeItemList.Count == 0)
+            if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arena) || !DrownMode.IsDrownMode(out _) || storeItemList.Count == 0)
                 return;
 
             bool isAlive = me != null && (me.state.alive || me.realizedCreature?.State?.alive == true);
@@ -147,7 +147,7 @@ namespace RainMeadow
                     bool greyedOut = item.itemName switch
                     {
                         Respawn => isAlive || !canAfford || drown.openedDen,
-                        OpenDens => drownMode.openedDen || !canAfford,
+                        OpenDens => drown.openedDen || !canAfford,
                         ElectricSpear => !ModManager.MSC || !canAfford || !isAlive,
                         Boomerang => !ModManager.Watcher || !canAfford || !isAlive,
                         _ => !canAfford || !isAlive

--- a/Arena/ArenaOnlineGameModes/Drown/StoreOverlay.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/StoreOverlay.cs
@@ -1,9 +1,7 @@
 using Menu;
 using System.Collections.Generic;
 using UnityEngine;
-using MoreSlugcats;
 using Drown;
-using System.CodeDom;
 
 namespace RainMeadow
 {
@@ -60,7 +58,7 @@ namespace RainMeadow
 
             foreach (var itemData in storeItemsData)
             {
-                if (DrownMode.isDrownMode(arena, out var _))
+                if (DrownMode.IsDrownMode(out var _))
                 {
                     storeItemList.Add(new ArenaItemButton(this, pages[0], pos, itemData.name, itemData.cost, itemData.hotkey));
                     pos.y -= 40;
@@ -133,7 +131,7 @@ namespace RainMeadow
         {
             base.Update();
 
-            if (!RainMeadow.isArenaMode(out var arena) || !DrownMode.isDrownMode(arena, out var drownMode) || storeItemList.Count == 0)
+            if (!RainMeadow.isArenaMode(out var arena) || !DrownMode.IsDrownMode(out var drownMode) || storeItemList.Count == 0)
                 return;
 
             bool isAlive = me != null && (me.state.alive || me.realizedCreature?.State?.alive == true);

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
@@ -15,17 +15,30 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
 
         public override ArenaSetup.GameTypeID GetGameModeId => TeamBattle;
 
-        public static bool isTeamBattleMode(ArenaOnlineGameMode arena, out TeamBattleMode tb)
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the online game mode is <see cref="ArenaOnlineGameMode"/>
+        /// and <see cref="TeamBattleMode"/> is not registered.
+        /// </exception>
+        public static bool IsTeamBattleMode(out TeamBattleMode teamBattle)
         {
-            tb = null;
-            if (arena.currentGameMode == TeamBattle.value)
+            teamBattle = null!;
+
+            if (!RainMeadow.isArenaMode(out ArenaOnlineGameMode arenaOnline))
+                return false;
+            if (!arenaOnline.registeredGameModes.TryGetValue(TeamBattle.value, out ExternalArenaGameMode externalArena))
             {
-                tb = (
-                    arena.registeredGameModes.FirstOrDefault(x => x.Key == TeamBattle.value).Value
-                    as TeamBattleMode
+                throw new InvalidOperationException(
+                    $"Could not find game mode. Registered: " +
+                    $"[ {string.Join(", ", arenaOnline.registeredGameModes.Keys)} ]."
                 );
+            }
+
+            if (arenaOnline.currentGameMode == TeamBattle.value)
+            {
+                teamBattle = (TeamBattleMode)externalArena;
                 return true;
             }
+
             return false;
         }
 
@@ -186,7 +199,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         )
         {
             base.ArenaSessionCtor(arena, orig, self, game);
-            if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
+            if (IsTeamBattleMode(out var tb))
             {
                 if (
                     OnlineManager
@@ -304,7 +317,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
             ArenaSitting.ArenaPlayer B
         )
         {
-            if (isTeamBattleMode(arena, out var tb))
+            if (IsTeamBattleMode(out var tb))
             {
                 OnlinePlayer? playerA = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(
                     arena,
@@ -358,7 +371,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         {
             var resultList = orig(self);
 
-            if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
+            if (IsTeamBattleMode(out var tb))
             {
                 tb.winningTeam = CalculateTeamScoresAndWinner(resultList, arena, arena.WinByScore, false, true);
 
@@ -411,7 +424,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
             ArenaSitting.ArenaPlayer B
         )
         {
-            if (isTeamBattleMode(arena, out var tb))
+            if (IsTeamBattleMode(out var tb))
             {
                 OnlinePlayer? playerA = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, A.playerNumber);
                 OnlinePlayer? playerB = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, B.playerNumber);
@@ -466,7 +479,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         )
         {
             base.ArenaSessionEnded(arena, orig, self, session);
-            if (TeamBattleMode.isTeamBattleMode(arena, out var tb) && OnlineManager.lobby.isOwner)
+            if (TeamBattleMode.IsTeamBattleMode(out var tb) && OnlineManager.lobby.isOwner)
             {
                 tb.roundSpawnPointCycler = tb.roundSpawnPointCycler + 1;
             }
@@ -480,7 +493,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         )
         {
             // Shameful copy-paste
-            if (isTeamBattleMode(arena, out var teamBattleMode))
+            if (IsTeamBattleMode(out var teamBattleMode))
             {
                 List<OnlinePlayer> list = new List<OnlinePlayer>();
 

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
@@ -199,7 +199,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         )
         {
             base.ArenaSessionCtor(arena, orig, self, game);
-            if (IsTeamBattleMode(out var tb))
+            if (IsTeamBattleMode(out TeamBattleMode teamBattle))
             {
                 if (
                     OnlineManager
@@ -210,7 +210,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                     arena.avatarSettings.bodyColor = Color.Lerp(
                         arena.avatarSettings.bodyColor,
                         teamColors[t.team],
-                        tb.lerp
+                        teamBattle.lerp
                     );
                 }
             }
@@ -317,7 +317,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
             ArenaSitting.ArenaPlayer B
         )
         {
-            if (IsTeamBattleMode(out var tb))
+            if (IsTeamBattleMode(out TeamBattleMode teamBattle))
             {
                 OnlinePlayer? playerA = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(
                     arena,
@@ -339,8 +339,8 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
 
                     if (teamA != null && teamB != null)
                     {
-                        bool aIsWinningTeam = teamA.team == tb.winningTeam;
-                        bool bIsWinningTeam = teamB.team == tb.winningTeam;
+                        bool aIsWinningTeam = teamA.team == teamBattle.winningTeam;
+                        bool bIsWinningTeam = teamB.team == teamBattle.winningTeam;
 
                         // Prioritize winning team
                         if (aIsWinningTeam != bIsWinningTeam)
@@ -371,9 +371,9 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         {
             var resultList = orig(self);
 
-            if (IsTeamBattleMode(out var tb))
+            if (IsTeamBattleMode(out TeamBattleMode teamBattle))
             {
-                tb.winningTeam = CalculateTeamScoresAndWinner(resultList, arena, arena.WinByScore, false, true);
+                teamBattle.winningTeam = CalculateTeamScoresAndWinner(resultList, arena, arena.WinByScore, false, true);
 
                 resultList.Sort((a, b) =>
                 {
@@ -389,10 +389,10 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
 
                         // --- Tier 1: Winner Status ---
                         // If there is a winning team, anyone on that team goes to the top.
-                        if (tb.winningTeam != -1)
+                        if (teamBattle.winningTeam != -1)
                         {
-                            bool aIsWinner = teamA.team == tb.winningTeam;
-                            bool bIsWinner = teamB.team == tb.winningTeam;
+                            bool aIsWinner = teamA.team == teamBattle.winningTeam;
+                            bool bIsWinner = teamB.team == teamBattle.winningTeam;
 
                             if (aIsWinner != bIsWinner)
                             {
@@ -424,7 +424,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
             ArenaSitting.ArenaPlayer B
         )
         {
-            if (IsTeamBattleMode(out var tb))
+            if (IsTeamBattleMode(out TeamBattleMode teamBattle))
             {
                 OnlinePlayer? playerA = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, A.playerNumber);
                 OnlinePlayer? playerB = ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arena, B.playerNumber);
@@ -437,8 +437,8 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                     if (teamA != null && teamB != null)
                     {
                         // Only consider them on the winning team if a winning team was actually decided (!= -1)
-                        bool aIsWinningTeam = (tb.winningTeam != -1) && (teamA.team == tb.winningTeam);
-                        bool bIsWinningTeam = (tb.winningTeam != -1) && (teamB.team == tb.winningTeam);
+                        bool aIsWinningTeam = (teamBattle.winningTeam != -1) && (teamA.team == teamBattle.winningTeam);
+                        bool bIsWinningTeam = (teamBattle.winningTeam != -1) && (teamB.team == teamBattle.winningTeam);
 
                         // Prioritize winning team
                         if (aIsWinningTeam != bIsWinningTeam)
@@ -479,10 +479,9 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         )
         {
             base.ArenaSessionEnded(arena, orig, self, session);
-            if (TeamBattleMode.IsTeamBattleMode(out var tb) && OnlineManager.lobby.isOwner)
-            {
-                tb.roundSpawnPointCycler = tb.roundSpawnPointCycler + 1;
-            }
+
+            if (IsTeamBattleMode(out TeamBattleMode teamBattle) && OnlineManager.lobby.isOwner)
+                teamBattle.roundSpawnPointCycler++;
         }
 
         public override void SpawnPlayer(
@@ -493,7 +492,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
         )
         {
             // Shameful copy-paste
-            if (IsTeamBattleMode(out var teamBattleMode))
+            if (IsTeamBattleMode(out TeamBattleMode teamBattle))
             {
                 List<OnlinePlayer> list = new List<OnlinePlayer>();
 
@@ -515,8 +514,8 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                 }
                 int randomExitIndex = 0;
                 int totalExits = self.game.world.GetAbstractRoom(0).exits;
-                teamBattleMode.roundSpawnPointCycler = (
-                    teamBattleMode.roundSpawnPointCycler % totalExits
+                teamBattle.roundSpawnPointCycler = (
+                    teamBattle.roundSpawnPointCycler % totalExits
                 );
 
                 if (
@@ -525,38 +524,38 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                         .TryGetData<ArenaTeamClientSettings>(out var teamSettings)
                 )
                 {
-                    teamBattleMode.martyrsSpawn =
+                    teamBattle.martyrsSpawn =
                         (
                             (int)TeamSpawnPoints.martyrsTeamName
-                            + teamBattleMode.roundSpawnPointCycler
+                            + teamBattle.roundSpawnPointCycler
                         ) % totalExits;
-                    teamBattleMode.outlawsSpawn =
-                        ((int)TeamSpawnPoints.outlawTeamName + teamBattleMode.roundSpawnPointCycler)
+                    teamBattle.outlawsSpawn =
+                        ((int)TeamSpawnPoints.outlawTeamName + teamBattle.roundSpawnPointCycler)
                         % totalExits;
-                    teamBattleMode.dragonslayersSpawn =
+                    teamBattle.dragonslayersSpawn =
                         (
                             (int)TeamSpawnPoints.dragonslayersTeamName
-                            + teamBattleMode.roundSpawnPointCycler
+                            + teamBattle.roundSpawnPointCycler
                         ) % totalExits;
-                    teamBattleMode.chieftainsSpawn =
+                    teamBattle.chieftainsSpawn =
                         (
                             (int)TeamSpawnPoints.chieftainsTeamName
-                            + teamBattleMode.roundSpawnPointCycler
+                            + teamBattle.roundSpawnPointCycler
                         ) % totalExits;
 
                     switch ((TeamSpawnPoints)teamSettings.team)
                     {
                         case TeamSpawnPoints.martyrsTeamName:
-                            randomExitIndex = teamBattleMode.martyrsSpawn;
+                            randomExitIndex = teamBattle.martyrsSpawn;
                             break;
                         case TeamSpawnPoints.outlawTeamName:
-                            randomExitIndex = teamBattleMode.outlawsSpawn;
+                            randomExitIndex = teamBattle.outlawsSpawn;
                             break;
                         case TeamSpawnPoints.dragonslayersTeamName:
-                            randomExitIndex = teamBattleMode.dragonslayersSpawn;
+                            randomExitIndex = teamBattle.dragonslayersSpawn;
                             break;
                         case TeamSpawnPoints.chieftainsTeamName:
-                            randomExitIndex = teamBattleMode.chieftainsSpawn;
+                            randomExitIndex = teamBattle.chieftainsSpawn;
                             break;
                         default:
                             Debug.LogWarning(
@@ -575,10 +574,10 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                             }
                             player.InvokeOnceRPC(
                                 ArenaRPCs.Arena_NotifySpawnPoint,
-                                teamBattleMode.martyrsSpawn,
-                                teamBattleMode.outlawsSpawn,
-                                teamBattleMode.dragonslayersSpawn,
-                                teamBattleMode.chieftainsSpawn
+                                teamBattle.martyrsSpawn,
+                                teamBattle.outlawsSpawn,
+                                teamBattle.dragonslayersSpawn,
+                                teamBattle.chieftainsSpawn
                             );
                         }
                     }

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattleLobbyData.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattleLobbyData.cs
@@ -49,63 +49,46 @@ namespace RainMeadow
             [OnlineField]
             public int roundSpawnPointCycler;
             public State() { }
-            public State(TeamBattleLobbyData arenaLobbyData, OnlineResource onlineResource)
+            public State(TeamBattleLobbyData lobbyData, OnlineResource onlineResource)
             {
-                ArenaOnlineGameMode arena = (onlineResource as Lobby).gameMode as ArenaOnlineGameMode;
-                if (arena != null)
+                if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
                 {
-                    bool isTb = TeamBattleMode.IsTeamBattleMode(out var teamBattleMode);
-                    if (isTb && teamBattleMode != null)
-                    {
-                        martyrColors = teamBattleMode.teamColors[0];
-                        outlawColors = teamBattleMode.teamColors[1];
-                        dragonslayerColors = teamBattleMode.teamColors[2];
-                        chieftainColors = teamBattleMode.teamColors[3];
-                        martyrsName = teamBattleMode.teamNames[0];
-                        outlawsName = teamBattleMode.teamNames[1];
-                        dragonslayersName = teamBattleMode.teamNames[2];
-                        chieftainsName = teamBattleMode.teamNames[3];
-                        winningTeam = teamBattleMode.winningTeam;
-                        martyrs = teamBattleMode.martyrsSpawn;
-                        outlaws = teamBattleMode.outlawsSpawn;
-                        dragonslayers = teamBattleMode.dragonslayersSpawn;
-                        chieftains = teamBattleMode.chieftainsSpawn;
-                        roundSpawnPointCycler = teamBattleMode.roundSpawnPointCycler;
-                        lerp = teamBattleMode.lerp;
-
-                    }
+                    martyrColors = teamBattle.teamColors[0];
+                    outlawColors = teamBattle.teamColors[1];
+                    dragonslayerColors = teamBattle.teamColors[2];
+                    chieftainColors = teamBattle.teamColors[3];
+                    martyrsName = teamBattle.teamNames[0];
+                    outlawsName = teamBattle.teamNames[1];
+                    dragonslayersName = teamBattle.teamNames[2];
+                    chieftainsName = teamBattle.teamNames[3];
+                    winningTeam = teamBattle.winningTeam;
+                    martyrs = teamBattle.martyrsSpawn;
+                    outlaws = teamBattle.outlawsSpawn;
+                    dragonslayers = teamBattle.dragonslayersSpawn;
+                    chieftains = teamBattle.chieftainsSpawn;
+                    roundSpawnPointCycler = teamBattle.roundSpawnPointCycler;
+                    lerp = teamBattle.lerp;
                 }
             }
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
             {
-                var lobby = (resource as Lobby);
-                var arena = (lobby.gameMode as ArenaOnlineGameMode);
-                if (arena != null)
+                if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
                 {
-
-
-                    bool cachedTb = TeamBattleMode.IsTeamBattleMode(out var teamBattleMode);
-                    if (cachedTb && teamBattleMode != null)
-                    {
-                        teamBattleMode.teamColors[0] = martyrColors;
-                        teamBattleMode.teamColors[1] = outlawColors;
-                        teamBattleMode.teamColors[2] = dragonslayerColors;
-                        teamBattleMode.teamColors[3] = chieftainColors;
-                        teamBattleMode.teamNames[0] = martyrsName;
-                        teamBattleMode.teamNames[1] = outlawsName;
-                        teamBattleMode.teamNames[2] = dragonslayersName;
-                        teamBattleMode.teamNames[3] = chieftainsName;
-                        teamBattleMode.winningTeam = winningTeam;
-                        teamBattleMode.martyrsSpawn = martyrs;
-                        teamBattleMode.outlawsSpawn = outlaws;
-                        teamBattleMode.dragonslayersSpawn = dragonslayers;
-
-                        teamBattleMode.roundSpawnPointCycler = roundSpawnPointCycler;
-                        teamBattleMode.lerp = lerp;
-
-
-                    }
+                    teamBattle.teamColors[0] = martyrColors;
+                    teamBattle.teamColors[1] = outlawColors;
+                    teamBattle.teamColors[2] = dragonslayerColors;
+                    teamBattle.teamColors[3] = chieftainColors;
+                    teamBattle.teamNames[0] = martyrsName;
+                    teamBattle.teamNames[1] = outlawsName;
+                    teamBattle.teamNames[2] = dragonslayersName;
+                    teamBattle.teamNames[3] = chieftainsName;
+                    teamBattle.winningTeam = winningTeam;
+                    teamBattle.martyrsSpawn = martyrs;
+                    teamBattle.outlawsSpawn = outlaws;
+                    teamBattle.dragonslayersSpawn = dragonslayers;
+                    teamBattle.roundSpawnPointCycler = roundSpawnPointCycler;
+                    teamBattle.lerp = lerp;
                 }
             }
 

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattleLobbyData.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattleLobbyData.cs
@@ -1,7 +1,5 @@
 ﻿using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace RainMeadow
@@ -56,7 +54,7 @@ namespace RainMeadow
                 ArenaOnlineGameMode arena = (onlineResource as Lobby).gameMode as ArenaOnlineGameMode;
                 if (arena != null)
                 {
-                    bool isTb = TeamBattleMode.isTeamBattleMode(arena, out var teamBattleMode);
+                    bool isTb = TeamBattleMode.IsTeamBattleMode(out var teamBattleMode);
                     if (isTb && teamBattleMode != null)
                     {
                         martyrColors = teamBattleMode.teamColors[0];
@@ -87,7 +85,7 @@ namespace RainMeadow
                 {
 
 
-                    bool cachedTb = TeamBattleMode.isTeamBattleMode(arena, out var teamBattleMode);
+                    bool cachedTb = TeamBattleMode.IsTeamBattleMode(out var teamBattleMode);
                     if (cachedTb && teamBattleMode != null)
                     {
                         teamBattleMode.teamColors[0] = martyrColors;

--- a/Arena/ArenaOnlinePlayerJoin.cs
+++ b/Arena/ArenaOnlinePlayerJoin.cs
@@ -133,7 +133,7 @@ namespace Menu
             if (arena != null)
             {
 
-                if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out var tb))
                 {
                     if (OnlineManager.lobby.clientSettings.TryGetValue(profileIdentifier, out var clientSettings))
                     {

--- a/Arena/ArenaOnlinePlayerJoin.cs
+++ b/Arena/ArenaOnlinePlayerJoin.cs
@@ -132,17 +132,13 @@ namespace Menu
             }
             if (arena != null)
             {
-
-                if (TeamBattleMode.IsTeamBattleMode(out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
                 {
                     if (OnlineManager.lobby.clientSettings.TryGetValue(profileIdentifier, out var clientSettings))
                     {
-                        if (clientSettings.TryGetData<ArenaTeamClientSettings>(out var team))
-                        {
-                            roundedRect.borderColor = tb.teamColors[team.team].ToHSL();
-                        }
+                        if (clientSettings.TryGetData(out ArenaTeamClientSettings team))
+                            roundedRect.borderColor = teamBattle.teamColors[team.team].ToHSL();
                     }
-
                 } else
                 {
                     roundedRect.borderColor = ogColor.ToHSL();

--- a/Arena/ArenaPlayerBox.cs
+++ b/Arena/ArenaPlayerBox.cs
@@ -175,7 +175,7 @@ namespace RainMeadow.UI.Components
             }
             if (hostIdentifierButton != null)
             {
-                if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out var tb))
                 {
                     hostIdentifierButton.symbolSprite.SetElementByName(tb.teamIcons[ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(profileIdentifier).team] ?? "ChieftainA");
                 }
@@ -218,7 +218,7 @@ namespace RainMeadow.UI.Components
                 {
                     return;
                 }
-                hostIdentifierButton = new(menu, this, TeamBattleMode.isTeamBattleMode(arena, out var tb) ? tb.teamIcons[ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(profileIdentifier).team] : "ChieftainA", "HOST_INFO", new(infoKickButton.pos.x + infoKickButton.size.x + 30, basePos.y + 21));
+                hostIdentifierButton = new(menu, this, TeamBattleMode.IsTeamBattleMode(out var tb) ? tb.teamIcons[ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(profileIdentifier).team] : "ChieftainA", "HOST_INFO", new(infoKickButton.pos.x + infoKickButton.size.x + 30, basePos.y + 21));
                 UiLineConnector connector = new(menu, infoKickButton, hostIdentifierButton, false);
                 connector.MoveLineSpriteBeforeNode(hostIdentifierButton.roundedRect.sprites[0]);
                 lines.Add(connector);

--- a/Arena/ArenaPlayerBox.cs
+++ b/Arena/ArenaPlayerBox.cs
@@ -175,9 +175,9 @@ namespace RainMeadow.UI.Components
             }
             if (hostIdentifierButton != null)
             {
-                if (TeamBattleMode.IsTeamBattleMode(out var tb))
+                if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
                 {
-                    hostIdentifierButton.symbolSprite.SetElementByName(tb.teamIcons[ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(profileIdentifier).team] ?? "ChieftainA");
+                    hostIdentifierButton.symbolSprite.SetElementByName(teamBattle.teamIcons[ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(profileIdentifier).team] ?? "ChieftainA");
                 }
                 else
                 {
@@ -214,11 +214,23 @@ namespace RainMeadow.UI.Components
             }
             if (OnlineManager.lobby != null && profileIdentifier == OnlineManager.lobby.owner)
             {
-                if (!RainMeadow.isArenaMode(out var arena))
-                {
+                if (!RainMeadow.isArenaMode(out _))
                     return;
-                }
-                hostIdentifierButton = new(menu, this, TeamBattleMode.IsTeamBattleMode(out var tb) ? tb.teamIcons[ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(profileIdentifier).team] : "ChieftainA", "HOST_INFO", new(infoKickButton.pos.x + infoKickButton.size.x + 30, basePos.y + 21));
+
+                string hostIdentifierSymbolName = TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle)
+                    ? teamBattle.teamIcons[ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(profileIdentifier).team]
+                    : "ChieftainA";
+
+                hostIdentifierButton = new ScrollSymbolButton(
+                    menu,
+                    this,
+                    hostIdentifierSymbolName,
+                    "HOST_INFO",
+                    new Vector2(
+                        infoKickButton.pos.x + infoKickButton.size.x + 30,
+                        basePos.y + 21
+                    )
+                );
                 UiLineConnector connector = new(menu, infoKickButton, hostIdentifierButton, false);
                 connector.MoveLineSpriteBeforeNode(hostIdentifierButton.roundedRect.sprites[0]);
                 lines.Add(connector);

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -2,9 +2,9 @@ using System;
 using Menu;
 using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using UnityEngine;
-using RWCustom;
 using System.Linq;
-using System.Collections.Generic;
+using RWCustom;
+
 namespace RainMeadow
 {
     public static class ArenaRPCs
@@ -142,16 +142,13 @@ namespace RainMeadow
         [RPCMethod]
         public static void Arena_NotifySpawnPoint(int martyrs, int outlaws, int dragonslayers, int chieftains)
         {
-            if (RainMeadow.isArenaMode(out var arena))
+            if (TeamBattleMode.IsTeamBattleMode(out var tb))
             {
-                if (TeamBattleMode.isTeamBattleMode(arena, out var tb))
-                {
 
-                    tb.martyrsSpawn = martyrs;
-                    tb.outlawsSpawn = outlaws;
-                    tb.dragonslayersSpawn = dragonslayers;
-                    tb.chieftainsSpawn = chieftains;
-                }
+                tb.martyrsSpawn = martyrs;
+                tb.outlawsSpawn = outlaws;
+                tb.dragonslayersSpawn = dragonslayers;
+                tb.chieftainsSpawn = chieftains;
             }
         }
         [RPCMethod]

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -142,13 +142,12 @@ namespace RainMeadow
         [RPCMethod]
         public static void Arena_NotifySpawnPoint(int martyrs, int outlaws, int dragonslayers, int chieftains)
         {
-            if (TeamBattleMode.IsTeamBattleMode(out var tb))
+            if (TeamBattleMode.IsTeamBattleMode(out TeamBattleMode teamBattle))
             {
-
-                tb.martyrsSpawn = martyrs;
-                tb.outlawsSpawn = outlaws;
-                tb.dragonslayersSpawn = dragonslayers;
-                tb.chieftainsSpawn = chieftains;
+                teamBattle.martyrsSpawn = martyrs;
+                teamBattle.outlawsSpawn = outlaws;
+                teamBattle.dragonslayersSpawn = dragonslayers;
+                teamBattle.chieftainsSpawn = chieftains;
             }
         }
         [RPCMethod]

--- a/Arena/README.md
+++ b/Arena/README.md
@@ -48,19 +48,31 @@ public sealed class SuperArenaMode : ExternalArenaGameMode
 {
     public static ArenaSetup.GameTypeID Id { get; } = new(Plugin.Name); // Or whatever you want the game mode name to be.
     
-    /// <exception cref="InvalidOperationException">Thrown if game mode is not registered.</exception>
-    public static bool IsSuperArenaMode(ArenaOnlineGameMode arenaOnline, out SuperArenaMode superArena)
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the online game mode is <see cref="ArenaOnlineGameMode"/>
+    /// and <see cref="SuperArenaMode"/> is not registered.
+    /// </exception>
+    public static bool IsSuperArenaMode(out SuperArenaMode superArena)
     {
-        string name = Id.value;
-        if (!arenaOnline.registeredGameModes.TryGetValue(name, out ExternalArenaGameMode registeredMode))
-            throw new InvalidOperationException($"Could not find game mode. registered: [ {string.Join(", ", arenaOnline.registeredGameModes.Keys)} ]");
-        
         superArena = null!;
-        if (arenaOnline.currentGameMode == name)
+
+        if (!RainMeadow.RainMeadow.isArenaMode(out ArenaOnlineGameMode arenaOnline))
+            return false;
+        if (!arenaOnline.registeredGameModes.TryGetValue(Id.value, out ExternalArenaGameMode externalArena))
         {
-            superArena = (SuperArenaMode)registeredMode;
+            throw new InvalidOperationException(
+                $"Could not find game mode. Registered: " +
+                $"[ {string.Join(", ", arenaOnline.registeredGameModes.Keys)} ]."
+            );
+        }
+
+        if (arenaOnline.currentGameMode == Id.value)
+        {
+            superArena = (SuperArenaMode)externalArena;
             return true;
         }
+
+        return false;
     }
 }
 ```

--- a/Arena/README_OLD.md
+++ b/Arena/README_OLD.md
@@ -121,14 +121,30 @@ public override ArenaSetup.GameTypeID GetGameModeId
 
 ## GameMode Check
 ```csharp
-public static bool isMyCoolGameMode(ArenaOnlineGameMode arena, out MyCoolNewGameMode tb)
+/// <exception cref="InvalidOperationException">
+/// Thrown if the online game mode is <see cref="ArenaOnlineGameMode"/>
+/// and <see cref="MyCoolNewGameMode"/> is not registered.
+/// </exception>
+public static bool IsMyCoolNewGameMode(out MyCoolNewGameMode myCoolNewGameMode)
 {
-    tb = null;
-    if (arena.currentGameMode == MyGameModeName.value)
+    myCoolNewGameMode = null!;
+
+    if (!RainMeadow.RainMeadow.isArenaMode(out ArenaOnlineGameMode arenaOnline))
+        return false;
+    if (!arenaOnline.registeredGameModes.TryGetValue(Id.value, out ExternalArenaGameMode externalArena))
     {
-        tb = (arena.registeredGameModes.FirstOrDefault(x => x.Key == MyGameModeName.value).Value as MyCoolNewGameMode);
+        throw new InvalidOperationException(
+            $"Could not find game mode. Registered: " +
+            $"[ {string.Join(", ", arenaOnline.registeredGameModes.Keys)} ]."
+        );
+    }
+
+    if (arenaOnline.currentGameMode == MyGameModeName.value)
+    {
+        myCoolNewGameMode = (MyCoolNewGameMode)externalArena;
         return true;
     }
+
     return false;
 }
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 ### Watcher
 - Gave summoned Ameobas the Watcher's body color
 ### Modders
+- ⚠️ Simplified active external arena mode checks by removing the `ArenaOnlineGameMode` parameter and renaming them to PascalCase.
+  - Example: `isTeamBattleMode(ArenaOnlineGameMode, out TeamBattleMode)` -> `IsTeamBattleMode(out TeamBattleMode)`
 - Added `ExportLocalSettings` and `ImportLocalSettings` virtual functions into `ExternalGameMode` for managing Arena settings 
 ## Meadow
 - Fixed creatures being able to get injured.

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1363,11 +1363,11 @@ public partial class RainMeadow
             }
         }
 
-        if (isArenaMode(out var arena) && !self.inShortcut)
+        if (isArenaMode(out ArenaOnlineGameMode arena) && !self.inShortcut)
         {
             int[] disabledCollisionChallenges = [60, 68]; //27, 44, 45, 55, and 58 all also have problems with player spawns bumping each other into death pits, but they also include creatures, which we still want to collide with.
                                                           //60 also has danglefruit that we don't collide with but that matters less. Ideally we'd set up a "just don't collide with players" collision layer, but this works for now.
-            if (arena.countdownInitiatedHoldFire || (ArenaChallengeMode.IsChallengeMode(out var chMode) && disabledCollisionChallenges.Contains(chMode.challengeID)))
+            if (arena.countdownInitiatedHoldFire || (ArenaChallengeMode.IsChallengeMode(out ArenaChallengeMode challenge) && disabledCollisionChallenges.Contains(challenge.challengeID)))
             {
                 if (self.collisionLayer != 0)
                 {

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -8,9 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization.Formatters;
 using UnityEngine;
-using UnityEngine.PlayerLoop;
 
 namespace RainMeadow;
 
@@ -1369,7 +1367,7 @@ public partial class RainMeadow
         {
             int[] disabledCollisionChallenges = [60, 68]; //27, 44, 45, 55, and 58 all also have problems with player spawns bumping each other into death pits, but they also include creatures, which we still want to collide with.
                                                           //60 also has danglefruit that we don't collide with but that matters less. Ideally we'd set up a "just don't collide with players" collision layer, but this works for now.
-            if (arena.countdownInitiatedHoldFire || (ArenaChallengeMode.isChallengeMode(arena, out var chMode) && disabledCollisionChallenges.Contains(chMode.challengeID)))
+            if (arena.countdownInitiatedHoldFire || (ArenaChallengeMode.IsChallengeMode(out var chMode) && disabledCollisionChallenges.Contains(chMode.challengeID)))
             {
                 if (self.collisionLayer != 0)
                 {

--- a/OnlineUIComponents/GameplayOverrides.cs
+++ b/OnlineUIComponents/GameplayOverrides.cs
@@ -35,7 +35,7 @@ namespace RainMeadow
 
                 if (friend is not null)
                 {
-                    if (TeamBattleMode.isTeamBattleMode(arena, out _))
+                    if (TeamBattleMode.IsTeamBattleMode(out _))
                     {
                         return ArenaHelpers.CheckSameTeam(
                             arena,

--- a/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -1,11 +1,8 @@
-using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using RWCustom;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle;
 using UnityEngine;
-using UnityEngine.PlayerLoop;
-using static RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle.TeamBattleMode;
 
 namespace RainMeadow
 {
@@ -198,7 +195,7 @@ namespace RainMeadow
             if (RainMeadow.isArenaMode(out var a) && owner.RealizedPlayer?.isCamo == true)
             {
                 // Check if we are teammates (Only true if it's Team Battle AND we are on the same team)
-                bool isTeammate = TeamBattleMode.isTeamBattleMode(a, out _) && ArenaHelpers.CheckSameTeam(OnlineManager.mePlayer, player);
+                bool isTeammate = TeamBattleMode.IsTeamBattleMode(out _) && ArenaHelpers.CheckSameTeam(OnlineManager.mePlayer, player);
 
                 // Hide if it's NOT me AND it's NOT a teammate
                 if (!player.isMe && !isTeammate)


### PR DESCRIPTION
- Changed method names to PascalCase.
- Removed requirement of passing `ArenaOnlineGameMode`.
- Renamed out'd external arenas to be consistent & correct.
  - tb, team, teamBattleMode -> teamBattle
  - d, drownData -> drown
  - chMode -> challenge
- Updated directly related documentation.

I still need to test that RM isn't bugged in a way that would result in the `InvalidOperationException` being thrown.