### PR TITLE
Makes people wait others to load in Arena

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -226,7 +226,7 @@ namespace RainMeadow
                             {
                                 startBump.startGameCounter = 10;
                             }
-                            return isArenaOnlineNOTReady;
+                            return isArenaOnlineWaitingForPlayers;
                         }
                     );
                     cursor.Emit(OpCodes.Brtrue, label);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -222,7 +222,7 @@ namespace RainMeadow
                                 && arenaOnline.externalArenaGameMode.HoldFireWhileTimerIsActive(arenaOnline)
                                 && (arenaOnline.arenaPrepTimer is null 
                                     || arenaOnline.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting);
-                            if (isArenaOnlineNOTReady)
+                            if (isArenaOnlineWaitingForPlayers)
                             {
                                 startBump.startGameCounter = 10;
                             }

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -218,15 +218,15 @@ namespace RainMeadow
                     cursor.Emit(OpCodes.Ldarg_0);
                     cursor.EmitDelegate((ArenaBehaviors.StartBump startBump) => 
                         {
-                            bool isOnlineArenaNotReady = isArenaMode(out var arena) 
-                                && arena.externalArenaGameMode.HoldFireWhileTimerIsActive(arena)
-                                && (arena.arenaPrepTimer is null 
-                                    || arena.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting);
-                            if (isOnlineArenaNotReady)
+                            bool isArenaOnlineNOTReady = isArenaMode(out var arenaOnline) 
+                                && arenaOnline.externalArenaGameMode.HoldFireWhileTimerIsActive(arenaOnline)
+                                && (arenaOnline.arenaPrepTimer is null 
+                                    || arenaOnline.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting);
+                            if (isArenaOnlineNOTReady)
                             {
                                 startBump.startGameCounter = 10;
                             }
-                            return isOnlineArenaNotReady;
+                            return isArenaOnlineNOTReady;
                         }
                     );
                     cursor.Emit(OpCodes.Brtrue, label);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -218,7 +218,7 @@ namespace RainMeadow
                     cursor.Emit(OpCodes.Ldarg_0);
                     cursor.EmitDelegate((ArenaBehaviors.StartBump startBump) => 
                         {
-                            bool isArenaOnlineNOTReady = isArenaMode(out var arenaOnline) 
+                            bool isArenaOnlineWaitingForPlayers = isArenaMode(out var arenaOnline) 
                                 && arenaOnline.externalArenaGameMode.HoldFireWhileTimerIsActive(arenaOnline)
                                 && (arenaOnline.arenaPrepTimer is null 
                                     || arenaOnline.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -197,7 +197,82 @@ namespace RainMeadow
             );
             On.VoidSpawnGraphics.UpdateGlowSpriteColor += VoidSpawnGraphics_UpdateGlowSpriteColor_ColorTheAmoeba;
             
+            On.RainWorldGame.Update += RainWorldGame_Update_ShortcutWaitForAllPlayers;
+            IL.ShortcutHandler.Update += ShortcutHandler_Update_DontYouDareSkipTheWait;
+            IL.ArenaBehaviors.StartBump.Update += StartBump_Update_StartTheBumpWhenEveryoneIsReady;
+
             DrownHooks();
+        }
+
+        private void StartBump_Update_StartTheBumpWhenEveryoneIsReady(ILContext il)
+        {
+            try
+            {
+                ILCursor cursor = new(il);
+                ILLabel label = cursor.DefineLabel();
+                if (cursor.TryGotoNext(MoveType.After,
+                    i => i.MatchLdarg(0),
+                    i => i.MatchLdfld<ArenaBehaviors.StartBump>(nameof(ArenaBehaviors.StartBump.startGameCounter)),
+                    i => i.MatchBrtrue(out label)))
+                {
+                    // Don't trigger the bump till everyone is ready
+                    cursor.Emit(OpCodes.Ldarg_0);
+                    cursor.EmitDelegate((ArenaBehaviors.StartBump startBump) => 
+                        {
+                            bool isOnlineArenaNotReady = isArenaMode(out var arena) 
+                                && arena.externalArenaGameMode.HoldFireWhileTimerIsActive(arena)
+                                && (arena.arenaPrepTimer is null 
+                                    || arena.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting);
+                            if (isOnlineArenaNotReady)
+                            {
+                                startBump.startGameCounter = 10;
+                            }
+                            return isOnlineArenaNotReady;
+                        }
+                    );
+                    cursor.Emit(OpCodes.Brtrue, label);
+                }
+            }
+            catch (Exception ex)
+            {
+                RainMeadow.Error("Could not find IL hook : "+ ex);
+            }
+        }
+
+        private void ShortcutHandler_Update_DontYouDareSkipTheWait(ILContext il)
+        {
+            try
+            {
+                ILCursor cursor = new(il);
+                if (cursor.TryGotoNext(MoveType.After, i => i.MatchLdsfld<ModManager>(nameof(ModManager.CoopAvailable))))
+                {
+                    // No Jolly skip if it's arena !
+                    cursor.EmitDelegate((bool orig) => orig && !isArenaMode(out _));
+                }
+            }
+            catch (Exception ex)
+            {
+                RainMeadow.Error("Could not find IL hook : "+ ex);
+            }
+        }
+        private void RainWorldGame_Update_ShortcutWaitForAllPlayers(On.RainWorldGame.orig_Update orig, RainWorldGame self)
+        {
+            if (isArenaMode(out var arena) 
+                && arena.externalArenaGameMode.HoldFireWhileTimerIsActive(arena)
+                && (arena.arenaPrepTimer is null || arena.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting))
+            {
+                // Debug($"Holding the players [{string.Join(", ", self.shortcuts.transportVessels.FindAll(x => x.creature is Player).Select(x => x.creature))}] in place ! <{arena.setupTime}><{arena.externalArenaGameMode.HoldFireWhileTimerIsActive(arena)}><{arena.arenaPrepTimer?.showMode}>");
+                for (int i = 0; i < self.shortcuts.transportVessels.Count; i++)
+                {
+                    if (self.shortcuts.transportVessels[i].creature is Player player
+                        && player.IsLocal()) // only affect us
+                    {
+                        self.shortcuts.transportVessels[i].wait = 1; // wait in there till everyone is ready.
+                        // Debug($"Player {self.shortcuts.transportVessels[i].creature}<{self.shortcuts.transportVessels[i].creature.inShortcut}><{self.shortcuts.transportVessels[i].creature.inShortcutVessel}> is at [{self.shortcuts.transportVessels[i].creature.mainBodyChunk.pos}][{self.shortcuts.OnScreenPositionOfInShortCutCreature(self.cameras[0].room, self.shortcuts.transportVessels[i].creature)}]");
+                    }
+                }
+            }
+            orig(self);
         }
 
         // Get our own shader into the mix, so we can color the Amoeba

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -311,94 +311,94 @@ namespace RainMeadow
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
             {
-                if ((resource as Lobby)?.gameMode is not ArenaOnlineGameMode arena) { RainMeadow.Error("Ressource is not an ArenaOnlineGameMode !"); return;}
-                arena.isInGame = isInGame;
-                arena.playList = playList;
-                arena.shufflePlayList = shufflePlayList;
-                arena.arenaSittingOnlineOrder = arenaSittingOnlineOrder;
-                arena.allPlayersReadyLockLobby = allPlayersReadyLockLobby;
-                arena.returnToLobby = returnToLobby;
-                arena.onlineArenaSettingsInterfaceMultiChoice = onlineArenaSettingsInterfaceMultiChoice;
-                arena.onlineArenaSettingsInterfaceeBool = onlineArenaSettingsInterfaceBool;
-                arena.playersInLobbyChoosingSlugs = playersChoosingSlugs;
-                arena.playersReadiedUp = playersReadiedUp;
-                arena.reigningChamps = reigningChamps;
+                if ((resource as Lobby)?.gameMode is not ArenaOnlineGameMode arenaOnline) { RainMeadow.Error("Ressource is not an ArenaOnlineGameMode !"); return;}
+                arenaOnline.isInGame = isInGame;
+                arenaOnline.playList = playList;
+                arenaOnline.shufflePlayList = shufflePlayList;
+                arenaOnline.arenaSittingOnlineOrder = arenaSittingOnlineOrder;
+                arenaOnline.allPlayersReadyLockLobby = allPlayersReadyLockLobby;
+                arenaOnline.returnToLobby = returnToLobby;
+                arenaOnline.onlineArenaSettingsInterfaceMultiChoice = onlineArenaSettingsInterfaceMultiChoice;
+                arenaOnline.onlineArenaSettingsInterfaceeBool = onlineArenaSettingsInterfaceBool;
+                arenaOnline.playersInLobbyChoosingSlugs = playersChoosingSlugs;
+                arenaOnline.playersReadiedUp = playersReadiedUp;
+                arenaOnline.reigningChamps = reigningChamps;
 
-                arena.playerNumberWithDeaths = playerNumberWithDeaths;
-                arena.playerNumberWithWins = playerNumberWithWins;
+                arenaOnline.playerNumberWithDeaths = playerNumberWithDeaths;
+                arenaOnline.playerNumberWithWins = playerNumberWithWins;
 
-                arena.playerNumberWithTrophies = playerNumberWithTrophies;
-                arena.playerNumberWithTrophiesPerRound = playerNumberWithTrophiesPerRound;
+                arenaOnline.playerNumberWithTrophies = playerNumberWithTrophies;
+                arenaOnline.playerNumberWithTrophiesPerRound = playerNumberWithTrophiesPerRound;
 
-                arena.playerTotScore = playerTotScore;
-                arena.playerNumberWithScore = playerNumberWithScore;
-                arena.playersLateWaitingInLobbyForNextRound = playersLateWaitingInLobby;
+                arenaOnline.playerTotScore = playerTotScore;
+                arenaOnline.playerNumberWithScore = playerNumberWithScore;
+                arenaOnline.playersLateWaitingInLobbyForNextRound = playersLateWaitingInLobby;
                 
-                arena.countdownSafetyCatchTimer = countdownSafetyCatchTimer;
-                arena.countdownInitiatedHoldFire = countdownInitiatedHoldFire;
-                arena.playerResultColors = playerResultColors;
-                arena.setupTime = arenaSetupTime;
-                arena.lobbyCountDown = lobbyCountDown;
-                arena.initiateLobbyCountdown = initiatedLobbyCountDown;
+                arenaOnline.countdownSafetyCatchTimer = countdownSafetyCatchTimer;
+                arenaOnline.countdownInitiatedHoldFire = countdownInitiatedHoldFire;
+                arenaOnline.playerResultColors = playerResultColors;
+                arenaOnline.setupTime = arenaSetupTime;
+                arenaOnline.lobbyCountDown = lobbyCountDown;
+                arenaOnline.initiateLobbyCountdown = initiatedLobbyCountDown;
 
-                arena.sainot = sainot;
-                arena.arenaSaintAscendanceTimer = saintAscendanceTimer;
-                arena.watcherCamoTimer = watcherCamoLimit;
-                arena.watcherRippleLevel = watcherRippleLevel;
-                arena.currentGameMode = currentGameMode;
-                arena.currentLevel = currentLevel;
-                arena.totalLevelCount = totalLevels;
-                arena.painCatEgg = painCatEgg;
-                arena.painCatThrows = painCatThrows;
-                arena.painCatLizard = painCatLizard;
-                arena.artiStunDistanceMult = artiStunDistance;
-                arena.disableMaul = disableMaul;
-                arena.itemSteal = arenaItemSteal;
-                arena.allowJoiningMidRound = allowJoiningMidRound;
-                arena.weaponCollisionFix = weaponCollisionFix;
+                arenaOnline.sainot = sainot;
+                arenaOnline.arenaSaintAscendanceTimer = saintAscendanceTimer;
+                arenaOnline.watcherCamoTimer = watcherCamoLimit;
+                arenaOnline.watcherRippleLevel = watcherRippleLevel;
+                arenaOnline.currentGameMode = currentGameMode;
+                arenaOnline.currentLevel = currentLevel;
+                arenaOnline.totalLevelCount = totalLevels;
+                arenaOnline.painCatEgg = painCatEgg;
+                arenaOnline.painCatThrows = painCatThrows;
+                arenaOnline.painCatLizard = painCatLizard;
+                arenaOnline.artiStunDistanceMult = artiStunDistance;
+                arenaOnline.disableMaul = disableMaul;
+                arenaOnline.itemSteal = arenaItemSteal;
+                arenaOnline.allowJoiningMidRound = allowJoiningMidRound;
+                arenaOnline.weaponCollisionFix = weaponCollisionFix;
 
-                arena.enableBees = enableBees;
-                arena.enableBombs = enableBombs;
-                arena.enableCorpseGrab = enableCorpseGrab;
+                arenaOnline.enableBees = enableBees;
+                arenaOnline.enableBombs = enableBombs;
+                arenaOnline.enableCorpseGrab = enableCorpseGrab;
 
-                arena.leaveForNextLevel = leaveForNextLevel;
-                arena.hasPermissionToRejoin = hasPermissionToRejoin;
-                arena.playersEqualToOnlineSitting = playersEqualToOnlineSitting;
+                arenaOnline.leaveForNextLevel = leaveForNextLevel;
+                arenaOnline.hasPermissionToRejoin = hasPermissionToRejoin;
+                arenaOnline.playersEqualToOnlineSitting = playersEqualToOnlineSitting;
 
-                arena.bannedSlugs = bannedSlugs;
-                arena.piggyBack = piggyBack;
-                arena.voidMasterEnabled = voidMasterEnabled;
-                arena.voidSpawnLethalityFactor = voidSpawnLethalityFactor;
+                arenaOnline.bannedSlugs = bannedSlugs;
+                arenaOnline.piggyBack = piggyBack;
+                arenaOnline.voidMasterEnabled = voidMasterEnabled;
+                arenaOnline.voidSpawnLethalityFactor = voidSpawnLethalityFactor;
 
-                arena.amoebaDuration = amoebaDuration;
-                arena.amoebaControl = amoebaControl;
-                arena.fullInvisInRippleSpace = fullInvisInRippleSpace;
-                arena.friendlyFire = friendlyFire;
-                arena.enableOverseer = enableOverseer;
+                arenaOnline.amoebaDuration = amoebaDuration;
+                arenaOnline.amoebaControl = amoebaControl;
+                arenaOnline.fullInvisInRippleSpace = fullInvisInRippleSpace;
+                arenaOnline.friendlyFire = friendlyFire;
+                arenaOnline.enableOverseer = enableOverseer;
 
-                arena.foodScore = foodScore;
+                arenaOnline.foodScore = foodScore;
 
-                arena.spearHitScore = spearHitScore;
-                arena.killScore = killScore;
-                arena.aliveScore = aliveScore;
-                arena.denEntryRule = denRule;
-                arena.denScore = denScore;
-                arena.hostLoadedOverlay = hostLoadedOverlay;
-                arena.emptyKillTagScore = emptyKillScore;
-                arena.challengeDenEjection = challengeDenEjection;
-                arena.spearHitScore = spearHitScore;
-                arena.killScore = killScore;
-                arena.aliveScore = aliveScore;
-                arena.denEntryRule = denRule;
-                arena.denScore = denScore;
-                arena.hostLoadedOverlay = hostLoadedOverlay;
-                arena.emptyKillTagScore = emptyKillScore;
-                arena.challengeDenEjection = challengeDenEjection;
+                arenaOnline.spearHitScore = spearHitScore;
+                arenaOnline.killScore = killScore;
+                arenaOnline.aliveScore = aliveScore;
+                arenaOnline.denEntryRule = denRule;
+                arenaOnline.denScore = denScore;
+                arenaOnline.hostLoadedOverlay = hostLoadedOverlay;
+                arenaOnline.emptyKillTagScore = emptyKillScore;
+                arenaOnline.challengeDenEjection = challengeDenEjection;
+                arenaOnline.spearHitScore = spearHitScore;
+                arenaOnline.killScore = killScore;
+                arenaOnline.aliveScore = aliveScore;
+                arenaOnline.denEntryRule = denRule;
+                arenaOnline.denScore = denScore;
+                arenaOnline.hostLoadedOverlay = hostLoadedOverlay;
+                arenaOnline.emptyKillTagScore = emptyKillScore;
+                arenaOnline.challengeDenEjection = challengeDenEjection;
 
-                arena.artiExplosionCount = artiExplosionCapacity;
-                arena.artiParryDistanceMult = artiParryDistance;
-                arena.artiParryLeniency = artiParryLeniency;
-                arena.enableMeadowCosmetics = enableMeadowCosmetics;
+                arenaOnline.artiExplosionCount = artiExplosionCapacity;
+                arenaOnline.artiParryDistanceMult = artiParryDistance;
+                arenaOnline.artiParryLeniency = artiParryLeniency;
+                arenaOnline.enableMeadowCosmetics = enableMeadowCosmetics;
             }
 
             public override Type GetDataType() => typeof(ArenaLobbyData);

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -60,6 +60,9 @@ namespace RainMeadow
             public int arenaSetupTime;
 
             [OnlineField(group = "arenaSetup")]
+            public int countdownSafetyCatchTimer;
+
+            [OnlineField(group = "arenaSetup")]
             public int lobbyCountDown;
 
             [OnlineField(group = "arenaSetup")]
@@ -247,6 +250,7 @@ namespace RainMeadow
                 playersChoosingSlugs = new(
                     arena.playersInLobbyChoosingSlugs.ToDictionary<string, int>()
                 );
+                countdownSafetyCatchTimer = arena.countdownSafetyCatchTimer;
                 countdownInitiatedHoldFire = arena.countdownInitiatedHoldFire;
                 playerResultColors = arena.playerResultColors;
                 arenaSetupTime = arena.setupTime;
@@ -303,101 +307,88 @@ namespace RainMeadow
 
             public override void ReadTo(OnlineResource.ResourceData data, OnlineResource resource)
             {
-                var lobby = (resource as Lobby);
-                (lobby.gameMode as ArenaOnlineGameMode).isInGame = isInGame;
-                (lobby.gameMode as ArenaOnlineGameMode).playList = playList;
-                (lobby.gameMode as ArenaOnlineGameMode).shufflePlayList = shufflePlayList;
-                (lobby.gameMode as ArenaOnlineGameMode).arenaSittingOnlineOrder =
-                    arenaSittingOnlineOrder;
-                (lobby.gameMode as ArenaOnlineGameMode).allPlayersReadyLockLobby =
-                    allPlayersReadyLockLobby;
-                (lobby.gameMode as ArenaOnlineGameMode).returnToLobby = returnToLobby;
-                (lobby.gameMode as ArenaOnlineGameMode).onlineArenaSettingsInterfaceMultiChoice =
-                    onlineArenaSettingsInterfaceMultiChoice;
-                (lobby.gameMode as ArenaOnlineGameMode).onlineArenaSettingsInterfaceeBool =
-                    onlineArenaSettingsInterfaceBool;
-                (lobby.gameMode as ArenaOnlineGameMode).playersInLobbyChoosingSlugs =
-                    playersChoosingSlugs;
-                (lobby.gameMode as ArenaOnlineGameMode).playersReadiedUp = playersReadiedUp;
-                (lobby.gameMode as ArenaOnlineGameMode).reigningChamps = reigningChamps;
+                if ((resource as Lobby)?.gameMode is not ArenaOnlineGameMode arena) { RainMeadow.Error("Ressource is not an ArenaOnlineGameMode !"); return;}
+                arena.isInGame = isInGame;
+                arena.playList = playList;
+                arena.shufflePlayList = shufflePlayList;
+                arena.arenaSittingOnlineOrder = arenaSittingOnlineOrder;
+                arena.allPlayersReadyLockLobby = allPlayersReadyLockLobby;
+                arena.returnToLobby = returnToLobby;
+                arena.onlineArenaSettingsInterfaceMultiChoice = onlineArenaSettingsInterfaceMultiChoice;
+                arena.onlineArenaSettingsInterfaceeBool = onlineArenaSettingsInterfaceBool;
+                arena.playersInLobbyChoosingSlugs = playersChoosingSlugs;
+                arena.playersReadiedUp = playersReadiedUp;
+                arena.reigningChamps = reigningChamps;
 
-                (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithDeaths =
-                    playerNumberWithDeaths;
-                (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithWins = playerNumberWithWins;
+                arena.playerNumberWithDeaths = playerNumberWithDeaths;
+                arena.playerNumberWithWins = playerNumberWithWins;
 
-                (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithTrophies =
-                    playerNumberWithTrophies;
-                (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithTrophiesPerRound =
-playerNumberWithTrophiesPerRound;
+                arena.playerNumberWithTrophies = playerNumberWithTrophies;
+                arena.playerNumberWithTrophiesPerRound = playerNumberWithTrophiesPerRound;
 
-                (lobby.gameMode as ArenaOnlineGameMode).playerTotScore = playerTotScore;
-                (lobby.gameMode as ArenaOnlineGameMode).playerNumberWithScore =
-                    playerNumberWithScore;
-                (lobby.gameMode as ArenaOnlineGameMode).playersLateWaitingInLobbyForNextRound =
-                    playersLateWaitingInLobby;
+                arena.playerTotScore = playerTotScore;
+                arena.playerNumberWithScore = playerNumberWithScore;
+                arena.playersLateWaitingInLobbyForNextRound = playersLateWaitingInLobby;
+                
+                
+                arena.countdownSafetyCatchTimer = countdownSafetyCatchTimer;
+                arena.countdownInitiatedHoldFire = countdownInitiatedHoldFire;
+                arena.playerResultColors = playerResultColors;
+                arena.setupTime = arenaSetupTime;
+                arena.lobbyCountDown = lobbyCountDown;
+                arena.initiateLobbyCountdown = initiatedLobbyCountDown;
 
-                (lobby.gameMode as ArenaOnlineGameMode).countdownInitiatedHoldFire =
-                    countdownInitiatedHoldFire;
-                (lobby.gameMode as ArenaOnlineGameMode).playerResultColors = playerResultColors;
-                (lobby.gameMode as ArenaOnlineGameMode).setupTime = arenaSetupTime;
-                (lobby.gameMode as ArenaOnlineGameMode).lobbyCountDown = lobbyCountDown;
-                (lobby.gameMode as ArenaOnlineGameMode).initiateLobbyCountdown =
-                    initiatedLobbyCountDown;
+                arena.sainot = sainot;
+                arena.arenaSaintAscendanceTimer = saintAscendanceTimer;
+                arena.watcherCamoTimer = watcherCamoLimit;
+                arena.watcherRippleLevel = watcherRippleLevel;
+                arena.currentGameMode = currentGameMode;
+                arena.currentLevel = currentLevel;
+                arena.totalLevelCount = totalLevels;
+                arena.painCatEgg = painCatEgg;
+                arena.painCatThrows = painCatThrows;
+                arena.painCatLizard = painCatLizard;
+                arena.artiStunDistanceMult = artiStunDistance;
+                arena.disableMaul = disableMaul;
+                arena.itemSteal = arenaItemSteal;
+                arena.allowJoiningMidRound = allowJoiningMidRound;
+                arena.weaponCollisionFix = weaponCollisionFix;
 
-                (lobby.gameMode as ArenaOnlineGameMode).sainot = sainot;
-                (lobby.gameMode as ArenaOnlineGameMode).arenaSaintAscendanceTimer =
-                    saintAscendanceTimer;
-                (lobby.gameMode as ArenaOnlineGameMode).watcherCamoTimer = watcherCamoLimit;
-                (lobby.gameMode as ArenaOnlineGameMode).watcherRippleLevel = watcherRippleLevel;
-                (lobby.gameMode as ArenaOnlineGameMode).currentGameMode = currentGameMode;
-                (lobby.gameMode as ArenaOnlineGameMode).currentLevel = currentLevel;
-                (lobby.gameMode as ArenaOnlineGameMode).totalLevelCount = totalLevels;
-                (lobby.gameMode as ArenaOnlineGameMode).painCatEgg = painCatEgg;
-                (lobby.gameMode as ArenaOnlineGameMode).painCatThrows = painCatThrows;
-                (lobby.gameMode as ArenaOnlineGameMode).painCatLizard = painCatLizard;
-                (lobby.gameMode as ArenaOnlineGameMode).artiStunDistanceMult = artiStunDistance;
-                (lobby.gameMode as ArenaOnlineGameMode).disableMaul = disableMaul;
-                (lobby.gameMode as ArenaOnlineGameMode).itemSteal = arenaItemSteal;
-                (lobby.gameMode as ArenaOnlineGameMode).allowJoiningMidRound = allowJoiningMidRound;
-                (lobby.gameMode as ArenaOnlineGameMode).weaponCollisionFix = weaponCollisionFix;
+                arena.enableBees = enableBees;
+                arena.enableBombs = enableBombs;
+                arena.enableCorpseGrab = enableCorpseGrab;
 
-                (lobby.gameMode as ArenaOnlineGameMode).enableBees = enableBees;
-                (lobby.gameMode as ArenaOnlineGameMode).enableBombs = enableBombs;
-                (lobby.gameMode as ArenaOnlineGameMode).enableCorpseGrab = enableCorpseGrab;
+                arena.leaveForNextLevel = leaveForNextLevel;
+                arena.hasPermissionToRejoin = hasPermissionToRejoin;
+                arena.playersEqualToOnlineSitting = playersEqualToOnlineSitting;
 
-                (lobby.gameMode as ArenaOnlineGameMode).leaveForNextLevel = leaveForNextLevel;
-                (lobby.gameMode as ArenaOnlineGameMode).hasPermissionToRejoin =
-                    hasPermissionToRejoin;
-                (lobby.gameMode as ArenaOnlineGameMode).playersEqualToOnlineSitting =
-                    playersEqualToOnlineSitting;
+                arena.bannedSlugs = bannedSlugs;
+                arena.piggyBack = piggyBack;
+                arena.voidMasterEnabled = voidMasterEnabled;
+                arena.voidSpawnLethalityFactor = voidSpawnLethalityFactor;
 
-                (lobby.gameMode as ArenaOnlineGameMode).bannedSlugs = bannedSlugs;
-                (lobby.gameMode as ArenaOnlineGameMode).piggyBack = piggyBack;
-                (lobby.gameMode as ArenaOnlineGameMode).voidMasterEnabled = voidMasterEnabled;
-                (lobby.gameMode as ArenaOnlineGameMode).voidSpawnLethalityFactor = voidSpawnLethalityFactor;
-
-                (lobby.gameMode as ArenaOnlineGameMode).amoebaDuration = amoebaDuration;
-                (lobby.gameMode as ArenaOnlineGameMode).amoebaControl = amoebaControl;
-                (lobby.gameMode as ArenaOnlineGameMode).friendlyFire = friendlyFire;
-                (lobby.gameMode as ArenaOnlineGameMode).enableOverseer = enableOverseer;
+                arena.amoebaDuration = amoebaDuration;
+                arena.amoebaControl = amoebaControl;
+                arena.friendlyFire = friendlyFire;
+                arena.enableOverseer = enableOverseer;
 
 
-                (lobby.gameMode as ArenaOnlineGameMode).foodScore = foodScore;
+                arena.foodScore = foodScore;
 
-                (lobby.gameMode as ArenaOnlineGameMode).spearHitScore = spearHitScore;
-                (lobby.gameMode as ArenaOnlineGameMode).killScore = killScore;
-                (lobby.gameMode as ArenaOnlineGameMode).aliveScore = aliveScore;
-                (lobby.gameMode as ArenaOnlineGameMode).denEntryRule = denRule;
-                (lobby.gameMode as ArenaOnlineGameMode).denScore = denScore;
-                (lobby.gameMode as ArenaOnlineGameMode).hostLoadedOverlay = hostLoadedOverlay;
-                (lobby.gameMode as ArenaOnlineGameMode).emptyKillTagScore = emptyKillScore;
-                (lobby.gameMode as ArenaOnlineGameMode).challengeDenEjection = challengeDenEjection;
+                arena.spearHitScore = spearHitScore;
+                arena.killScore = killScore;
+                arena.aliveScore = aliveScore;
+                arena.denEntryRule = denRule;
+                arena.denScore = denScore;
+                arena.hostLoadedOverlay = hostLoadedOverlay;
+                arena.emptyKillTagScore = emptyKillScore;
+                arena.challengeDenEjection = challengeDenEjection;
 
 
-                (lobby.gameMode as ArenaOnlineGameMode).artiExplosionCount = artiExplosionCapacity;
-                (lobby.gameMode as ArenaOnlineGameMode).artiParryDistanceMult = artiParryDistance;
-                (lobby.gameMode as ArenaOnlineGameMode).artiParryLeniency = artiParryLeniency;
-                (lobby.gameMode as ArenaOnlineGameMode).enableMeadowCosmetics = enableMeadowCosmetics;
+                arena.artiExplosionCount = artiExplosionCapacity;
+                arena.artiParryDistanceMult = artiParryDistance;
+                arena.artiParryLeniency = artiParryLeniency;
+                arena.enableMeadowCosmetics = enableMeadowCosmetics;
 
             }
 

--- a/Arena/ArenaTimer.cs
+++ b/Arena/ArenaTimer.cs
@@ -83,7 +83,7 @@ namespace RainMeadow
                     showMode = TimerMode.Countdown;
                 }
 
-                if ((safetyCatchTimer > 300)) // Something went wrong with the timer. Let's move on
+                if (safetyCatchTimer > arena.countdownSafetyCatchTimer) // Something went wrong with the timer. Let's move on
                 {
                     showMode = TimerMode.Countdown;
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Fixed the result box bump sound effect on the final results screen playing per player instead of just once
 - Synced the players' ready state on the overlay results screen
 - Fixed the "TO LOBBY" button on the final results screen drawing behind result boxes
+- Made players wait in the starting pipe until everyone joined. The maximum waiting time is configurable in the Remix menu.
 ### Watcher
 - Gave summoned Ameobas the Watcher's body color
 ### Modders

--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -96,6 +96,7 @@ public class RainMeadowOptions : OptionInterface
     public readonly Configurable<Color> currentlyActiveCustomCosmeticColor;
     public readonly Configurable<int> ChallengeID;
 
+    public readonly Configurable<int> CountdownSafetyCatchTimer;
 
     public readonly Configurable<int> ArenaFoodScore;
 
@@ -254,6 +255,7 @@ public class RainMeadowOptions : OptionInterface
         ArenaItemSteal = config.Bind("ArenaItemSteal", false);
         EnablePiggyBack = config.Bind("EnablePiggyBack", true);
 
+        CountdownSafetyCatchTimer = config.Bind("CountdownSafetyCatchTimer", 300);
 
         PickedIntroRoll = config.Bind("PickedIntroRoll", IntroRoll.Meadow);
         LobbyMusic = config.Bind("MeadowLobbyMusic", "default"); // Happy One Year, Meadow
@@ -637,6 +639,13 @@ public class RainMeadowOptions : OptionInterface
 
                 new OpLabel(210f, 340, Translate("Toggle Show Score")),
                 new OpKeyBinder(ArenaToggleShowScoreKey, new Vector2(210f, 310f), new Vector2(150f, 30f)),
+
+                new OpLabel(10f, 280, Translate("Countdown Safety Time (ticks)")),
+                new OpTextBox(CountdownSafetyCatchTimer, new Vector2(10f, 250), 160f)
+                {
+                    accept = OpTextBox.Accept.Int,
+                    description = Translate("How long the countdown will wait for everyone to join. Default : 300 ticks (7.5s)")
+                },
             ];
             UIelement[] arenaPotentialSpoilerSettings = [slugpupHellBackgroundLabel, slugpupHellBackgroundCheckbox];
             for (int i = 0; i < arenaPotentialSpoilerSettings.Length; i++) arenaPotentialSpoilerSettings[i].Hide();

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -64,6 +64,7 @@ namespace RainMeadow
         public int foodScore = RainMeadow.rainMeadowOptions.ArenaFoodScore.Value;
 
         public int spearHitScore = RainMeadow.rainMeadowOptions.ArenaSpearHitScore.Value;
+        public int countdownSafetyCatchTimer = RainMeadow.rainMeadowOptions.CountdownSafetyCatchTimer.Value;
 
         public int killScore = RainMeadow.rainMeadowOptions.ArenaKillScore.Value;
         public int aliveScore = RainMeadow.rainMeadowOptions.ArenaAliveScore.Value;

--- a/OnlineUIComponents/ArenaSpawnLocationIndicator.cs
+++ b/OnlineUIComponents/ArenaSpawnLocationIndicator.cs
@@ -23,7 +23,8 @@ public class ArenaSpawnLocationIndicator : HudPart
 
         if (clientSettings.avatars.Count == 0
             || clientSettings.avatars[0]?.FindEntity(true) is not OnlineCreature oc
-            || oc.realizedCreature is not Player player)
+            || oc.realizedCreature is not Player player
+            || player.inShortcutVessel is not null)
         {
             counter = 0;
             return;

--- a/OnlineUIComponents/ArenaSpawnLocationIndicator.cs
+++ b/OnlineUIComponents/ArenaSpawnLocationIndicator.cs
@@ -19,7 +19,7 @@ public class ArenaSpawnLocationIndicator : HudPart
     public override void Update()
     {
         counter++;
-        if (counter != 30) return;
+        if (counter != 10) return;
 
         if (clientSettings.avatars.Count == 0
             || clientSettings.avatars[0]?.FindEntity(true) is not OnlineCreature oc

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -1,5 +1,6 @@
 ﻿using HUD;
 using RainMeadow.Arena.Nightcat;
+using RWCustom;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -41,6 +42,7 @@ namespace RainMeadow
         private WorldCoordinate lastWorldPos;
         private int lastCameraPos;
         private int lastAbstractRoom;
+        private static readonly IntVector2 outsideArenaDenPos = new IntVector2(-1, -1);
 
         public float DeadFade
         {
@@ -167,7 +169,7 @@ namespace RainMeadow
                 // in room or in shortcut
                 if (abstractPlayer.realizedCreature is Player player)
                 {
-                    if (player.inShortcutVessel is not null)
+                    if (player.inShortcutVessel is not null && player.inShortcutVessel.pos != outsideArenaDenPos) // avoiding that 
                     {
                         found = true;
                         rawPos = camera.room.MiddleOfTile(player.inShortcutVessel.pos) - camera.pos;

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -161,13 +161,19 @@ namespace RainMeadow
                 // in room or in shortcut
                 if (abstractPlayer.realizedCreature is Player player)
                 {
-                    if (player.room == camera.room)
+                    if (player.inShortcutVessel is not null)
+                    {
+                        found = true;
+                        rawPos = camera.room.MiddleOfTile(player.inShortcutVessel.pos) - camera.pos;
+                        this.pointDir = Vector2.down;
+                    }
+                    else if (player.room == camera.room)
                     {
                         found = true;
                         rawPos = Vector2.Lerp(player.bodyChunks[0].pos, player.bodyChunks[1].pos, 0.33333334f) - camera.pos;
                         this.pointDir = Vector2.down;
                     }
-                    else
+                    else // unsure if that check is still necessary
                     {
                         Vector2? shortcutpos = camera.game.shortcuts.OnScreenPositionOfInShortCutCreature(camera.room, player);
                         if (shortcutpos != null)


### PR DESCRIPTION
So another random beef of mine I wanted fixed.
In FFA or Teams, the countdown for the grace period is extended to make sure everyone can load in before counting down.
This is a great system ! It stops people will slow pc to get instantly killed. However, while the arena is waiting for every player, the ones that loaded in (mainly the host) can move freely and already take crusial items and spots.

I do find it quite unfair, expectially in lobby with low countdown that have no regard on spawn killing. It also puts people with slow pc at a constant disadvantage (I mean, one of many) that could be easily be solved.

My solution is simple : while the countdown is waiting for everyone, the players will... wait in their pipe !
This doesn't take in account the time for players to load all the items and creatures in the room, but it's already a big plus from the host getting a free 1-5s on anyone in the grace period.

The countdown has a safety catcher in case not everyone makes it. This was already there, I've just made it configurable if some people don't wanna deal with waiting to a maximum of 7.5sfor everyone to join in.

**TLDR :** 
- Fixed host being able to shelter immediatly before anyone loaded in
- Locked people in their shelter at the start of the round until everyone loaded in

**Note :**
This branch needs playtest with real players. If this happen to have underlying issues, I'd rather it not be pushed for 1.15 release so I can take my time to tackle everything.