### PR TITLE
fix(lobbyselect): refreshing in lan domain fetching steam lobbies

### DIFF
--- a/Menu/Menus/LobbySelectMenu.cs
+++ b/Menu/Menus/LobbySelectMenu.cs
@@ -89,7 +89,11 @@ public class LobbySelectMenu : SmartMenu
         );
 
         lobbyCardSelector = new LobbyCardSelector(this, mainPage, new Vector2(225, 115));
-        lobbyCardSelector.RefreshLobbies += MatchmakingManager.currentInstance.RequestLobbyList;
+#pragma warning disable IDE0200
+        // this forces RefreshLobbies to fetch the actual currentInstance instead of just forcefully pointing at the original currentInstance
+        lobbyCardSelector.RefreshLobbies += () =>
+            MatchmakingManager.currentInstance.RequestLobbyList();
+#pragma warning restore IDE0200
         lobbyCardSelector.OnLobbyCardsUpdated += () =>
         {
             metadataPanel?.ClearLobbyInfo();


### PR DESCRIPTION
forces the `RefreshLobbies` event to check `MatchmakingManager.currentInstance` every time it is invoked instead of just using the instance at the time of the ctor call