### PR TITLE
feat(lobbyselect): use OpUpdown in size filter, default size filter raised to 99

### DIFF
--- a/Menu/Components/LobbyCardSelector.cs
+++ b/Menu/Components/LobbyCardSelector.cs
@@ -377,7 +377,7 @@ public class LobbyCardSelector : ButtonScroller, SelectOneButton.SelectOneButton
     {
         public List<LobbyInfo> filteredInfos = [];
 
-        public int maxPlayerCount = 32;
+        public int maxPlayerCount = 99;
         public bool publicOnly = false;
         public string gamemode = "__any",
             lobbyName = "",

--- a/Menu/Menus/Panels/LobbySelectFiltersPanel.cs
+++ b/Menu/Menus/Panels/LobbySelectFiltersPanel.cs
@@ -24,7 +24,7 @@ class LobbySelectFiltersPanel : PositionedMenuObject, CheckBox.IOwnCheckBox
         modFilterLabel;
     public OpComboBox2 gamemodeFilterComboBox,
         modFilterComboBox;
-    public OpTextBox sizeFilterTextBox;
+    public OpUpdown sizeFilterTextBox;
     public RestorableCheckbox publicLobbiesOnlyCheckBox;
 
     public event OnFilterUpdateHandler? OnFilterUpdated;
@@ -54,13 +54,12 @@ class LobbySelectFiltersPanel : PositionedMenuObject, CheckBox.IOwnCheckBox
 
         positioner.y -= 40;
 
-        sizeFilterTextBox = new OpTextBox(
-            new Configurable<int>(32),
-            positioner + new Vector2(45, 0),
-            50
+        sizeFilterTextBox = new OpUpdown(
+            new Configurable<int>(99, new ConfigAcceptableRange<int>(0, 99)),
+            positioner + new Vector2(40, -5),
+            60
         )
         {
-            alignment = FLabelAlignment.Center,
             description = menu.Translate("Filter for a maximum lobby size"),
             accept = OpTextBox.Accept.Int,
             maxLength = 2,
@@ -73,7 +72,7 @@ class LobbySelectFiltersPanel : PositionedMenuObject, CheckBox.IOwnCheckBox
             OnFilterChange();
         };
         new PatchedUIelementWrapper(tabWrapper, sizeFilterTextBox);
-        maxLobbySize = 32;
+        maxLobbySize = 99;
 
         sizeFilterLabel = new MenuLabel(
             menu,


### PR DESCRIPTION
ohhh I'm supposed to pass in a ConfigAcceptableRange for it to not crash as an OpUpdown :P. Also raises the default lobby size filter to 99 so large lobbies aren't filtered out by default.