### PR TITLE
Fix name tags sometimes getting stuck

### DIFF
--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -138,6 +138,7 @@ namespace RainMeadow
                 }
             }
 
+            this.shouldSkipDrawposLerp = false;
             this.found = false;
             if (camera.room == null || !camera.room.shortCutsReady) return;
             if (!clientSettings.inGame) return;


### PR DESCRIPTION
fixes a bug introduced by #1528 where name tags would occasionally draw at the previous camera's position of another player