### PR TITLE
fix: dead state condition in OnlineSeedPod

### DIFF
--- a/Online/Entity/OnlineSeedPod.cs
+++ b/Online/Entity/OnlineSeedPod.cs
@@ -93,7 +93,7 @@
                 {
                     seedCob.opened = opened;
                     seedCob.spawnedUtility = spawnedUtility;
-                    seedCob.dead = seedCob.dead || opened || spawnedUtility;
+                    seedCob.dead = seedCob.dead || spawnedUtility;
                 }
             }
         }


### PR DESCRIPTION
Corn, when the room is unloaded, will show as dead when reloaded due to `dead` currently checking `opened`. 

Base game, it checks for the save state consumable being touched. 

```cs
    public class AbstractSeedCob : AbstractConsumable
    {
        public bool opened;

        public bool dead = true;

        public bool rotted;

        public bool spawnedUtility;

        public AbstractSeedCob(World world, PhysicalObject realizedObject, WorldCoordinate pos, EntityID ID, int originRoom, int consumableIndex, bool dead, PlacedObject.ConsumableObjectData consumableData)
            : base(world, AbstractObjectType.SeedCob, realizedObject, pos, ID, originRoom, consumableIndex, consumableData)
        {
            this.dead = dead;
            if (!dead && world.game.session is StoryGameSession && (world.game.session as StoryGameSession).saveState.ItemConsumed(world, karmaFlower: false, originRoom, consumableIndex))
            {
                this.dead = true;
            }

            opened = this.dead;
        }
    }
```

I’m not sure the purpose behind having `opened` here writing to `dead` since the context for the code was written 2 years(!) ago.

Fix was tested. If you have any context to add for the bool to exist here, I’ll make an issue for someone to explore at a future date.