### PR TITLE
hotfix : Fixed Den not opening when someone left (1.15.1)

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -187,7 +187,7 @@ namespace RainMeadow
                 this.VoidSpawnGraphics_EffectShader_ChangeToColoredShader
             );
             On.VoidSpawnGraphics.UpdateGlowSpriteColor += VoidSpawnGraphics_UpdateGlowSpriteColor_ColorTheAmoeba;
-            
+
             IL.PlayerGraphics.RippleTrailUpdate += PlayerGraphics_RippleTrailUpdate_DisableTrailInArenaMode;
             IL.RippleCreatureTracker.RippleCreatureSprite.DrawSprites += RippleCreatureSprite_DrawSprites_ShowWatchersInRippleSpace;
             On.Room.Loaded += Room_Loaded_AddRippleCreatureTracker;
@@ -217,11 +217,11 @@ namespace RainMeadow
                 {
                     // Don't trigger the bump till everyone is ready
                     cursor.Emit(OpCodes.Ldarg_0);
-                    cursor.EmitDelegate((ArenaBehaviors.StartBump startBump) => 
+                    cursor.EmitDelegate((ArenaBehaviors.StartBump startBump) =>
                         {
-                            bool isArenaOnlineWaitingForPlayers = isArenaMode(out var arenaOnline) 
+                            bool isArenaOnlineWaitingForPlayers = isArenaMode(out var arenaOnline)
                                 && arenaOnline.externalArenaGameMode.HoldFireWhileTimerIsActive(arenaOnline)
-                                && (arenaOnline.arenaPrepTimer is null 
+                                && (arenaOnline.arenaPrepTimer is null
                                     || arenaOnline.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting);
                             if (isArenaOnlineWaitingForPlayers)
                             {
@@ -257,7 +257,7 @@ namespace RainMeadow
         }
         private void RainWorldGame_Update_ShortcutWaitForAllPlayers(On.RainWorldGame.orig_Update orig, RainWorldGame self)
         {
-            if (isArenaMode(out var arena) 
+            if (isArenaMode(out var arena)
                 && arena.externalArenaGameMode.HoldFireWhileTimerIsActive(arena)
                 && (arena.arenaPrepTimer is null || arena.arenaPrepTimer.showMode == ArenaPrepTimer.TimerMode.Waiting))
             {
@@ -287,7 +287,7 @@ namespace RainMeadow
                 // stun creatures from the summoned Amoeba
                 for (int i = 0; i < self.room.voidSpawns.Count; i++)
                 {
-                    if (self.room.voidSpawns[i].variant == VoidSpawn.SpawnType.RippleAmoeba 
+                    if (self.room.voidSpawns[i].variant == VoidSpawn.SpawnType.RippleAmoeba
                         && Vector2.Distance(self.mainBodyChunk.pos, self.room.voidSpawns[i].firstChunk.pos) <= AmoebaSummonBehavior.stunDistance
                         && self.room.voidSpawns[i].abstractPhysicalObject.rippleLayer == self.abstractCreature.rippleLayer)
                     {
@@ -302,8 +302,8 @@ namespace RainMeadow
             try
             {
                 ILCursor cursor = new(il);
-                
-                while (cursor.TryGotoNext(MoveType.After, 
+
+                while (cursor.TryGotoNext(MoveType.After,
                     x => x.MatchCall(typeof(Player).GetProperty(nameof(Player.rippleLevel)).GetGetMethod())))
                 {
                     // Set the level artificially to 0.5 when in arena, no matter the real level... unless it's max ripple.
@@ -326,7 +326,7 @@ namespace RainMeadow
                 ILCursor cursor = new(il);
                 ILLabel label = cursor.DefineLabel();
 
-                if (cursor.TryGotoNext(MoveType.After, 
+                if (cursor.TryGotoNext(MoveType.After,
                     x => x.MatchLdarg(0),
                     x => x.MatchCall(typeof(Player).GetProperty(nameof(Player.rippleLevel)).GetGetMethod()),
                     x => x.MatchLdcR4(4),
@@ -366,7 +366,7 @@ namespace RainMeadow
 
                     VoidSpawn spawn = self.room.voidSpawns[i];
                     if (!self.room.game.GetArenaGameSession.arenaSitting.gameTypeSetup.spearsHitPlayers
-                            || (TeamBattleMode.IsTeamBattleMode(out _) 
+                            || (TeamBattleMode.IsTeamBattleMode(out _)
                                 && ArenaHelpers.CheckSameTeam(self.abstractCreature.GetOnlineCreature()?.owner, spawn.abstractPhysicalObject.GetOnlineObject()?.owner)
                                 && !arena.friendlyFire))
                         return false; // don't attack friendlies !
@@ -387,7 +387,7 @@ namespace RainMeadow
                 if (cursor.TryGotoNext(MoveType.Before,
                         x => x.MatchLdloc(0),
                         x => x.MatchBrtrue(out _))
-                    && cursor.TryGotoNext(MoveType.Before, 
+                    && cursor.TryGotoNext(MoveType.Before,
                         x => x.MatchBr(out skipDeathEffect))
                 )
                 {
@@ -463,7 +463,7 @@ namespace RainMeadow
                 ILCursor cursor = new(il);
                 ILLabel label = cursor.DefineLabel();
 
-                if (cursor.TryGotoNext(MoveType.After, 
+                if (cursor.TryGotoNext(MoveType.After,
                     x => x.MatchCallvirt(typeof(RainWorldGame).GetProperty(nameof(RainWorldGame.ActiveRippleLayer)).GetGetMethod()),
                     x => x.MatchLdcI4(1),
                     x => x.MatchBeq(out label)
@@ -499,7 +499,7 @@ namespace RainMeadow
             try
             {
                 var cursor = new ILCursor(il);
-                    
+
                 if (cursor.TryGotoNext(MoveType.After, x => x.MatchLdfld<AbstractPhysicalObject>(nameof(AbstractPhysicalObject.rippleBothSides))))
                 {
                     cursor.Emit(OpCodes.Ldarg_0);
@@ -512,7 +512,7 @@ namespace RainMeadow
                             && self.creature?.realizedCreature is Player
                             && self.creature.rippleLayer != 0)
                         {
-                            return true; 
+                            return true;
                         }
                         return orig;
                     });
@@ -560,7 +560,7 @@ namespace RainMeadow
                     cursor.EmitDelegate((bool orig, PlayerGraphics self) =>
                     {
                         // If it's Meadow Arena mode, also disable trail
-                        return orig || RainMeadow.isArenaMode(out _); 
+                        return orig || RainMeadow.isArenaMode(out _);
                     });
                 }
                 else
@@ -985,7 +985,7 @@ namespace RainMeadow
             bool slowDownCharge = false;
             foreach (VoidSpawn voidSpawn in self.room.voidSpawns)
             {
-                if (!voidSpawn.IsLocal() || !self.IsLocal()) 
+                if (!voidSpawn.IsLocal() || !self.IsLocal())
                     continue;
                 if (voidSpawn.behavior != null) //player actually created it
                     slowDownCharge = true;
@@ -1036,7 +1036,7 @@ namespace RainMeadow
                 self.FailToSpawnWarpPoint(Player.BlackListReason.HideReasoning);
                 return;
             }
-                
+
             var room = self.room;
 
             RainMeadow.sSpawningNonTransferable = true;
@@ -1294,7 +1294,7 @@ namespace RainMeadow
                 && ArenaHelpers.GetArenaClientSettings(oe!.owner)?.weaverTail == true
             )
                 self.player.watcherMorph = 0.51f;
-            
+
             orig(self, sLeaser, rCam, timeStacker, camPos);
 
             if (isArenaMode(out var arena)
@@ -1307,15 +1307,15 @@ namespace RainMeadow
                 int otherRippleLayer = self.player.abstractCreature.rippleLayer;
                 bool isMeWatcher = ModManager.Watcher && arena.avatarSettings.playingAs == Watcher.WatcherEnums.SlugcatStatsName.Watcher;
                 bool isSameRippleLevel = meRippleLayer == otherRippleLayer;
-                float rippleSpaceAlpha = meRippleLayer == 0 
+                float rippleSpaceAlpha = meRippleLayer == 0
                     ? (isMeWatcher && !arena.fullInvisInRippleSpace
-                        ? 1f - self.player.camoProgress * 0.25f 
+                        ? 1f - self.player.camoProgress * 0.25f
                         : 1f - self.player.camoProgress)
                     : (isMeWatcher && !arena.fullInvisInRippleSpace
                         ? 1f
                         : self.player.camoProgress); // Show other Watchers if you are yourself in camo
                 float handAlpha = isSameRippleLevel ? rippleSpaceAlpha : 0;
-                
+
                 sLeaser.sprites[7].alpha = handAlpha; // hand 1
                 sLeaser.sprites[8].alpha = handAlpha; // hand 2
                 sLeaser.sprites[9].alpha = rippleSpaceAlpha; // eyes
@@ -2365,31 +2365,35 @@ namespace RainMeadow
                 int num = 0;
                 for (int i = 0; i < self.Players.Count; i++)
                 {
-                    bool flag = true;
+                    bool countPlayers = true;
+
                     if (!self.Players[i].state.alive)
                     {
-                        flag = false;
+                        countPlayers = false;
+                    }
+                    if (countPlayers
+                        && self.Players[i].GetOnlineCreature()?.owner is null)
+                    {
+                        countPlayers = false;
                     }
 
-                    if (
-                        flag
+                    if (countPlayers
                         && self.exitManager != null
                         && self.exitManager.IsPlayerInDen(self.Players[i])
                     )
                     {
-                        flag = false;
+                        countPlayers = false;
                     }
 
-                    if (
-                        flag
+                    if (countPlayers
                         && self.Players[i].realizedCreature != null
-                        && (self.Players[i].realizedCreature as Player).dangerGrasp != null
+                        && (self.Players[i].realizedCreature as Player)!.dangerGrasp != null
                     )
                     {
-                        flag = false;
+                        countPlayers = false;
                     }
 
-                    if (flag)
+                    if (countPlayers)
                     {
                         for (int j = 0; j < self.arenaSitting.players.Count; j++)
                         {
@@ -2398,7 +2402,7 @@ namespace RainMeadow
                                 && self.arenaSitting.players[j].hasEnteredGameArea
                             )
                             {
-                                flag = false;
+                                countPlayers = false;
                             }
 
                             if (
@@ -2406,14 +2410,14 @@ namespace RainMeadow
                                 && self.arenaSitting.players[j].sandboxWin < 0
                             )
                             {
-                                flag = false;
+                                countPlayers = false;
                             }
 
                             break;
                         }
                     }
 
-                    if (flag)
+                    if (countPlayers)
                     {
                         num++;
                     }

--- a/Arena/ArenaOnlineGameModes/Competitive.cs
+++ b/Arena/ArenaOnlineGameModes/Competitive.cs
@@ -55,7 +55,7 @@ namespace RainMeadow
                     player.realizedCreature != null && (player.realizedCreature.State.alive)
                 ) ?? 0;
 
-            if (playersStillStanding == 1 && arenaOnline.arenaSittingOnlineOrder.Count > 1 && !arenaOnline.countdownInitiatedHoldFire)
+            if (playersStillStanding == 1 && arenaOnline.arenaSittingOnlineOrder.Count >= 1 && !arenaOnline.countdownInitiatedHoldFire)
             {
                 return true;
             }

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
@@ -110,7 +110,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
 
             if (
                 playersStillStanding == 1
-                && arenaOnline.arenaSittingOnlineOrder.Count > 1
+                && arenaOnline.arenaSittingOnlineOrder.Count >= 1
                 && !arenaOnline.countdownInitiatedHoldFire
             )
             {
@@ -727,7 +727,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
             )
             {
                 if (player.isMe // Custom color only for me in team battles
-                    && OnlineManager.lobby.clientSettings.TryGetValue(player, out var cs) 
+                    && OnlineManager.lobby.clientSettings.TryGetValue(player, out var cs)
                     && cs.chatUsernameColor is Color color)
                 {
                     return color;

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -270,6 +270,9 @@ namespace RainMeadow
                 {
                     arena.arenaSittingOnlineOrder.Remove(earlyQuitterOrLatecomer.inLobbyId); // you'll add them in NextLevel
                 }
+                int removedPlayers = arena.ArenaSession?.Players?.RemoveAll(
+                    x => x.GetOnlineCreature()?.owner == earlyQuitterOrLatecomer) ?? 0;
+                RainMeadow.Debug($"Removed {removedPlayers} players from {earlyQuitterOrLatecomer}");
             }
         }
 
@@ -425,8 +428,8 @@ namespace RainMeadow
             if (RainMeadow.isArenaMode(out var arena))
             {
                 arena.setupTime = setupTime;
-                // I don't think this is used so I'm not sure if the param here is 
-                // retrieved from host's meadow remix settings or host's actual 
+                // I don't think this is used so I'm not sure if the param here is
+                // retrieved from host's meadow remix settings or host's actual
                 // Player.maxGodTime. I'll leave it be but if this is causing issues
                 // just slap on a * 40 or / 40
                 arena.arenaSaintAscendanceTimer = saintMaxTime;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## General
 - Removed nightcat's stylish hat in SlugIcon (now uses watcher sprites)
 
+## Arena
+- Fixed Den not opening when someone left
+
 # Release 1.15.0
 
 ## Engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Removed nightcat's stylish hat in SlugIcon (now uses watcher sprites)
 
 ## Arena
-- Fixed Den not opening when someone left
+- Fixed dens not opening when someone left
 
 # Release 1.15.0
 


### PR DESCRIPTION
unsure why that bug is back, but I basically :

- Removed the realized Player in the ArenaGameSession.Players list when leaving
- Stop counting players with no owners as active
- Opened den in Competitive and TeamBattle when there's 1 player and the countdown is over

Tested in local (3 players) and everything seems to work fine