### PR TITLE
hotfix : Added RPC owner check (1.15.1/1.16.0)

### DIFF
--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -305,9 +305,9 @@ namespace RainMeadow
             }
         }
         [RPCMethod]
-        public static void Arena_EndSessionEarly()
+        public static void Arena_EndSessionEarly(RPCEvent rpc)
         {
-            if (RainMeadow.isArenaMode(out var arena))
+            if (RainMeadow.isArenaMode(out var arena) && rpc.from == arena.lobby?.owner)
             {
                 var game = (RWCustom.Custom.rainWorld.processManager.currentMainLoop as RainWorldGame);
                 if (game == null)
@@ -316,9 +316,6 @@ namespace RainMeadow
                     return;
                 }
                 game.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.MultiplayerResults);
-
-
-
             }
         }
 
@@ -425,8 +422,8 @@ namespace RainMeadow
             if (RainMeadow.isArenaMode(out var arena))
             {
                 arena.setupTime = setupTime;
-                // I don't think this is used so I'm not sure if the param here is 
-                // retrieved from host's meadow remix settings or host's actual 
+                // I don't think this is used so I'm not sure if the param here is
+                // retrieved from host's meadow remix settings or host's actual
                 // Player.maxGodTime. I'll leave it be but if this is causing issues
                 // just slap on a * 40 or / 40
                 arena.arenaSaintAscendanceTimer = saintMaxTime;

--- a/Online/Entity/OnlinePhysicalObject.cs
+++ b/Online/Entity/OnlinePhysicalObject.cs
@@ -211,7 +211,7 @@ namespace RainMeadow
                 creatingRemoteObject = oldCreatingRemoteObject;
                 throw;
             }
-            creatingRemoteObject = oldCreatingRemoteObject; 
+            creatingRemoteObject = oldCreatingRemoteObject;
 
 
             realized = initialState.realized;
@@ -228,7 +228,7 @@ namespace RainMeadow
             base.NewOwner(newOwner);
             if (newOwner.isMe)
             {
-            
+
                 if (realized && apo.realizedObject is null && apo.destroyOnAbstraction)
                 {
                     realized = false;
@@ -428,7 +428,7 @@ namespace RainMeadow
                 if (apo is AbstractCreature) apo.Room?.creatures?.Remove((AbstractCreature)apo);
             }
         }
-        
+
         public void RemoveEntityFromGame(bool onlineaware = true)
         {
             RainMeadow.Debug("Removing entity from game: " + this);
@@ -499,7 +499,7 @@ namespace RainMeadow
                 }
                 if (inResource is RoomSession rs)
                 {
-                    if (!apo.slatedForDeletion) RemoveEntityFromRoom(true);                    
+                    if (!apo.slatedForDeletion) RemoveEntityFromRoom(true);
                 }
                 AllMoving(false);
             }
@@ -597,8 +597,8 @@ namespace RainMeadow
                     return;
                 }
 
-                result = new SharedPhysics.CollisionResult(collision_obj.apo.realizedObject, 
-                    chunk?.ToBodyChunk(), 
+                result = new SharedPhysics.CollisionResult(collision_obj.apo.realizedObject,
+                    chunk?.ToBodyChunk(),
                     onAppendagePos?.GetAppendagePos(collision_obj.apo.realizedObject), hitSomething, collisionPoint);
             }
         }
@@ -608,12 +608,12 @@ namespace RainMeadow
         public void WeaponHitSomething(RealizedWeaponState statewhenhit, OnlineCollisionResult hit)
         {
             if (this.IsLocked("parry")) return;
-            if (this.apo.realizedObject != null) 
+            if (this.apo.realizedObject != null)
             {
                 statewhenhit.ReadTo(this);
                 SharedPhysics.CollisionResult? result = null;
                 hit.BuildCollisionResult(out result);
-                if (result.HasValue) 
+                if (result.HasValue)
                 {
                     OnlinePhysicalObject? onlineResult = result.Value.obj.abstractPhysicalObject.GetOnlineObject();
                     (this.apo.realizedObject as Weapon)!.HitSomething(result.Value, true);
@@ -647,9 +647,10 @@ namespace RainMeadow
         }
 
         [RPCMethod]
-        public void Explode(Vector2 pos)
+        public void Explode(RPCEvent rpc, Vector2 pos)
         {
             if (apo.realizedObject is null) return;
+            if (rpc.from != owner && rpc.from != roomSession?.owner) return;
             apo.realizedObject.bodyChunks[0].pos = pos;
             switch (apo.realizedObject)
             {

--- a/Online/RPCs.cs
+++ b/Online/RPCs.cs
@@ -37,7 +37,7 @@ namespace RainMeadow
         public static void Weapon_CreatureDeflect(OnlinePhysicalObject onlineWeapon, RealizedWeaponState realizedWeaponState, bool artificerParry, bool isSilent)
         {
             if (onlineWeapon.IsLocked("parry")) return;
-            
+
             try
             {
                 if (onlineWeapon.apo.realizedObject is Weapon weapon)
@@ -50,7 +50,7 @@ namespace RainMeadow
                     realizedWeaponState.ReadTo(onlineWeapon);  // actually, let everyone enjoy the spectacle.
                     if (!isSilent)
                     {
-                        if (artificerParry) 
+                        if (artificerParry)
                         {
                             RainMeadow.PlayArtiParryCustomSound(weapon);
                         }
@@ -70,15 +70,15 @@ namespace RainMeadow
 
         [RPCMethod]
         public static void Weapon_HitAnotherThrownWeapon(RPCEvent rpc,
-            OnlinePhysicalObject onlineWeapon1, OnlinePhysicalObject onlineWeapon2, 
-            RealizedWeaponState realizedWeaponState1, RealizedWeaponState realizedWeaponState2, 
+            OnlinePhysicalObject onlineWeapon1, OnlinePhysicalObject onlineWeapon2,
+            RealizedWeaponState realizedWeaponState1, RealizedWeaponState realizedWeaponState2,
             Vector2 weapon1LastPos, Vector2 weapon2LastPos, // To get the right sound/visual effect
             UnityEngine.Random.State rng)
         {
             if (onlineWeapon1.IsLocked("parry") || onlineWeapon2.IsLocked("parry")) return;
             if (rpc.from != onlineWeapon1.owner && rpc.from != onlineWeapon2.owner) throw new InvalidOperationException("Not owner of either weapon");
             var state = UnityEngine.Random.state;
-            
+
             try
             {
                 UnityEngine.Random.state = rng;
@@ -86,7 +86,7 @@ namespace RainMeadow
                 {
                     realizedWeaponState1.ReadTo(onlineWeapon1);
                     weapon1.firstChunk.lastPos = weapon1LastPos;
-                    
+
                     realizedWeaponState2.ReadTo(onlineWeapon2);
                     weapon2.firstChunk.lastPos = weapon2LastPos;
 
@@ -171,9 +171,11 @@ namespace RainMeadow
         }
 
         [RPCMethod]
-        public static void ExitToGameModeMenu()
+        public static void ExitToGameModeMenu(RPCEvent rpc)
         {
-            if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.manager.upcomingProcess is null)) return;
+            if (rpc.from != OnlineManager.lobby?.owner
+                || !(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game
+                    && game.manager.upcomingProcess is null)) return;
 
             game.manager.RequestMainProcessSwitch(OnlineManager.lobby.gameMode.MenuProcessId());
         }


### PR DESCRIPTION
A certain XuanZeBuFeng notified us on some security issues in our RPCs, so I fixed them the best I could.

- Added owner check to RPC.ExitToGameModeMenu
- Added owner check (room or object) to OnlinePhysicalObject.Explode

Was able to explode as Arti and exit to arena menu in local testing