### PR TITLE
preserve RandomSeed across cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Release 1.16.0
+
+## Engine
+- Fixed RandomSeed not being saved across cycles (was causing e.g. slugpup colour to change)
+
 # Release 1.15.2
 
 ## Arena 

--- a/Game/RainMeadow.ItemHooks.cs
+++ b/Game/RainMeadow.ItemHooks.cs
@@ -17,6 +17,30 @@ namespace RainMeadow
             // Seedcobs are cursed
             APOFS += SeedCob_APOFS;
             IL.SeedCob.PlaceInRoom += SeedCob_PlaceInRoom;
+
+            // save and restore EntityID.altSeed
+            On.EntityID.ToString += EntityID_ToString;
+            On.EntityID.FromString += EntityID_FromString;
+        }
+
+        private string EntityID_ToString(On.EntityID.orig_ToString orig, ref EntityID self)
+        {
+            if (OnlineManager.lobby is null) return orig(ref self);
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", orig(ref self), self.altSeed);
+        }
+
+        private EntityID EntityID_FromString(On.EntityID.orig_FromString orig, string s)
+        {
+            if (OnlineManager.lobby is null) return orig(s);
+
+            var entityID = orig(s);
+            string[] array = s.Split('.');
+            if (array.Length > 3)
+            {
+                entityID.altSeed = int.Parse(array[3], NumberStyles.Any, CultureInfo.InvariantCulture);
+            }
+            return entityID;
         }
 
         private void SeedCob_PlaceInRoom(ILContext il)


### PR DESCRIPTION
by saving and restoring altSeed as part of the EntityID

this fixes e.g. slugpups spawned by clients changing colour after saving

tested by WillowWisp to also work with custom mods that make use of RandomSeed