### PR TITLE
fix: set levels dir as high impact

### DIFF
--- a/ModManager/RainMeadowModInfoManager.cs
+++ b/ModManager/RainMeadowModInfoManager.cs
@@ -104,7 +104,16 @@ public static class RainMeadowModInfoManager
         var modInfo = new RainMeadowModInfo();
 
         // TODO: consider mod.modifiesRegions
-        if (Directory.Exists(Path.Combine(mod.path, "modify", "world")))
+        // Mods that change the world (regions) or the arena levels are high-impact: clients missing
+        // them can't load what the host is running.
+        string[] highImpactDirectories =
+        [
+            Path.Combine(mod.path, "modify", "world"),
+            Path.Combine(mod.path, "levels"),
+            Path.Combine(mod.path, "modify", "levels"),
+        ];
+
+        if (highImpactDirectories.Any(Directory.Exists))
         {
             modInfo.SyncRequiredMods.Add(mod.id);
         }

--- a/ModManager/RainMeadowModInfoManager.cs
+++ b/ModManager/RainMeadowModInfoManager.cs
@@ -104,8 +104,8 @@ public static class RainMeadowModInfoManager
         var modInfo = new RainMeadowModInfo();
 
         // TODO: consider mod.modifiesRegions
-        // Mods that change the world regions or the arena levels are high-impact: clients missing
-        // them would crash on level join .
+        // Mods that change the world regions or the arena levels are high-impact
+        // For arena, clients missing them would crash on level join .
         string[] highImpactDirectories =
         [
             Path.Combine(mod.path, "modify", "world"),

--- a/ModManager/RainMeadowModInfoManager.cs
+++ b/ModManager/RainMeadowModInfoManager.cs
@@ -104,8 +104,8 @@ public static class RainMeadowModInfoManager
         var modInfo = new RainMeadowModInfo();
 
         // TODO: consider mod.modifiesRegions
-        // Mods that change the world (regions) or the arena levels are high-impact: clients missing
-        // them can't load what the host is running.
+        // Mods that change the world regions or the arena levels are high-impact: clients missing
+        // them would crash on level join .
         string[] highImpactDirectories =
         [
             Path.Combine(mod.path, "modify", "world"),


### PR DESCRIPTION
Regions are to Story as Levels are to Arena

I don't really know if modify/levels is required because that typically just translates into spawning behavior changes but I don't think it'd hurt. 