### PR TITLE
Fix name tag positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Release 1.16.0
+
+## General
+- Improved name tag positioning
+  - Fixed name tag position being behind by an extra tick
+  - Fixed name tag being offset incorrectly when pointing at a player in a neighboring room
+  - Fixed incorrect lerping logic
+  - Fixed an edge case in positioning logic that would sometimes cause it to go closer to the edge of the screen than intended
+  - Fixed positioning logic for far away players
+  - Improved positioning for players really close to edges of the screen
+
 # Release 1.15.2
 
 ## Arena 

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -315,6 +315,11 @@ namespace RainMeadow
                 targetPoint.y >= rect.yMin &&
                 targetPoint.y <= rect.yMax) return targetPoint;
 
+            return rect.GetClosestPointOnEdgeAlongLineFromCenter(targetPoint);
+        }
+
+        public static Vector2 GetClosestPointOnEdgeAlongLineFromCenter(this Rect rect, Vector2 targetPoint)
+        {
             float halfWidth = rect.width * 0.5f;
             float halfHeight = rect.height * 0.5f;
             targetPoint -= rect.center; // from center

--- a/OnlineUIComponents/OnlinePlayerDeathBump.cs
+++ b/OnlineUIComponents/OnlinePlayerDeathBump.cs
@@ -41,9 +41,7 @@ namespace RainMeadow
 
         public void SetPosToPlayer()
         {
-            this.pos = owner.drawpos + new Vector2(0, 30f);
-            this.pos.x = Mathf.Clamp(this.pos.x, 30f, this.owner.camera.sSize.x - 30f);
-            this.pos.y = Mathf.Clamp(this.pos.y, 30f, this.owner.camera.sSize.y - 30f);
+            this.pos = owner.GetTargetDrawPos(1f)?.pos ?? new Vector2(-1000f, -1000f);
             this.lastPos = this.pos;
         }
 

--- a/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -81,8 +81,6 @@ namespace RainMeadow
                 this.lighter_color = color;
             }
 
-            this.pos = new Vector2(-1000f, -1000f);
-            this.lastPos = this.pos;
             this.gradient = new FSprite("Futile_White", true);
             owner.hud.fContainers[0].AddChild(this.gradient);
             this.gradient.shader = owner.hud.rainWorld.Shaders["FlatLight"];
@@ -185,7 +183,6 @@ namespace RainMeadow
                 if (!player.isMe && !isTeammate && (myRippleLayer != 1 || otherRippleLayer != 1))
                 {
                     show = false;
-                    pos.x = -1000f;
                     this.alpha = 0f;
                 }
             }
@@ -196,44 +193,32 @@ namespace RainMeadow
                 this.blink = 1f;
                 this.alpha = Custom.LerpAndTick(this.alpha, owner.needed && show ? 1 : 0, 0.08f, 0.033333335f);
 
-                if (owner.found)
+                if (RainMeadow.rainMeadowOptions.ShowPing.Value && !player.isMe)//
                 {
-                    if (RainMeadow.rainMeadowOptions.ShowPing.Value && !player.isMe)//
-                    {
-                        this.pingLabel.alpha = Custom.LerpAndTick(this.alpha, owner.needed && show ? 1 : 0, 0.08f, 0.033333335f);
-                    }
-
-                    this.pos = owner.drawpos;
-                    if (owner.pointDir == Vector2.down) pos += new Vector2(0f, 45f);
-
-                    if (this.lastAlpha == 0) this.lastPos = pos;
-
-                    if (owner.PlayerConsideredDead) this.alpha = Mathf.Min(this.alpha, 0.5f);
-
-                    if (onlineTimeSinceSpawn < 135 && owner.clientSettings.isMine)
-                    {
-                        playerIcon.DrawSlugIcon(false);
-                    }
-                    else if (RainMeadow.isArenaMode(out var arena))
-                    {
-                        string arenaIcon = arena.externalArenaGameMode.AddIcon(arena, this, owner, customization, player);
-                        if (arenaIcon != "") playerIcon.DrawSingleElement(arenaIcon);
-                        else playerIcon.DrawSlugIcon(owner.PlayerConsideredDead);
-                        playerIcon.icon.color = arena.externalArenaGameMode.IconColor(arena, this, owner, customization, player);
-                    }
-                    else if (owner.PlayerInAncientShelter) playerIcon.DrawSingleElement("ShortcutAShelter");
-                    else if (owner.PlayerInShelter) playerIcon.DrawSingleElement("ShortcutShelter");
-                    else if (owner.PlayerInGate) playerIcon.DrawSingleElement("ShortcutGate");
-                    else if (iconString is null) playerIcon.DrawSlugIcon(owner.PlayerConsideredDead);
-                    else playerIcon.DrawSingleElement(iconString);
-
-                    if (flashIcons) this.alpha = Mathf.Lerp(lighter_color.a, 0f, (Mathf.Cos(owner.owner.hudCounter / fadeSpeed) + 1f) / 2f);
-                    else if (RainMeadow.rainMeadowOptions.ShowFriends.Value) this.alpha = lighter_color.a;
+                    this.pingLabel.alpha = Custom.LerpAndTick(this.alpha, owner.needed && show ? 1 : 0, 0.08f, 0.033333335f);
                 }
-                else
+
+                if (owner.PlayerConsideredDead) this.alpha = Mathf.Min(this.alpha, 0.5f);
+
+                if (onlineTimeSinceSpawn < 135 && owner.clientSettings.isMine)
                 {
-                    pos.x = -1000f;
+                    playerIcon.DrawSlugIcon(false);
                 }
+                else if (RainMeadow.isArenaMode(out var arena))
+                {
+                    string arenaIcon = arena.externalArenaGameMode.AddIcon(arena, this, owner, customization, player);
+                    if (arenaIcon != "") playerIcon.DrawSingleElement(arenaIcon);
+                    else playerIcon.DrawSlugIcon(owner.PlayerConsideredDead);
+                    playerIcon.icon.color = arena.externalArenaGameMode.IconColor(arena, this, owner, customization, player);
+                }
+                else if (owner.PlayerInAncientShelter) playerIcon.DrawSingleElement("ShortcutAShelter");
+                else if (owner.PlayerInShelter) playerIcon.DrawSingleElement("ShortcutShelter");
+                else if (owner.PlayerInGate) playerIcon.DrawSingleElement("ShortcutGate");
+                else if (iconString is null) playerIcon.DrawSlugIcon(owner.PlayerConsideredDead);
+                else playerIcon.DrawSingleElement(iconString);
+
+                if (flashIcons) this.alpha = Mathf.Lerp(lighter_color.a, 0f, (Mathf.Cos(owner.owner.hudCounter / fadeSpeed) + 1f) / 2f);
+                else if (RainMeadow.rainMeadowOptions.ShowFriends.Value) this.alpha = lighter_color.a;
 
                 this.counter++;
             }
@@ -254,14 +239,20 @@ namespace RainMeadow
 
         public override void Draw(float timeStacker)
         {
-            Vector2 vector = Vector2.Lerp(this.lastPos, this.pos, timeStacker) + new Vector2(0.01f, 0.01f);
-            var pos = vector;
+            (Vector2 pos, Vector2 dir)? drawPos = owner.GetTargetDrawPos(timeStacker);
+            if (!drawPos.HasValue)
+            {
+                alpha = 0f;
+                lastAlpha = 0f;
+                drawPos = (new Vector2(-1000f, -1000f), Vector2.zero);
+            }
+            var pos = drawPos.Value.pos + new Vector2(0.01f, 0.01f);
             float num = Mathf.Pow(Mathf.Max(0f, Mathf.Lerp(this.lastAlpha, this.alpha, timeStacker)), 0.7f);
             this.pingLabel.text = $"({realPing}ms)";
 
             this.arrowSprite.x = pos.x;
             this.arrowSprite.y = pos.y;
-            this.arrowSprite.rotation = RWCustom.Custom.VecToDeg(owner.pointDir * -1);
+            this.arrowSprite.rotation = RWCustom.Custom.VecToDeg(drawPos.Value.dir * -1);
 
             this.gradient.x = pos.x;
             this.gradient.y = pos.y + 10f;

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -206,30 +206,17 @@ namespace RainMeadow
             {
                 Vector2? pos = null;
 
-                if (abstractPlayer.realizedCreature is Player player)
+                Player? player = (Player?)abstractPlayer.realizedCreature;
+                if (player is not null && (isTargetInSameRoom || DoesPlayerPosMatchPlayerACPos(player)))
                 {
-                    if (player.inShortcut
-                        && player.inShortcutVessel is not null
-                        && player.inShortcutVessel.pos != outsideArenaDenPos // avoiding that 0,0 shortcut
-                        && player.room is null && player.inShortcutVessel.room.index == abstractPlayer.pos.room)
+                    if (player is { inShortcut: true, inShortcutVessel: not null }
+                        && player.inShortcutVessel.pos != outsideArenaDenPos) // avoiding that 0,0 shortcut
                     {
                         pos = _targetRoomWorldPosInPixels + camera.room.MiddleOfTile(player.inShortcutVessel.pos);
                     }
-                    else if (abstractPlayer.pos.TileDefined
-                        && player.room is not null && player.room.abstractRoom.index == abstractPlayer.pos.room)
-                    {
-                        // realizedCreature of a remote player can sometimes not be null when its actually not realized
-                        // so no new state for it is being sent, while new state for the abstractPlayer is always sent
-                        // so until this is fixed somewhere else in rain meadow,
-                        // we just check if the realized player's tile position matches what it should be
-                        const float tolerance = 20f; // up to one tile in each direction
-                        Vector2 expectedPos = player.room.MiddleOfTile(abstractPlayer.pos);
-                        Vector2 posDiff = expectedPos - GetPlayerTileReferencePos(player);
-                        if (Math.Abs(posDiff.x) <= tolerance && Math.Abs(posDiff.y) <= tolerance)
-                        {
-                            BodyChunk[] chunks = player.bodyChunks;
-                            pos = _targetRoomWorldPosInPixels + Vector2.Lerp(chunks[0].pos, chunks[1].pos, 1f / 3f);
-                        }
+                    else {
+                        BodyChunk[] chunks = player.bodyChunks;
+                        pos = _targetRoomWorldPosInPixels + Vector2.Lerp(chunks[0].pos, chunks[1].pos, 1f / 3f);
                     }
                 }
 
@@ -381,10 +368,33 @@ namespace RainMeadow
             }
         }
 
-        /// <summary>
-        /// The position of the player that is used to set the abstract player's tile position.
-        /// </summary>
-        private static Vector2 GetPlayerTileReferencePos(Player player)
+        private static bool DoesPlayerPosMatchPlayerACPos(Player player)
+        {
+            AbstractCreature ac = player.abstractCreature;
+
+            if (player is { inShortcut: true, inShortcutVessel: not null }
+                && player.inShortcutVessel.pos != outsideArenaDenPos)
+            {
+                return player.inShortcutVessel.room.index == ac.pos.room;
+            }
+
+            if (!ac.pos.TileDefined || player.room?.abstractRoom.index != ac.pos.room)
+                return false;
+
+            // realizedCreature of a remote player can sometimes not be null when its actually not realized
+            // so no new state for it is being sent, while new state for the abstractPlayer is always sent
+            // so until this is fixed somewhere else in rain meadow,
+            // we just check if the realized player's tile position matches what it should be
+            const float toleranceInPixels = 20f; // up to one tile in each direction
+            Vector2 posDiff = player.room.MiddleOfTile(ac.pos) - GetReferencePlayerACPosInPixels(player);
+            return Math.Abs(posDiff.x) <= toleranceInPixels && Math.Abs(posDiff.y) <= toleranceInPixels;
+        }
+
+        /// <returns>
+        /// The position of <paramref name="player"/>
+        /// that is used to set <paramref name="player"/>'s <see cref="AbstractCreature.pos"/>.
+        /// </returns>
+        private static Vector2 GetReferencePlayerACPosInPixels(Player player)
         {
             // from PhysicalObject.Update
             Vector2 pos = player.FirstChunk().pos;

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -1,4 +1,5 @@
-﻿using HUD;
+﻿using System;
+using HUD;
 using RainMeadow.Arena.Nightcat;
 using RWCustom;
 using System.Collections.Generic;
@@ -143,7 +144,7 @@ namespace RainMeadow
 
             if (camera.room == null || !camera.room.shortCutsReady) return;
             if (!clientSettings.inGame) return;
-            if (playerId.FindEntity(true) is OnlineCreature oc) // TODO: support multiple avatars
+            if (playerId.FindEntity(true) is OnlineCreature oc)
             {
                 abstractPlayer = oc.abstractCreature;
                 oc.TryGetData<SlugcatCustomization>(out customization);
@@ -209,16 +210,30 @@ namespace RainMeadow
                 {
                     if (player.inShortcut
                         && player.inShortcutVessel is not null
-                        && player.inShortcutVessel.pos != outsideArenaDenPos) // avoiding that 0,0 shortcut
+                        && player.inShortcutVessel.pos != outsideArenaDenPos // avoiding that 0,0 shortcut
+                        && player.room is null && player.inShortcutVessel.room.index == abstractPlayer.pos.room)
                     {
                         pos = _targetRoomWorldPosInPixels + camera.room.MiddleOfTile(player.inShortcutVessel.pos);
                     }
-                    else
+                    else if (abstractPlayer.pos.TileDefined
+                        && player.room is not null && player.room.abstractRoom.index == abstractPlayer.pos.room)
                     {
-                        pos = _targetRoomWorldPosInPixels + Vector2.Lerp(player.bodyChunks[0].pos, player.bodyChunks[1].pos, 1f / 3f);
+                        // realizedCreature of a remote player can sometimes not be null when its actually not realized
+                        // so no new state for it is being sent, while new state for the abstractPlayer is always sent
+                        // so until this is fixed somewhere else in rain meadow,
+                        // we just check if the realized player's tile position matches what it should be
+                        const float tolerance = 20f; // up to one tile in each direction
+                        Vector2 expectedPos = player.room.MiddleOfTile(abstractPlayer.pos);
+                        Vector2 posDiff = expectedPos - GetPlayerTileReferencePos(player);
+                        if (Math.Abs(posDiff.x) <= tolerance && Math.Abs(posDiff.y) <= tolerance)
+                        {
+                            BodyChunk[] chunks = player.bodyChunks;
+                            pos = _targetRoomWorldPosInPixels + Vector2.Lerp(chunks[0].pos, chunks[1].pos, 1f / 3f);
+                        }
                     }
                 }
-                else if (abstractPlayer.pos.TileDefined)
+
+                if (!pos.HasValue && abstractPlayer.pos.TileDefined)
                 {
                     pos = _targetRoomWorldPosInPixels + camera.room.MiddleOfTile(abstractPlayer.pos);
                 }
@@ -364,6 +379,36 @@ namespace RainMeadow
             {
                 this.parts[i].ClearSprites();
             }
+        }
+
+        /// <summary>
+        /// The position of the player that is used to set the abstract player's tile position.
+        /// </summary>
+        private static Vector2 GetPlayerTileReferencePos(Player player)
+        {
+            // from PhysicalObject.Update
+            Vector2 pos = player.FirstChunk().pos;
+
+            if (!ModManager.MSC)
+                return pos;
+
+            // from Player.Update
+            if (player.animation != Player.AnimationIndex.HangFromBeam
+                && player.animation != Player.AnimationIndex.DeepSwim)
+            {
+                pos = player.bodyChunks[1].pos;
+            }
+            else if (player.animation == Player.AnimationIndex.BeamTip
+                || player.animation == Player.AnimationIndex.StandOnBeam)
+            {
+                pos = player.bodyChunks[1].pos - new Vector2(0f, 20f);
+            }
+            else if (player.animation == Player.AnimationIndex.HangUnderVerticalBeam)
+            {
+                pos = player.bodyChunks[0].pos + new Vector2(0f, 20f);
+            }
+
+            return pos;
         }
 
         private static Vector2 GetAbstractRoomWorldPosInPixels(AbstractRoom abstractRoom)

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -40,8 +40,8 @@ namespace RainMeadow
         internal bool needed;
         private Vector2 _cameraRoomWorldPosInPixels;
         private Vector2 _targetRoomWorldPosInPixels;
-        private int _prevCameraRoomIndex = -1;
-        private int _prevTargetRoomIndex = -1;
+        private AbstractRoom? _prevCameraRoom;
+        private AbstractRoom? _prevTargetRoom;
         private static readonly IntVector2 outsideArenaDenPos = new IntVector2(-1, -1);
 
         public float DeadFade
@@ -160,21 +160,21 @@ namespace RainMeadow
                 this.parts.Add(this.playerDisplay);
             }
 
-            if (abstractPlayer.pos.room != _prevTargetRoomIndex)
+            if (abstractPlayer.Room != _prevTargetRoom)
             {
-                AbstractRoom? abstractRoom = camera.game.world.GetAbstractRoom(abstractPlayer.pos.room);
+                AbstractRoom? abstractRoom = abstractPlayer.Room;
                 if (abstractRoom is not null)
                     _targetRoomWorldPosInPixels = GetAbstractRoomWorldPosInPixels(abstractRoom);
                 _prevTargetState = null;
             }
-            _prevTargetRoomIndex = abstractPlayer.pos.room;
+            _prevTargetRoom = abstractPlayer.Room;
 
-            if (camera.room.abstractRoom.index != _prevCameraRoomIndex)
+            if (camera.room.abstractRoom != _prevCameraRoom)
             {
                 _cameraRoomWorldPosInPixels = GetAbstractRoomWorldPosInPixels(camera.room.abstractRoom);
                 _prevTargetState = null;
             }
-            _prevCameraRoomIndex = camera.room.abstractRoom.index;
+            _prevCameraRoom = camera.room.abstractRoom;
 
             bool isTargetInSameRoom = abstractPlayer.Room == camera.room.abstractRoom;
 

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -40,8 +40,8 @@ namespace RainMeadow
         internal bool needed;
         private Vector2 _cameraRoomWorldPosInPixels;
         private Vector2 _targetRoomWorldPosInPixels;
-        private int _prevCameraRoom;
-        private int _prevTargetRoom;
+        private int _prevCameraRoomIndex = -1;
+        private int _prevTargetRoomIndex = -1;
         private static readonly IntVector2 outsideArenaDenPos = new IntVector2(-1, -1);
 
         public float DeadFade
@@ -160,21 +160,21 @@ namespace RainMeadow
                 this.parts.Add(this.playerDisplay);
             }
 
-            if (abstractPlayer.pos.room != _prevTargetRoom)
+            if (abstractPlayer.pos.room != _prevTargetRoomIndex)
             {
                 AbstractRoom? abstractRoom = camera.game.world.GetAbstractRoom(abstractPlayer.pos.room);
                 if (abstractRoom is not null)
                     _targetRoomWorldPosInPixels = GetAbstractRoomWorldPosInPixels(abstractRoom);
                 _prevTargetState = null;
             }
-            _prevTargetRoom = abstractPlayer.pos.room;
+            _prevTargetRoomIndex = abstractPlayer.pos.room;
 
-            if (camera.room.abstractRoom.index != _prevCameraRoom)
+            if (camera.room.abstractRoom.index != _prevCameraRoomIndex)
             {
                 _cameraRoomWorldPosInPixels = GetAbstractRoomWorldPosInPixels(camera.room.abstractRoom);
                 _prevTargetState = null;
             }
-            _prevCameraRoom = camera.room.abstractRoom.index;
+            _prevCameraRoomIndex = camera.room.abstractRoom.index;
 
             bool isTargetInSameRoom = abstractPlayer.Room == camera.room.abstractRoom;
 

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -329,12 +329,15 @@ namespace RainMeadow
 
             bool isTargetOnScreen = positionBounds.Contains(targetPos);
 
-            Vector2 clampedPos = positionBounds.GetClosestInteriorPoint(targetPos);
-            Vector2 clampedDir = (targetPos - clampedPos).normalized;
+            Vector2 dir = isTargetOnScreen
+                ? state.Direction
+                : (targetPos - positionBounds.GetClosestInteriorPoint(targetPos)).normalized;
+
+            targetPos -= dir * state.VisibilityOffset;
 
             return (
-                pos: isTargetOnScreen ? targetPos - state.Direction * state.VisibilityOffset : clampedPos,
-                dir: isTargetOnScreen ? state.Direction * (state.InvertArrow ? -1 : 1) : clampedDir
+                pos: positionBounds.GetClosestInteriorPoint(targetPos),
+                dir: isTargetOnScreen ? dir * (state.InvertArrow ? -1 : 1) : dir
             );
         }
 

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -107,9 +107,8 @@ namespace RainMeadow
             }
         }
 
-        public override void Update()
+        private void UpdateParts()
         {
-            base.Update();
             for (int i = this.parts.Count - 1; i >= 0; i--)
             {
                 if (this.parts[i].slatedForDeletion)
@@ -136,7 +135,10 @@ namespace RainMeadow
                     this.parts[i].Update();
                 }
             }
+        }
 
+        private void UpdatePlayer()
+        {
             this.found = false;
             if (camera.room == null || !camera.room.shortCutsReady) return;
             if (!clientSettings.inGame) return;
@@ -314,6 +316,13 @@ namespace RainMeadow
             //    this.nightcatCounter = -1;
             //}
 
+        }
+
+        public override void Update()
+        {
+            base.Update();
+            UpdatePlayer();
+            UpdateParts();
         }
 
         public override void Draw(float timeStacker)

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -33,14 +33,14 @@ namespace RainMeadow
         public Player RealizedPlayer => this.abstractPlayer.realizedCreature as Player;
 
         public RoomCamera camera;
-        private Rect camrect;
         public Vector2 drawpos;
-        public bool found;
-        public Vector2 pointDir;
+        private PositionState? _targetState;
+        private PositionState? _prevTargetState;
         internal bool needed;
-        private WorldCoordinate lastWorldPos;
-        private int lastCameraPos;
-        private int lastAbstractRoom;
+        private Vector2 _cameraRoomWorldPosInPixels;
+        private Vector2 _targetRoomWorldPosInPixels;
+        private int _prevCameraRoom;
+        private int _prevTargetRoom;
         private static readonly IntVector2 outsideArenaDenPos = new IntVector2(-1, -1);
 
         public float DeadFade
@@ -64,7 +64,6 @@ namespace RainMeadow
             RainMeadow.Debug("Adding PlayerSpecificOnlineHud for " + clientSettings.owner);
             this.owner = owner;
             this.camera = camera;
-            camrect = new Rect(Vector2.zero, this.camera.sSize).CloneWithExpansion(-30f);
             this.onlineGameMode = onlineGameMode;
             this.clientSettings = clientSettings;
             this.playerId = playerId;
@@ -139,7 +138,9 @@ namespace RainMeadow
 
         private void UpdatePlayer()
         {
-            this.found = false;
+            _prevTargetState = _targetState;
+            _targetState = null;
+
             if (camera.room == null || !camera.room.shortCutsReady) return;
             if (!clientSettings.inGame) return;
             if (playerId.FindEntity(true) is OnlineCreature oc) // TODO: support multiple avatars
@@ -158,99 +159,79 @@ namespace RainMeadow
                 this.parts.Add(this.playerDisplay);
             }
 
-            Vector2 rawPos = new();
-            // in this room
-            if (abstractPlayer.Room == camera.room.abstractRoom)
+            if (abstractPlayer.pos.room != _prevTargetRoom)
             {
-                // in room or in shortcut
+                AbstractRoom? abstractRoom = camera.game.world.GetAbstractRoom(abstractPlayer.pos.room);
+                if (abstractRoom is not null)
+                    _targetRoomWorldPosInPixels = GetAbstractRoomWorldPosInPixels(abstractRoom);
+                _prevTargetState = null;
+            }
+            _prevTargetRoom = abstractPlayer.pos.room;
+
+            if (camera.room.abstractRoom.index != _prevCameraRoom)
+            {
+                _cameraRoomWorldPosInPixels = GetAbstractRoomWorldPosInPixels(camera.room.abstractRoom);
+                _prevTargetState = null;
+            }
+            _prevCameraRoom = camera.room.abstractRoom.index;
+
+            bool isTargetInSameRoom = abstractPlayer.Room == camera.room.abstractRoom;
+
+            if (!isTargetInSameRoom)
+            {
+                // try to find target in neighbor room
+                int[] connections = camera.room.abstractRoom.connections;
+                for (int i = 0; i < connections.Length; i++)
+                {
+                    if (abstractPlayer.pos.room != connections[i])
+                        continue;
+                    WorldCoordinate shortcutPos = camera.room.LocalCoordinateOfNode(i);
+                    _targetState = new PositionState(
+                        Position: _cameraRoomWorldPosInPixels + camera.room.MiddleOfTile(shortcutPos),
+                        Direction: camera.room.ShorcutEntranceHoleDirection(shortcutPos.Tile).ToVector2(),
+                        VisibilityOffset: 10f,
+                        InvertArrow: true, // Point away from the shortcut entrance
+                        PointTowardsDirection: false
+                    );
+                    break;
+                }
+            }
+            bool isTargetInNeighborRoom = _targetState.HasValue;
+
+            // in same or far room
+            if (!isTargetInNeighborRoom)
+            {
+                Vector2? pos = null;
+
                 if (abstractPlayer.realizedCreature is Player player)
                 {
                     if (player.inShortcut
                         && player.inShortcutVessel is not null
                         && player.inShortcutVessel.pos != outsideArenaDenPos) // avoiding that 0,0 shortcut
                     {
-                        found = true;
-                        rawPos = camera.room.MiddleOfTile(player.inShortcutVessel.pos) - camera.pos;
-                        this.pointDir = Vector2.down;
+                        pos = _targetRoomWorldPosInPixels + camera.room.MiddleOfTile(player.inShortcutVessel.pos);
                     }
-                    else if (player.room == camera.room)
+                    else
                     {
-                        found = true;
-                        rawPos = Vector2.Lerp(player.bodyChunks[0].pos, player.bodyChunks[1].pos, 0.33333334f) - camera.pos;
-                        this.pointDir = Vector2.down;
-                    }
-                    else // unsure if that check is still necessary
-                    {
-                        Vector2? shortcutpos = camera.game.shortcuts.OnScreenPositionOfInShortCutCreature(camera.room, player);
-                        if (shortcutpos != null)
-                        {
-                            found = true;
-                            rawPos = shortcutpos.Value - camera.pos;
-                            this.pointDir = Vector2.down;
-                        }
+                        pos = _targetRoomWorldPosInPixels + Vector2.Lerp(player.bodyChunks[0].pos, player.bodyChunks[1].pos, 1f / 3f);
                     }
                 }
-
-                if (found)
+                else if (abstractPlayer.pos.TileDefined)
                 {
-                    this.drawpos = camrect.GetClosestInteriorPoint(rawPos); // gives straight arrows
-                    if (drawpos != rawPos)
-                    {
-                        pointDir = (rawPos - drawpos).normalized;
-                    }
+                    pos = _targetRoomWorldPosInPixels + camera.room.MiddleOfTile(abstractPlayer.pos);
+                }
+
+                if (pos.HasValue)
+                {
+                    _targetState = new PositionState(
+                        Position: pos.Value,
+                        Direction: Vector2.down,
+                        VisibilityOffset: 45f,
+                        InvertArrow: false,
+                        PointTowardsDirection: !isTargetInSameRoom
+                    );
                 }
             }
-            else // different room
-            {
-                // neighbor
-                var connections = camera.room.abstractRoom.connections;
-                for (int i = 0; i < connections.Length; i++)
-                {
-                    if (abstractPlayer.pos.room == connections[i])
-                    {
-                        found = true;
-                        var shortcutpos = camera.room.LocalCoordinateOfNode(i);
-                        rawPos = camera.room.MiddleOfTile(shortcutpos) - camera.pos;
-                        pointDir = camera.room.ShorcutEntranceHoleDirection(shortcutpos.Tile).ToVector2() * -1;
-                        break;
-                    }
-                }
-                if (found)
-                {
-                    this.drawpos = camrect.GetClosestInteriorPoint(rawPos);
-                    Vector2 translation = pointDir * 10f; // Vector shift for shortcut viewability
-                    this.drawpos += translation;
-
-                    if (drawpos != rawPos)
-                    {
-                        pointDir = (rawPos - drawpos).normalized * -1; // Point away from the shortcut entrance
-                    }
-                }
-                else // elsewhere, use world pos
-                {
-                    var world = camera.game.world;
-                    if (world.GetAbstractRoom(abstractPlayer.pos.room) is AbstractRoom abstractRoom) // room in region
-                    {
-                        found = true;
-                        if (abstractPlayer.pos != lastWorldPos || camera.currentCameraPosition != lastCameraPos || camera.room.abstractRoom.index != lastAbstractRoom) // cache these maths
-                        {
-                            var worldpos = (abstractRoom.mapPos / 3f + new Vector2(10f, 10f)) * 20f;
-                            if (this.abstractPlayer.realizedCreature is Creature creature) worldpos += creature.mainBodyChunk.pos - abstractRoom.size.ToVector2() * 20f / 2f;
-                            else if (abstractPlayer.pos.TileDefined) worldpos += abstractPlayer.pos.Tile.ToVector2() * 20f - abstractRoom.size.ToVector2() * 20f / 2f;
-
-                            var viewpos = (camera.room.abstractRoom.mapPos / 3f + new Vector2(10f, 10f)) * 20f + camera.pos + this.camera.sSize / 2f - camera.room.abstractRoom.size.ToVector2() * 20f / 2f;
-
-                            pointDir = (worldpos - viewpos).normalized;
-                            drawpos = camrect.GetClosestInteriorPointAlongLineFromCenter(this.camera.sSize / 2f + pointDir * 2048f); // gives angled arrows
-                        }
-                    }
-                }
-            }
-
-            lastWorldPos = abstractPlayer.pos;
-            lastCameraPos = camera.currentCameraPosition;
-            lastAbstractRoom = camera.room.abstractRoom.index;
-
 
             if (this.antiDeathBumpFlicker > 0)
             {
@@ -282,7 +263,10 @@ namespace RainMeadow
                 }
                 this.deadCounter = -1;
                 this.hud.PlaySound(SoundID.UI_Multiplayer_Player_Revive);
-                this.hud.fadeCircles.Add(new FadeCircle(this.hud, 10f, 10f, 0.82f, 30f, 4f, this.drawpos, this.hud.fContainers[1]));
+
+                Vector2? drawPos = GetTargetDrawPos(1f)?.pos;
+                if (drawPos.HasValue)
+                    this.hud.fadeCircles.Add(new FadeCircle(this.hud, 10f, 10f, 0.82f, 30f, 4f, drawPos.Value, this.hud.fContainers[1]));
             }
 
             this.lastDead = this.PlayerConsideredDead;
@@ -318,6 +302,40 @@ namespace RainMeadow
 
         }
 
+        public (Vector2 pos, Vector2 dir)? GetTargetDrawPos(float timeStacker)
+        {
+            PositionState? currentState = PositionState.Lerp(_prevTargetState, _targetState, timeStacker);
+            if (!currentState.HasValue)
+                return null;
+            PositionState state = currentState.Value;
+
+            Vector2 cameraPos = Vector2.Lerp(camera.lastPos, camera.pos, timeStacker);
+            Vector2 cameraWorldPos = GetAbstractRoomWorldPosInPixels(camera.room.abstractRoom) + cameraPos;
+
+            Vector2 targetPos = state.Position - cameraWorldPos;
+
+            Rect cameraBounds = new(Vector2.zero, camera.sSize);
+            Rect positionBounds = cameraBounds.CloneWithExpansion(-30f);
+
+            if (state.PointTowardsDirection)
+            {
+                return (
+                    pos: positionBounds.GetClosestPointOnEdgeAlongLineFromCenter(targetPos),
+                    dir: (targetPos - positionBounds.center).normalized
+                );
+            }
+
+            bool isTargetOnScreen = positionBounds.Contains(targetPos);
+
+            Vector2 clampedPos = positionBounds.GetClosestInteriorPoint(targetPos);
+            Vector2 clampedDir = (targetPos - clampedPos).normalized;
+
+            return (
+                pos: isTargetOnScreen ? targetPos - state.Direction * state.VisibilityOffset : clampedPos,
+                dir: isTargetOnScreen ? state.Direction * (state.InvertArrow ? -1 : 1) : clampedDir
+            );
+        }
+
         public override void Update()
         {
             base.Update();
@@ -340,6 +358,48 @@ namespace RainMeadow
             for (int i = 0; i < this.parts.Count; i++)
             {
                 this.parts[i].ClearSprites();
+            }
+        }
+
+        private static Vector2 GetAbstractRoomWorldPosInPixels(AbstractRoom abstractRoom)
+        {
+            return (abstractRoom.mapPos / 3f + new Vector2(10f, 10f) - abstractRoom.size.ToVector2() / 2f) * 20f;
+        }
+
+        private readonly record struct PositionState(
+            Vector2 Position,
+            Vector2 Direction,
+            float VisibilityOffset,
+            bool InvertArrow,
+            bool PointTowardsDirection)
+        {
+            public Vector2 Position { get; } = Position;
+            public Vector2 Direction { get; } = Direction;
+            public float VisibilityOffset { get; } = VisibilityOffset;
+            public bool InvertArrow { get; } = InvertArrow;
+            public bool PointTowardsDirection { get; } = PointTowardsDirection;
+
+            public static PositionState? Lerp(PositionState? a, PositionState? b, float t) => t switch {
+                <= 0f => a ?? b,
+                >= 1f => b,
+                _     => LerpUnclamped(a, b, t)
+            };
+
+            private static PositionState? LerpUnclamped(PositionState? a, PositionState? b, float t)
+            {
+                if (!b.HasValue)
+                    return null;
+                if (!a.HasValue)
+                    return b;
+                PositionState from = a.Value;
+                PositionState to = b.Value;
+                return new PositionState(
+                    Position: Vector2.LerpUnclamped(from.Position, to.Position, t),
+                    Direction: Vector2.LerpUnclamped(from.Direction, to.Direction, t),
+                    VisibilityOffset: Mathf.LerpUnclamped(from.VisibilityOffset, to.VisibilityOffset, t),
+                    InvertArrow: to.InvertArrow,
+                    PointTowardsDirection: to.PointTowardsDirection
+                );
             }
         }
     }

--- a/OnlineUIComponents/PlayerSpecificOnlineHud.cs
+++ b/OnlineUIComponents/PlayerSpecificOnlineHud.cs
@@ -186,10 +186,12 @@ namespace RainMeadow
                     if (abstractPlayer.pos.room != connections[i])
                         continue;
                     WorldCoordinate shortcutPos = camera.room.LocalCoordinateOfNode(i);
+                    Vector2 dir = camera.room.ShorcutEntranceHoleDirection(shortcutPos.Tile).ToVector2();
+                    Vector2 pos = camera.ApplyDepth(camera.room.MiddleOfTile(shortcutPos) + dir * 15f, -5f);
                     _targetState = new PositionState(
-                        Position: _cameraRoomWorldPosInPixels + camera.room.MiddleOfTile(shortcutPos),
-                        Direction: camera.room.ShorcutEntranceHoleDirection(shortcutPos.Tile).ToVector2(),
-                        VisibilityOffset: 10f,
+                        Position: _cameraRoomWorldPosInPixels + pos,
+                        Direction: dir,
+                        VisibilityOffset: 20f,
                         InvertArrow: true, // Point away from the shortcut entrance
                         PointTowardsDirection: false
                     );


### PR DESCRIPTION
- fixed name tag position being behind by an extra tick
  - theres still another tick of delay but it comes from rain world itself so itd be out of scope for rain meadow to fix
  - more specifically, HUD.Update gets called before almost everything else (including OverWorld.Update) in RainWorldGame.Update, which means that the hud updates with the state of the game from the previous tick before the game is actually updated. this affects *all* huds in rain world, including name tags / player arrows in vanilla, so a proper fix would fix the issue for everything, which would happen to include rain meadow name tags

before | after
--- | ---
<video src="https://github.com/user-attachments/assets/aeaa7d60-a94f-41ae-9025-38909eee07bc"> | <video src="https://github.com/user-attachments/assets/122921e1-f79f-4b50-a3e0-ee713abb22f1">
---

- fixed the arrow being incorrectly offset relative to the shortcut icon when showing a player in the neighboring room

before | after
--- | ---
<img width="174" height="470" alt="image" src="https://github.com/user-attachments/assets/7210d597-386c-487d-a1f1-a1df540bfa77" /> | <img width="174" height="470" alt="image" src="https://github.com/user-attachments/assets/490ba231-b0c9-4e5e-b2eb-d42874892575" />
---

- fixed the name tag lerping its position when it should change instantly (like when the camera moves or changes its room)
  - note that the tick of delay from the rw bug described above is still present, but the switch is still a lot less jarring

before | after
--- | ---
<video src="https://github.com/user-attachments/assets/843fa682-7073-48da-8377-a6a655d87827"> | <video src="https://github.com/user-attachments/assets/3b51da24-9f97-4131-8ec6-8a380413efa1">
---


- fixed an edge case in clamping logic thatd sometimes cause the name tag to be closer to the edge of the screen than intended
  - when the target player is in a neighbor room and the shortcut is close enough to the edge of the screen that the name tag ends up being less than 40 pixels (2 tiles) away from the edge of the screen before applying the 10 pixel offset

before | after
--- | ---
<video src="https://github.com/user-attachments/assets/a9020917-3c4c-4215-b114-4ed6b1036e36"> | <video src="https://github.com/user-attachments/assets/bb12a20c-3a23-437c-af8e-fdf1da917405">
---


- fixed positioning logic for far away players
  - if a far away player happened to be realized (i think this only happens with jolly coop?) the old logic would technically incorrectly target the main body chunk, it would also only update the target position when the player's abstract creature's position changes regardless of whether the realized creature's position changes
  - also name tags would sometimes just freeze until you get close enough to their player
---


- improved positioning for players really close to edges of the screen (<30px)

before | after
--- | ---
<video src="https://github.com/user-attachments/assets/61885c4f-3969-45bc-b5f4-3b2f35208998"> | <video src="https://github.com/user-attachments/assets/1a71a26c-d234-4382-bf4f-f3f70a04a774">
---


most of these fixes come from just rewriting the positioning logic almost entirely so i had to put it in a single commit which made git generate kind of a bad diff, idk if i can make it look better for easier reviewing, sorry :(

ive tested this quite extensively and couldnt notice any issues (other than ones already present in rain meadow that are out of scope for this PR)