### PR TITLE
hotfix: missing online counterparts during transitions

### DIFF
--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -186,8 +186,9 @@ namespace RainMeadow
                 RainMeadow.Debug("Unsubscribing from old world");
                 if (roomSession.worldSession.isActive)
                 {
-                    roomSession.worldSession.Deactivate();
+                    // NotNeeded BEFORE Deactivate, otherwise the room sessions never get released
                     roomSession.worldSession.NotNeeded();
+                    roomSession.worldSession.Deactivate();
                 }
 
                 if (roomSession.worldSession.participants.Count > 0)

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -566,17 +566,20 @@ namespace RainMeadow
 
         private System.Collections.IEnumerator Overworld_Loaded_WaitLoop(On.OverWorld.orig_WorldLoaded orig, OverWorld self, bool warpUsed, WorldSession oldWorldSession, WorldSession newWorldSession, World world)
         {
-            System.Func<bool> waitCondition = null;
+            System.Func<bool>? waitCondition = null;
 
             if ((OnlineManager.lobby.gameMode is not MeadowGameMode && !OnlineManager.lobby.isOwner))
             {
                 waitCondition = () => !newWorldSession.isAvailable;
             }
 
+            // orig already ran  so there is nothing left to execute here.
+            // This only holds transitionInProgress until the old world's participants clear
+            // used to throw an exception literally every warp
             return WorldSession.WaitAndExecuteSession(
                 oldWorldSession,
                 waitCondition,
-                () => self.WorldLoaded(warpUsed)
+                null
             );
         }
 

--- a/Game/RainMeadow.EntityHooks.cs
+++ b/Game/RainMeadow.EntityHooks.cs
@@ -40,9 +40,9 @@ namespace RainMeadow
             On.Watcher.BigSandGrubNeck.Update += BigSandGrubNeck_Update;
             On.Watcher.BigSandGrubGraphics.UpdateSegments += BigSandGrubGraphics_UpdateSegments;
             On.Watcher.SandGrub.Collide += SandGrub_Collide;
-            On.Watcher.SandGrub.UpdateTentacle += SandGrub_UpdateTentacle;           
+            On.Watcher.SandGrub.UpdateTentacle += SandGrub_UpdateTentacle;
             On.Watcher.PrinceBulb.AIMapReady += PrinceBulb_AIMapReady;
-            
+
             new Hook(typeof(AbstractCreature).GetProperty("Quantify").GetGetMethod(), this.AbstractCreature_Quantify);
         }
 
@@ -260,7 +260,7 @@ namespace RainMeadow
             if (self.GetOnlineObject(out var oe) && (oe.isTransferable || !oe.isMine)) self.destroyOnAbstraction = false;
 
             orig(self, coord);
-            
+
             if (OnlineManager.lobby != null && oe is not null)
             {
                 oe.realized = false;
@@ -274,7 +274,7 @@ namespace RainMeadow
                         {
                             self.Destroy();
                         }
-                    } 
+                    }
                 }
             }
         }
@@ -587,8 +587,11 @@ namespace RainMeadow
             { // there exists "warps" to the same world, twice, for some bloody reason
                 //this in fact probably is required for now because rain world devs DESPISE US
                 RainMeadow.Debug("Unsubscribing from old world");
-                oldWorldSession.Deactivate();
+                // NotNeeded first!
+                // it only cascades to the room sessions while we're still active.
+                // Deactivating first nulls out subresources
                 oldWorldSession.NotNeeded(); // done? let go
+                oldWorldSession.Deactivate();
             }
 
             self.game.manager.rainWorld.StartCoroutine(Overworld_Loaded_WaitLoop(orig, self, warpUsed, oldWorldSession, newWorldSession, newWorld));

--- a/Game/RainMeadow.LoadingHooks.cs
+++ b/Game/RainMeadow.LoadingHooks.cs
@@ -106,6 +106,10 @@ namespace RainMeadow
 
                     if (!self.shortcutsOnly && self.room.game != null)
                     {
+                        // world was deactivated for a transition, but the room session outlives it in the rs map
+                        // requesting it gets refused by the supervisor since its ALSO releasing and
+                        // letting it prepare realizes entities into a world nobody owns which gets really dicey in watcher warps
+                        if (!rs.worldSession.isActive) return;
                         RainMeadow.Trace($"{rs} : {rs.isPending} {rs.isAvailable} {rs.isActive}");
                         rs.Needed();
                         if (!rs.isAvailable || rs.isPending) return;
@@ -123,6 +127,7 @@ namespace RainMeadow
             orig(self, room, loadAiHeatMaps, falseBake, shortcutsOnly);
             if (!shortcutsOnly && room.game != null && OnlineManager.lobby != null && RoomSession.map.TryGetValue(room.abstractRoom, out var rs))
             {
+                if (!rs.worldSession.isActive) return; // world is being torn down, see RoomPreparer_Update
                 rs.Needed();
             }
         }

--- a/Game/RainMeadow.ObjectHooks.cs
+++ b/Game/RainMeadow.ObjectHooks.cs
@@ -24,8 +24,14 @@ namespace RainMeadow
         private void Room_Update_FreezeDeactivatedWorld(On.Room.orig_Update orig, Room self)
         {
             if (OnlineManager.lobby != null
-                && self.abstractRoom.GetResource() is RoomSession rs
-                && !rs.worldSession.isActive) return;
+                && self.abstractRoom.GetResource() is RoomSession rs)
+            {
+                if (!rs.worldSession.isActive)
+                {
+                    RainMeadow.Error($"froze room update for its world, it's never coming back");
+                    return;
+                }
+            }
             orig(self);
         }
 

--- a/Game/RainMeadow.ObjectHooks.cs
+++ b/Game/RainMeadow.ObjectHooks.cs
@@ -28,7 +28,7 @@ namespace RainMeadow
             {
                 if (!rs.worldSession.isActive)
                 {
-                    RainMeadow.Error($"froze room update for its world, it's never coming back");
+                    RainMeadow.Debug($"froze room update for its world, it's never coming back");
                     return;
                 }
             }

--- a/Game/RainMeadow.ObjectHooks.cs
+++ b/Game/RainMeadow.ObjectHooks.cs
@@ -14,9 +14,19 @@ namespace RainMeadow
         private void ObjectHooks()
         {
             IL.Room.Update += Room_Update;
+            On.Room.Update += Room_Update_FreezeDeactivatedWorld;
 
             // IL.ScavengerOutpost.ctor += ScavengerOutpost_ctor1; ;
             On.LobeTree.ValidSpawnPos += LobeTree_ValidSpawnPos;
+        }
+
+        // A deactivated world deregistered all its entities, but its rooms update until the process switches.
+        private void Room_Update_FreezeDeactivatedWorld(On.Room.orig_Update orig, Room self)
+        {
+            if (OnlineManager.lobby != null
+                && self.abstractRoom.GetResource() is RoomSession rs
+                && !rs.worldSession.isActive) return;
+            orig(self);
         }
 
         private bool LobeTree_ValidSpawnPos(On.LobeTree.orig_ValidSpawnPos orig, Room room, IntVector2 pos, List<Vector2> lobeTreeSpawnLocsSoFar)

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -2087,6 +2087,7 @@ public partial class RainMeadow
         if (OnlineManager.lobby.gameMode is MeadowGameMode) return; // do not run
 
         OnlineCreature? onlineCreature = self.abstractCreature.GetOnlineCreature();
+        // player quit while a death event was running, or wait loop is processing
         if (onlineCreature is null)
         {
             orig(self);

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -139,7 +139,7 @@ public partial class RainMeadow
         try
         {
             ILCursor cursor = new ILCursor(il);
-            if (cursor.TryGotoNext(MoveType.Before, 
+            if (cursor.TryGotoNext(MoveType.Before,
                 x => x.MatchCallvirt(typeof(FNode).GetProperty(nameof(FNode.isVisible)).GetSetMethod())))
             {
                 cursor.MoveAfterLabels();
@@ -147,8 +147,8 @@ public partial class RainMeadow
                 cursor.EmitDelegate((bool orig, Creature creature) =>
                 {
                     // Debug($"Is mud of [{creature}/{creature.abstractCreature?.GetOnlineCreature()}] visible ? <{orig}><{creature.abstractCreature?.rippleLayer}><{creature.abstractCreature?.world?.game?.ActiveRippleLayer}>");
-                    return orig 
-                        && creature.abstractCreature?.rippleLayer == 0 
+                    return orig
+                        && creature.abstractCreature?.rippleLayer == 0
                         && creature.abstractCreature?.world?.game?.ActiveRippleLayer == 0;
                 });
             }
@@ -189,7 +189,7 @@ public partial class RainMeadow
     }
 
     // sync Artificer's parry. Cmon she needs it.
-    public static void PlayArtiParryCustomSound(Weapon weapon) 
+    public static void PlayArtiParryCustomSound(Weapon weapon)
     {
         weapon.room.PlaySound(SoundID.Spear_Bounce_Off_Creauture_Shell, weapon.firstChunk, false, 1.2f, 2f);
     }
@@ -210,13 +210,13 @@ public partial class RainMeadow
             cursor.EmitDelegate((Player player, List<Weapon> weapons, int i) =>
             {
                 Weapon weapon = weapons[i]; // we grab the weapon from the local variables
-                if (OnlineManager.lobby != null && i == 0) {PlayArtiParryCustomSound(weapon);} // play only in Meadow, not in local
+                if (OnlineManager.lobby != null && i == 0) { PlayArtiParryCustomSound(weapon); } // play only in Meadow, not in local
 
                 if (weapon.abstractPhysicalObject.GetOnlineObject() is not OnlinePhysicalObject onlineWeapon
                     || onlineWeapon.isMine // We don't need to do anything if the spear is ours
                     || player.abstractCreature.GetOnlineCreature() is not OnlineCreature onlineCreature
                     || !onlineCreature.isMine) return; // We don't fire if the parry isn't from the client
-                
+
                 RainMeadow.Debug($"ARTI PARRY !! {onlineCreature}, {onlineWeapon}, {onlineWeapon.owner}, Frame {Mathf.RoundToInt(ARTI_PARRY_MAX_COOLDOWN - player.pyroParryCooldown)}");
 
                 RealizedWeaponState? realizedWeaponState = GetAppropriateWeaponState(onlineWeapon);
@@ -224,8 +224,8 @@ public partial class RainMeadow
                 {
                     RainMeadow.Error($"Failed to create the appropriate weapon state for obj {onlineWeapon}");
                     return;
-                } 
-                
+                }
+
                 onlineWeapon.Lock("parry", onlineWeapon.owner.InvokeRPC(RPCs.Weapon_CreatureDeflect, onlineWeapon, realizedWeaponState, true, i != 0));
                 foreach (OnlinePlayer otherplayer in onlineWeapon.roomSession?.participants ?? [])
                 {
@@ -269,10 +269,10 @@ public partial class RainMeadow
             cursor.EmitDelegate((Weapon weapon, SharedPhysics.CollisionResult result) =>
             {
                 if (weapon.abstractPhysicalObject.GetOnlineObject() is OnlinePhysicalObject onlineWeapon
-                    && result.obj is Creature target 
+                    && result.obj is Creature target
                     && target.abstractCreature.GetOnlineCreature() is OnlineCreature onlineCreature)
                 {
-                    if (!onlineCreature.isMine) 
+                    if (!onlineCreature.isMine)
                     {
                         // spear was already deflected, if an RPC comes in, we'll ignore it
                         onlineWeapon.Lock("deflected"); // Locking manually is abit sketchy, but it's kind of my only way.
@@ -286,10 +286,10 @@ public partial class RainMeadow
                         {
                             RainMeadow.Error($"Failed to create the appropriate weapon state for obj {onlineWeapon}");
                             return;
-                        } 
-                        
+                        }
+
                         onlineWeapon.Lock("parry", onlineWeapon.owner.InvokeRPC(RPCs.Weapon_CreatureDeflect, onlineWeapon, realizedWeaponState, false, false));
-                        
+
                         foreach (OnlinePlayer player in onlineWeapon.roomSession?.participants ?? [])
                         {
                             if (player is not null && player != onlineWeapon.owner && !player.isMe)
@@ -306,7 +306,7 @@ public partial class RainMeadow
             Logger.LogError(e);
         }
     }
-    
+
     public bool BottomPlayerUsingSpearmasterAbility(Player spearmaster, out Player user)
     {
         user = null!;
@@ -1156,9 +1156,9 @@ public partial class RainMeadow
         if (OnlineManager.lobby != null)
         {
             if (self.controller is null && self.room.world.game.cameras[0]?.hud is HUD.HUD hud
-                && (hud.textPrompt?.pausedMode is true 
+                && (hud.textPrompt?.pausedMode is true
                     || RMOverlayHUDMenu.GetOverlay()?.isFocusedOnMenu is true
-                    || (hud.parts.OfType<SpectatorHud>().Any(x => x.isActive) 
+                    || (hud.parts.OfType<SpectatorHud>().Any(x => x.isActive)
                         && RainMeadow.rainMeadowOptions.StopMovementWhileSpectateOverlayActive.Value)))
             {
                 GameplayOverrides.StopPlayerMovement(self);
@@ -2088,8 +2088,11 @@ public partial class RainMeadow
 
         OnlineCreature? onlineCreature = self.abstractCreature.GetOnlineCreature();
         if (onlineCreature is null)
-            throw new InvalidProgrammerException("Player doesn't have an OnlineCreature counterpart!!");
-
+        {
+            orig(self);
+            RainMeadow.Error("Player doesn't have an OnlineCreature counterpart!!");
+            return;
+        }
         // Remote avatars die when their owner's state says so, not from our local
         // simulation. Predicted deaths (weapon hits are simulated on the attacker's end
         // too) would get corrected by the next state and fake a revive on the HUD.

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -710,10 +710,6 @@ namespace RainMeadow
 
             AbstractRoom absRoom = game.world.abstractRooms[0];
             Room room = absRoom.realizedRoom;
-            WorldSession worldSession = WorldSession.map.GetValue(
-                game.world,
-                (w) => throw new KeyNotFoundException()
-            );
 
             if (RoomSession.map.TryGetValue(absRoom, out var roomSession))
             {

--- a/Online/Resource/OnlineResource.Transactions.cs
+++ b/Online/Resource/OnlineResource.Transactions.cs
@@ -107,6 +107,7 @@ namespace RainMeadow
             RainMeadow.Debug(this);
             // dropping a participant is always safe
             // and refusing it on the basis that super.isReleasing just makes them retry forever
+            if (isSupervisor)
             {
                 request.from.QueueEvent(new GenericResult.Ok(request));
                 ParticipantLeft(request.from);

--- a/Online/Resource/OnlineResource.Transactions.cs
+++ b/Online/Resource/OnlineResource.Transactions.cs
@@ -75,7 +75,9 @@ namespace RainMeadow
         protected void Requested(RPCEvent request)
         {
             RainMeadow.Debug(this);
-            if (canBeRequested && isSupervisor && !super.isReleasing)
+            // we release the moment the last participant leaves now, so a client
+            // requesting in that same tick might get a lease we're letting go of
+            if (canBeRequested && isSupervisor && !isReleasing && !super.isReleasing)
             {
                 if (owner == null)
                 {

--- a/Online/Resource/OnlineResource.Transactions.cs
+++ b/Online/Resource/OnlineResource.Transactions.cs
@@ -105,7 +105,8 @@ namespace RainMeadow
         private void Released(RPCEvent request)
         {
             RainMeadow.Debug(this);
-            if (isSupervisor && !super.isReleasing)
+            // dropping a participant is always safe
+            // and refusing it on the basis that super.isReleasing just makes them retry forever
             {
                 request.from.QueueEvent(new GenericResult.Ok(request));
                 ParticipantLeft(request.from);
@@ -140,7 +141,7 @@ namespace RainMeadow
             else if (requestResult is GenericResult.Error) // I should retry
             {
                 RainMeadow.Error("Request failed for " + this);
-                PerformRequests();
+                RetryTransaction();
             }
         }
 
@@ -155,8 +156,15 @@ namespace RainMeadow
             else if (releaseResult is GenericResult.Error) // I should retry
             {
                 RainMeadow.Error("Release failed for " + this);
-                PerformRequests();
+                RetryTransaction();
             }
+        }
+
+        // if we're caught in a scenario where world is releasing and we're being refused by our own handler, we need to deal with that
+        // a refusal from my own handler would feed the ProcessSelfEvents loop that's still trying to clear out!
+        private void RetryTransaction()
+        {
+            OnlineManager.RunDeferred(PerformRequests);
         }
 
         // A pending transfer was asnwered to

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -385,9 +385,9 @@ namespace RainMeadow
             }
             else if (!isNeeded && isAvailable && canRelease)
             {
-                // NotNeeded only gets one shot at releasing. If it was turned down because a
-                // participant was still here or hadn't ackd the latest lease nothing ever tries
-                // again and whoever is waiting for this resource to empty out waits forever.
+                // If  NotNeeded was  turned down because a
+                // participant was still here or hasn't ackd the latest lease nothing ever tries
+                // again and whoever is waiting for this resource to empty out waits forever. Truly doom
                 Release();
             }
             ParticipantLeftImpl(participant);

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -228,7 +228,9 @@ namespace RainMeadow
 
         protected void SubresourcesUnloaded() // callback-ish for resources freeing up
         {
-            if (!isNeeded && canRelease)
+            // super can already be unavailable here. an inactive resource is allowed to
+            // release while children are still available, so Release() would throw
+            if (!isNeeded && isAvailable && canRelease)
             {
                 Release();
             }
@@ -383,15 +385,18 @@ namespace RainMeadow
                 if (isWaitingForState) isWaitingForState = false;
                 PerformRequests();
             }
-            else if (!isNeeded && isAvailable && canRelease)
-            {
-                // If  NotNeeded was  turned down because a
-                // participant was still here or hasn't ackd the latest lease nothing ever tries
-                // again and whoever is waiting for this resource to empty out waits forever. Truly doom
-                Release();
-            }
             ParticipantLeftImpl(participant);
             OnParticipantLeft?.Invoke(this, participant);
+
+            // If NotNeeded was  turned down because a
+            // participant was still here or hasn't ackd the latest lease nothing ever tries
+            // again and whoever is waiting for this resource to empty out waits forever. Truly doom
+            // Runs after so nobody gets handed an already-unavailable resource
+            // with no supervisor (during wait loops)
+            if (!participant.isMe && !isNeeded && isAvailable && canRelease)
+            {
+                Release();
+            }
         }
 
         protected void SanitizeSubresources()

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -393,7 +393,7 @@ namespace RainMeadow
             // again and whoever is waiting for this resource to empty out waits forever. Truly doom
             // Runs after so nobody gets handed an already-unavailable resource
             // with no supervisor (during wait loops)
-            if (!participant.isMe && !isNeeded && isAvailable && canRelease)
+            if (!participant.isMe && !isNeeded && !isPending && isAvailable && canRelease)
             {
                 Release();
             }

--- a/Online/Resource/OnlineResource.cs
+++ b/Online/Resource/OnlineResource.cs
@@ -383,6 +383,13 @@ namespace RainMeadow
                 if (isWaitingForState) isWaitingForState = false;
                 PerformRequests();
             }
+            else if (!isNeeded && isAvailable && canRelease)
+            {
+                // NotNeeded only gets one shot at releasing. If it was turned down because a
+                // participant was still here or hadn't ackd the latest lease nothing ever tries
+                // again and whoever is waiting for this resource to empty out waits forever.
+                Release();
+            }
             ParticipantLeftImpl(participant);
             OnParticipantLeft?.Invoke(this, participant);
         }

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -29,7 +29,7 @@ namespace RainMeadow
             bool cleanupTriggered = false;
 
             session.transitionInProgress = true;
-            bool canSkipWaitLoop = OnlineManager.lobby.gameMode is MeadowGameMode;
+            bool canSkipWaitLoop = OnlineManager.lobby.gameMode is MeadowGameMode || RainMeadow.isStoryMode(out var story) && story.currentCampaign == Watcher.WatcherEnums.SlugcatStatsName.Watcher;
 
             while (true)
             {

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -60,7 +60,6 @@ namespace RainMeadow
                         var remainingPlayers = session
                             .participants.Where(x => x != player)
                             .ToList();
-                        // Only the transitioning session: dropping ourselves from the overworld leaves it ownerless.
                         session.UpdateParticipants(remainingPlayers);
                         OnlineManager.RemoveSubscription(session, player);
                     }

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -29,7 +29,7 @@ namespace RainMeadow
             bool cleanupTriggered = false;
 
             session.transitionInProgress = true;
-            bool canSkipWaitLoop = OnlineManager.lobby.gameMode is MeadowGameMode || RainMeadow.isStoryMode(out var story) && story.currentCampaign == Watcher.WatcherEnums.SlugcatStatsName.Watcher;
+            bool canSkipWaitLoop = OnlineManager.lobby.gameMode is MeadowGameMode;
 
             while (true)
             {

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -60,11 +60,7 @@ namespace RainMeadow
                         var remainingPlayers = session
                             .participants.Where(x => x != player)
                             .ToList();
-                        if (session.overworldSession != null)
-                        {
-                            session.overworldSession.UpdateParticipants(remainingPlayers);
-                            OnlineManager.RemoveSubscription(session.overworldSession, player);
-                        }
+                        // Only the transitioning session: dropping ourselves from the overworld leaves it ownerless.
                         session.UpdateParticipants(remainingPlayers);
                         OnlineManager.RemoveSubscription(session, player);
                     }

--- a/Online/Resource/WorldSession.cs
+++ b/Online/Resource/WorldSession.cs
@@ -13,20 +13,19 @@ namespace RainMeadow
 
         /// <summary>
         /// A centralized coroutine helper that waits for a WorldSession's participants to clear before proceeding.
-        /// It enforces a 5-second safety timeout to prevent softlocks (deadlocks) if entities fail to remove.
+        /// It enforces an 8-second safety timeout to prevent softlocks (deadlocks) if entities fail to remove.
         /// </summary>
         /// <param name="session">The WorldSession currently transitioning.</param>
         /// <param name="extraWaitCondition">Optional: An additional condition that must remain true to keep waiting (e.g., !newWorldSession.isAvailable). Pass null if not needed.</param>
-        /// <param name="onComplete">The action/method to execute once the wait finishes or times out (e.g., orig(self, ...)).</param>
+        /// <param name="onComplete">Optional: the action to execute once the wait finishes or times out. Pass null when the caller has already done its work and only needs transitionInProgress.</param>
         public static System.Collections.IEnumerator WaitAndExecuteSession(
             WorldSession session,
-            System.Func<bool> extraWaitCondition,
-            System.Action onComplete
+            System.Func<bool>? extraWaitCondition,
+            System.Action? onComplete
         )
         {
             float startTime = UnityEngine.Time.time;
             float timeoutSeconds = 8f;
-            bool cleanupTriggered = false;
 
             session.transitionInProgress = true;
             bool canSkipWaitLoop = OnlineManager.lobby.gameMode is MeadowGameMode;
@@ -38,8 +37,7 @@ namespace RainMeadow
                 bool conditionMet = extraWaitCondition == null || !extraWaitCondition();
 
                 // In Meadow, we only care about the extra condition.
-                // In Story/Arena, we wait for participants to be 0 AND the condition to be met.
-                // Except for Watcher because the loading in that is obscene
+                // In Story/Arena, we wait for participants to be 0 AND the condition to be met or timeout to be hit.
 
                 bool isDoneWaiting = canSkipWaitLoop
                     ? conditionMet
@@ -48,23 +46,13 @@ namespace RainMeadow
                 if (isDoneWaiting)
                     break;
 
-                if (!canSkipWaitLoop && elapsed > timeoutSeconds && !cleanupTriggered)
+                if (!canSkipWaitLoop && elapsed > timeoutSeconds)
                 {
-                    cleanupTriggered = true; // Only do this once
                     RainMeadow.Debug(
-                        "WaitLoop: Timeout reached. Forcing participant cleanup, but continuing to wait for conditions..."
+                        "WaitLoop: Timeout reached. Breaking..."
                     );
-                    foreach (var player in participants)
-                    {
-                        RainMeadow.Debug($"WaitLoop: Force-removing {player} from session.");
-                        var remainingPlayers = session
-                            .participants.Where(x => x != player)
-                            .ToList();
-                        session.UpdateParticipants(remainingPlayers);
-                        OnlineManager.RemoveSubscription(session, player);
-                    }
+                    break;
 
-                    // After removing, let the loop check isDoneWaiting again.
                 }
 
                 yield return null;


### PR DESCRIPTION
Ok, let me give some background on this before you think "wtf is this? "

In `PlayerOnDie` recently, we used to log an error when the Online counterpart was missing. It swapped to being a thrown exception, and that was causing crashes in arena. 

I found that weird, so I went looking. 

During the WaitLoop we use for Story & Arena, there's a period of time where we're waiting for participants to exit the world and room resources but are still running simulations. That's what the `Room_Preparer` and `Room_Update` freeze hooks address: an inactive world but a room still wanting to simulate while we're transitioning, which pisses things off. 

After that, I noticed that the host never attempts a second Release correctly when participants leave. It'd just try once during a world tear down, give up because participants were still leaving, then would depend on the deadlock timer to escape.

As a result, `Release`() was added to `ParticipantLeft` to re-try. 

Then, when I was testing across all modes, I noticed Watcher was throwing some weird errors about Room states failing updates during warp transitions to another world. 

After investigating, I realized `NotNeeded`() and `Deactivate`() were in the wrong spots. `Deactivate` nulls out resources and was happening first, so room states weren't being properly cleaned up. That's why they're now swapped. 

After doing *that*, I tested Meadow mode and realize the final client in a resource could not transition gates. Just kept getting a failure to release things *we* own.

After more investigation, I realized that with the `NotNeeded` and `Deactivate` properly swapped it exposed a bug where the client was spinning in place trying to address a `Release` they would never complete because we had an `super.isReleasing` check during the Release, but because participants being removed is safe we didn't need this and could defer with a retry outside the Update frame to reduce pressure and stop re-filling the `ProcessSelfEvents` that created a "livelock" scenario where we're constantly screwing ourselves over. 


Benefits of this PR:
- Gate / Warp transitions are happier
- I don't see any repeated room failure releases we used to get in #1196 


==
- Tested across all modes with 3 users in LAN. 
- Included in multiple "real" playtests
- Supersedes #1588 

If this is too much for a hotfix then we can go with the #1588