### PR TITLE
hotfix : Sent the quit RPC to everyone and not just the host (1.15.1)

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -2371,7 +2371,7 @@ namespace RainMeadow
         {
             if (isArenaMode(out var arenaOnline))
             {
-                return arenaOnline.externalArenaGameMode.GetPlayerStillActive(self, false).Count;
+                return arenaOnline.externalArenaGameMode.GetActivePlayerACs(arenaOnline, self).Count;
             }
             else
             {

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -2221,32 +2221,35 @@ namespace RainMeadow
                     {
                         return;
                     }
-                    if (OnlineManager.lobby.isOwner)
+
+                    for (int i = 0; i < arena.arenaSittingOnlineOrder.Count; i++)
                     {
-                        for (int i = 0; i < arena.arenaSittingOnlineOrder.Count; i++)
+                        OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByLobbyId(
+                            arena.arenaSittingOnlineOrder[i]
+                        );
+
+                        if (onlinePlayer != null && !onlinePlayer.isMe)
                         {
-                            OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByLobbyId(
-                                arena.arenaSittingOnlineOrder[i]
-                            );
-                            if (onlinePlayer != null && !onlinePlayer.isMe)
+                            if (OnlineManager.lobby.isOwner)
                             {
                                 onlinePlayer.InvokeOnceRPC(ArenaRPCs.Arena_EndSessionEarly);
                             }
+                            else
+                            {
+                                onlinePlayer.InvokeOnceRPC(
+                                    ArenaRPCs.Arena_RemovePlayerWhoQuit,
+                                    OnlineManager.mePlayer
+                                );
+                            }
                         }
-                        self.manager.RequestMainProcessSwitch(
-                            ProcessManager.ProcessID.MultiplayerResults
-                        );
                     }
-                    arena.returnToLobby = true;
 
-                    if (!OnlineManager.lobby.isOwner)
-                    {
-                        arena.clientWantsToLeaveGame = true;
-                        OnlineManager.lobby.owner.InvokeOnceRPC(
-                            ArenaRPCs.Arena_RemovePlayerWhoQuit,
-                            OnlineManager.mePlayer
-                        );
-                    }
+                    self.manager.RequestMainProcessSwitch(
+                        ProcessManager.ProcessID.MultiplayerResults
+                    );
+
+                    arena.returnToLobby = true;
+                    if (!OnlineManager.lobby.isOwner) arena.clientWantsToLeaveGame = true;
                 }
             }
             orig(self, sender, message);

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -2369,70 +2369,9 @@ namespace RainMeadow
             bool dontCountSandboxLosers
         )
         {
-            if (isArenaMode(out var arena))
+            if (isArenaMode(out var arenaOnline))
             {
-                int num = 0;
-                for (int i = 0; i < self.Players.Count; i++)
-                {
-                    bool countPlayers = true;
-
-                    if (!self.Players[i].state.alive)
-                    {
-                        countPlayers = false;
-                    }
-                    if (countPlayers
-                        && self.Players[i].GetOnlineCreature()?.owner is null)
-                    {
-                        countPlayers = false;
-                    }
-
-                    if (countPlayers
-                        && self.exitManager != null
-                        && self.exitManager.IsPlayerInDen(self.Players[i])
-                    )
-                    {
-                        countPlayers = false;
-                    }
-
-                    if (countPlayers
-                        && self.Players[i].realizedCreature != null
-                        && (self.Players[i].realizedCreature as Player)!.dangerGrasp != null
-                    )
-                    {
-                        countPlayers = false;
-                    }
-
-                    if (countPlayers)
-                    {
-                        for (int j = 0; j < self.arenaSitting.players.Count; j++)
-                        {
-                            if (
-                                self.Players[i].Room == self.game.world.offScreenDen
-                                && self.arenaSitting.players[j].hasEnteredGameArea
-                            )
-                            {
-                                countPlayers = false;
-                            }
-
-                            if (
-                                dontCountSandboxLosers
-                                && self.arenaSitting.players[j].sandboxWin < 0
-                            )
-                            {
-                                countPlayers = false;
-                            }
-
-                            break;
-                        }
-                    }
-
-                    if (countPlayers)
-                    {
-                        num++;
-                    }
-                }
-
-                return num;
+                return arenaOnline.externalArenaGameMode.GetPlayerStillActive(self, false).Count;
             }
             else
             {

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -2244,12 +2244,18 @@ namespace RainMeadow
                         }
                     }
 
-                    self.manager.RequestMainProcessSwitch(
-                        ProcessManager.ProcessID.MultiplayerResults
-                    );
+                    if (OnlineManager.lobby.isOwner)
+                    {
+                        self.manager.RequestMainProcessSwitch(
+                            ProcessManager.ProcessID.MultiplayerResults
+                        );
+                    }
+                    else
+                    {
+                        arena.clientWantsToLeaveGame = true;
+                    }
 
                     arena.returnToLobby = true;
-                    if (!OnlineManager.lobby.isOwner) arena.clientWantsToLeaveGame = true;
                 }
             }
             orig(self, sender, message);

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -817,21 +817,19 @@ namespace RainMeadow
             //{
             //a.SpawnSnails(shortCutVessel.room.realizedRoom, shortCutVessel);
             //}
-            if (abstractCreature.realizedCreature is not Player)
+            if (abstractCreature.realizedCreature is not Player player)
             {
                 return;
             }
-            if (
-                (abstractCreature.realizedCreature as Player).SlugCatClass
+            if (player.SlugCatClass
                 == SlugcatStats.Name.Night
             )
             {
-                (abstractCreature.realizedCreature as Player).slugcatStats.throwingSkill = 1;
+                player.slugcatStats.throwingSkill = 1;
             }
             if (ModManager.MSC)
             {
-                if (
-                    (abstractCreature.realizedCreature as Player).SlugCatClass
+                if (player.SlugCatClass
                     == SlugcatStats.Name.Red
                 )
                 {
@@ -849,8 +847,7 @@ namespace RainMeadow
                     );
                 }
 
-                if (
-                    (abstractCreature.realizedCreature as Player).SlugCatClass
+                if (player.SlugCatClass
                     == SlugcatStats.Name.Yellow
                 )
                 {
@@ -868,8 +865,7 @@ namespace RainMeadow
                     );
                 }
 
-                if (
-                    (abstractCreature.realizedCreature as Player).SlugCatClass
+                if (player.SlugCatClass
                     == MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Artificer
                 )
                 {
@@ -887,29 +883,27 @@ namespace RainMeadow
                     );
                 }
 
-                if (
-                    (abstractCreature.realizedCreature as Player).SlugCatClass
+                if (player.SlugCatClass
                     == MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Slugpup
                 )
                 {
-                    (abstractCreature.realizedCreature as Player).slugcatStats.throwingSkill = 1;
+                    player.slugcatStats.throwingSkill = 1;
                 }
 
-                if (
-                    (abstractCreature.realizedCreature as Player).SlugCatClass
+                if (player.SlugCatClass
                     == MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel
                 )
                 {
-                    (abstractCreature.realizedCreature as Player).slugcatStats.throwingSkill =
+                    player.slugcatStats.throwingSkill =
                         arenaOnline.painCatThrowingSkill;
                     RainMeadow.Debug(
                         "ENOT THROWING SKILL "
-                            + (abstractCreature.realizedCreature as Player)
+                            + player
                                 .slugcatStats
                                 .throwingSkill
                     );
                     if (
-                        (abstractCreature.realizedCreature as Player).slugcatStats.throwingSkill
+                        player.slugcatStats.throwingSkill
                             == 0
                         && arenaOnline.painCatEgg
                     )
@@ -954,37 +948,35 @@ namespace RainMeadow
                     }
                 }
 
-                if (
-                    (abstractCreature.realizedCreature as Player).SlugCatClass
+                if (player.SlugCatClass
                     == MoreSlugcats.MoreSlugcatsEnums.SlugcatStatsName.Saint
                 )
                 {
                     if (!arenaOnline.sainot) // ascendance saint
                     {
-                        (abstractCreature.realizedCreature as Player).slugcatStats.throwingSkill =
+                        player.slugcatStats.throwingSkill =
                             0;
                     }
                     else
                     {
-                        (abstractCreature.realizedCreature as Player).slugcatStats.throwingSkill =
+                        player.slugcatStats.throwingSkill =
                             1;
                     }
                 }
             }
 
-            if (
-                ModManager.Watcher
-                && (abstractCreature.realizedCreature as Player).SlugCatClass
+            if (ModManager.Watcher
+                && player.SlugCatClass
                     == Watcher.WatcherEnums.SlugcatStatsName.Watcher
             )
             {
-                if ((abstractCreature.realizedCreature as Player).rippleLevel >= 3f)
+                if (player.rippleLevel >= 3f)
                 {
-                    (abstractCreature.realizedCreature as Player).enterIntoCamoDuration = 80;
+                    player.enterIntoCamoDuration = 80;
                 }
                 else
                 {
-                    (abstractCreature.realizedCreature as Player).enterIntoCamoDuration = 40;
+                    player.enterIntoCamoDuration = 40;
                 }
             }
         }
@@ -1245,7 +1237,7 @@ namespace RainMeadow
                 .Select(player => ArenaHelpers.GetArenaClientSettings(player)) // Get settings
                 .Where(settings => settings != null) // Ensure settings exist
                 .Count(settings =>
-                    settings.playingAs == RainMeadow.Ext_SlugcatStatsName.OnlineOverseerSpectator
+                    settings!.playingAs == RainMeadow.Ext_SlugcatStatsName.OnlineOverseerSpectator
                 );
             if (
                 self.Players.Count + activePlayerCountWithOverseers
@@ -1572,6 +1564,74 @@ namespace RainMeadow
                 return a.deaths > b.deaths;
 
             return a.allKills.Count > b.allKills.Count;
+        }
+
+        public virtual List<AbstractCreature> GetPlayerStillActive(
+            ArenaGameSession self,
+            bool dontCountSandboxLosers = false
+        )
+        {
+            List<AbstractCreature> activePlayers = [];
+
+            for (int i = 0; i < self.Players.Count; i++)
+            {
+                bool countPlayerAsActive = true;
+
+                if (!self.Players[i].state.alive)
+                {
+                    countPlayerAsActive = false;
+                }
+                else if (self.Players[i].GetOnlineCreature()?.owner is null)
+                {
+                    countPlayerAsActive = false;
+                }
+
+                else if (self.exitManager != null
+                    && self.exitManager.IsPlayerInDen(self.Players[i])
+                )
+                {
+                    countPlayerAsActive = false;
+                }
+
+                else if (self.Players[i].realizedCreature != null
+                    && (self.Players[i].realizedCreature as Player)!.dangerGrasp != null
+                )
+                {
+                    countPlayerAsActive = false;
+                }
+
+                else
+                {
+                    for (int j = 0; j < self.arenaSitting.players.Count; j++)
+                    {
+                        if ((self.Players[i].state as PlayerState)!.playerNumber == self.arenaSitting.players[j].playerNumber)
+                        {
+                            if (self.Players[i].Room == self.game.world.offScreenDen
+                                && self.arenaSitting.players[j].hasEnteredGameArea
+                            )
+                            {
+                                countPlayerAsActive = false;
+                            }
+
+                            if (dontCountSandboxLosers
+                                && self.arenaSitting.players[j].sandboxWin < 0
+                            )
+                            {
+                                countPlayerAsActive = false;
+                            }
+
+                            break;
+                        }
+                    }
+                }
+
+                if (countPlayerAsActive)
+                {
+                    activePlayers.Add(self.Players[i]);
+                }
+            }
+
+            return activePlayers;
         }
 
         /// <remarks>

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1581,22 +1581,24 @@ namespace RainMeadow
 
                 if (!playerAC.state.alive
                     || arenaSession.exitManager?.IsPlayerInDen(playerAC) == true
-                    || ((Player)playerAC.realizedCreature)?.dangerGrasp is not null)
+                    || ((Player?)playerAC.realizedCreature)?.dangerGrasp is not null)
                 {
                     continue;
                 }
 
-                ArenaSitting.ArenaPlayer arenaPlayer = ArenaHelpers.FindArenaPlayerByOnlinePlayer(
+                ArenaSitting.ArenaPlayer? arenaPlayer = ArenaHelpers.FindArenaPlayerByOnlinePlayer(
                     arenaOnline,
                     arenaSession.arenaSitting,
                     onlinePlayer
-                )!;
+                );
 
-                if (playerAC.Room == arenaSession.game.world.offScreenDen
-                    && arenaPlayer.hasEnteredGameArea
-                    && !includeSandboxLosers && arenaPlayer.sandboxWin < 0)
+                if (arenaPlayer is not null)
                 {
-                    continue;
+                    if ((playerAC.Room == arenaSession.game.world.offScreenDen && arenaPlayer.hasEnteredGameArea)
+                        || (!includeSandboxLosers && arenaPlayer.sandboxWin < 0))
+                    {
+                        continue;
+                    }
                 }
 
                 activePlayers.Add(playerAC);

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1566,69 +1566,40 @@ namespace RainMeadow
             return a.allKills.Count > b.allKills.Count;
         }
 
-        public virtual List<AbstractCreature> GetPlayerStillActive(
-            ArenaGameSession self,
-            bool dontCountSandboxLosers = false
-        )
+        public virtual List<AbstractCreature> GetActivePlayerACs(
+            ArenaOnlineGameMode arenaOnline,
+            ArenaGameSession arenaSession,
+            bool includeSandboxLosers = true)
         {
             List<AbstractCreature> activePlayers = [];
 
-            for (int i = 0; i < self.Players.Count; i++)
+            foreach (AbstractCreature playerAC in arenaSession.Players)
             {
-                bool countPlayerAsActive = true;
+                OnlinePlayer? onlinePlayer = playerAC.GetOnlineCreature()?.owner;
+                if (onlinePlayer is null)
+                    continue;
 
-                if (!self.Players[i].state.alive)
+                if (!playerAC.state.alive
+                    || arenaSession.exitManager?.IsPlayerInDen(playerAC) == true
+                    || ((Player)playerAC.realizedCreature)?.dangerGrasp is not null)
                 {
-                    countPlayerAsActive = false;
-                }
-                else if (self.Players[i].GetOnlineCreature()?.owner is null)
-                {
-                    countPlayerAsActive = false;
-                }
-
-                else if (self.exitManager != null
-                    && self.exitManager.IsPlayerInDen(self.Players[i])
-                )
-                {
-                    countPlayerAsActive = false;
+                    continue;
                 }
 
-                else if (self.Players[i].realizedCreature != null
-                    && (self.Players[i].realizedCreature as Player)!.dangerGrasp != null
-                )
+                ArenaSitting.ArenaPlayer arenaPlayer = ArenaHelpers.FindArenaPlayerByOnlinePlayer(
+                    arenaOnline,
+                    arenaSession.arenaSitting,
+                    onlinePlayer
+                )!;
+
+                if (playerAC.Room == arenaSession.game.world.offScreenDen
+                    && arenaPlayer.hasEnteredGameArea
+                    && !includeSandboxLosers && arenaPlayer.sandboxWin < 0)
                 {
-                    countPlayerAsActive = false;
+                    continue;
                 }
 
-                else
-                {
-                    for (int j = 0; j < self.arenaSitting.players.Count; j++)
-                    {
-                        if ((self.Players[i].state as PlayerState)!.playerNumber == self.arenaSitting.players[j].playerNumber)
-                        {
-                            if (self.Players[i].Room == self.game.world.offScreenDen
-                                && self.arenaSitting.players[j].hasEnteredGameArea
-                            )
-                            {
-                                countPlayerAsActive = false;
-                            }
-
-                            if (dontCountSandboxLosers
-                                && self.arenaSitting.players[j].sandboxWin < 0
-                            )
-                            {
-                                countPlayerAsActive = false;
-                            }
-
-                            break;
-                        }
-                    }
-                }
-
-                if (countPlayerAsActive)
-                {
-                    activePlayers.Add(self.Players[i]);
-                }
+                activePlayers.Add(playerAC);
             }
 
             return activePlayers;

--- a/Arena/ArenaOnlineGameModes/Competitive.cs
+++ b/Arena/ArenaOnlineGameModes/Competitive.cs
@@ -50,12 +50,7 @@ namespace RainMeadow
                 return orig(self) || (self.gameSession?.arenaSitting?.players?.Any(p => p?.score >= self.gameSession.GameTypeSetup.ScoreToEnterDen) ?? false);
             }
 
-            int playersStillStanding =
-                self.gameSession.Players?.Count(player =>
-                    player.realizedCreature != null && (player.realizedCreature.State.alive)
-                ) ?? 0;
-
-            if (playersStillStanding == 1 && arenaOnline.arenaSittingOnlineOrder.Count >= 1 && !arenaOnline.countdownInitiatedHoldFire)
+            if (self.gameSession.thisFrameActivePlayers == 1 && arenaOnline.arenaSittingOnlineOrder.Count >= 1 && !arenaOnline.countdownInitiatedHoldFire)
             {
                 return true;
             }

--- a/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
+++ b/Arena/ArenaOnlineGameModes/TeamBattle/TeamBattle.cs
@@ -103,13 +103,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                 return orig(self) || (self.gameSession?.arenaSitting?.players?.Any(p => p?.score >= self.gameSession.GameTypeSetup.ScoreToEnterDen) ?? false);
             }
 
-            int playersStillStanding =
-                self.gameSession.Players?.Count(player =>
-                    player.realizedCreature != null && player.realizedCreature.State.alive
-                ) ?? 0;
-
-            if (
-                playersStillStanding == 1
+            if (self.gameSession.thisFrameActivePlayers == 1
                 && arenaOnline.arenaSittingOnlineOrder.Count >= 1
                 && !arenaOnline.countdownInitiatedHoldFire
             )
@@ -122,7 +116,7 @@ namespace RainMeadow.Arena.ArenaOnlineGameModes.TeamBattle
                 return true;
             }
 
-            if (playersStillStanding > 1 && arenaOnline.setupTime == 0)
+            if (self.gameSession.thisFrameActivePlayers > 1 && arenaOnline.setupTime == 0)
             {
                 HashSet<int> aliveTeams = new HashSet<int>();
                 if (self.gameSession.Players != null)

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -266,13 +266,14 @@ namespace RainMeadow
         {
             if (RainMeadow.isArenaMode(out var arena))
             {
-                if (arena.arenaSittingOnlineOrder.Contains(earlyQuitterOrLatecomer.inLobbyId))
+                if (arena.lobby.isOwner
+                    && arena.arenaSittingOnlineOrder.Contains(earlyQuitterOrLatecomer.inLobbyId))
                 {
                     arena.arenaSittingOnlineOrder.Remove(earlyQuitterOrLatecomer.inLobbyId); // you'll add them in NextLevel
                 }
                 int removedPlayers = arena.ArenaSession?.Players?.RemoveAll(
                     x => x.GetOnlineCreature()?.owner == earlyQuitterOrLatecomer) ?? 0;
-                RainMeadow.Debug($"Removed {removedPlayers} players from {earlyQuitterOrLatecomer}");
+                RainMeadow.Debug($"Removed {removedPlayers} players from {earlyQuitterOrLatecomer} who quitted!");
             }
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ## Arena
 - Fixed dens not opening when someone left
 
+### Modders
+- Added virtual `ExternalArenaGameMode.GetPlayerStillActive` method.
+
 # Release 1.15.0
 
 ## Engine


### PR DESCRIPTION
Changes :

- Woopsies, fixed back #1604 who was only working for the host
- Created the virtual externalArenaGameMode.GetPlayerStillActive which is used in the hook On.ArenaGameSession.PlayersStillActive (fixed some bugs about it too)
- used self.gameSession.thisFrameActivePlayers to check standing players in gamemodes (why didn't we do that before ?)
- Fixed a huge might be null warning in ExternalArenaGameMode, don't mind it.
