### PR TITLE
remove nullables from some of TryGet patterns from Extensions

### DIFF
--- a/Arena/AmoebaSummonBehavior.cs
+++ b/Arena/AmoebaSummonBehavior.cs
@@ -38,7 +38,7 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
             {
                 if (
                     arenaPlayer.playerNumber
-                    == ArenaHelpers.FindOnlinePlayerNumber(arena, opo!.owner)
+                    == ArenaHelpers.FindOnlinePlayerNumber(arena, opo.owner)
                 )
                 {
                     additionalPoints = arenaPlayer.allKills.Count;
@@ -56,7 +56,7 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
             if (!RainMeadow.isArenaMode(out var arena)) return base.SwimTowards;
             VoidSpawn voidSpawn = this.owner;
             // RainMeadow.Debug($"{voidSpawn} choosing a behavior...");
-            
+
 
             // 1. If pointing, go toward the point.
             if (arena.amoebaControl && Input.GetKey(RainMeadow.rainMeadowOptions.PointingKey.Value))
@@ -82,7 +82,7 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
                     return pointingVector;
                 }
             }
-            
+
 
             // 2. If spear hit is on, and a target player was found, go toward it.
             Player? ownerPlayer = null;
@@ -106,11 +106,11 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
                 }
                 if (!voidSpawn.room.game.GetArenaGameSession.arenaSitting.gameTypeSetup.spearsHitPlayers)
                     continue;
-                
+
                 if (TeamBattleMode.IsTeamBattleMode(out var tb))
                 {
                     ArenaTeamClientSettings? playerTeam =
-                        ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(oe!.owner);
+                        ArenaHelpers.GetDataSettings<ArenaTeamClientSettings>(oe.owner);
                     if (playerTeam != null && playerTeam.team == arena.arenaTeamClientSettings.team)
                         continue;
                 }
@@ -131,18 +131,18 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
                 )
                 {
                     foundPlayer = realizedPlayer;
-                    foundPlayerPriority  = GetPriority(arena, voidSpawn, foundPlayer);
+                    foundPlayerPriority = GetPriority(arena, voidSpawn, foundPlayer);
                     minDistance = distance;
                 }
             }
-            
-            if (foundPlayer != null) 
+
+            if (foundPlayer != null)
             {
                 // RainMeadow.Debug($"(2) Attacking Player !");
                 this.wasCircling = false;
                 return foundPlayer.mainBodyChunk.pos;
             }
-            
+
 
             // 3. If a hostile creature is found, go toward it.
             Creature? foundCreature = null;
@@ -167,7 +167,7 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
                 );
                 int aggression = voidSpawn.abstractPhysicalObject.rippleLayer != creature.abstractCreature.rippleLayer
                     ? 0 // can't really aggro if you are not in the same realm
-                    : (ownerPlayer is not null 
+                    : (ownerPlayer is not null
                         ? (int)(abstractCreature.abstractAI?.RealAI?.CurrentPlayerAggression(ownerPlayer.abstractCreature) * 10 ?? 0)
                         : 5); // aggression is from 0 to 1, make it an int from 0 to 10
 
@@ -182,7 +182,7 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
                 }
             }
 
-            if (foundCreature != null) 
+            if (foundCreature != null)
             {
                 // RainMeadow.Debug($"(3) Attacking Creature !");
                 if (minDistance <= stunDistance) voidSpawn.playerProximityTime = 10;
@@ -190,7 +190,7 @@ public class AmoebaSummonBehavior(VoidSpawn owner) : VoidSpawn.Behavior(owner)
                 return foundCreature.mainBodyChunk.pos;
             }
 
-            
+
             // 4. If an owner is found, circle around it
             if (ownerPlayer is not null)
             {

--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -234,7 +234,7 @@ namespace RainMeadow
             }
             catch (Exception ex)
             {
-                Error("Could not find IL hook : "+ ex);
+                Error("Could not find IL hook : " + ex);
             }
         }
 
@@ -251,7 +251,7 @@ namespace RainMeadow
             }
             catch (Exception ex)
             {
-                Error("Could not find IL hook : "+ ex);
+                Error("Could not find IL hook : " + ex);
             }
         }
         private void RainWorldGame_Update_ShortcutWaitForAllPlayers(On.RainWorldGame.orig_Update orig, RainWorldGame self)
@@ -394,7 +394,7 @@ namespace RainMeadow
                     if (!self.IsLocal())
                     {
                         if (AmoebaSummonBehavior.GetPriority(arena, spawn, self) > 1)
-                                spawn.playerProximityTime = 10; //slow down when near the player (if not dead or in ripple space)
+                            spawn.playerProximityTime = 10; //slow down when near the player (if not dead or in ripple space)
                         return false;
                     }
                     if (spawn.IsLocal() && spawn.behavior != null)
@@ -709,8 +709,8 @@ namespace RainMeadow
                 cursor.Emit(OpCodes.Brtrue, toParryLoop);
 
                 // Change the light explosion range (purely cosmetic, will not throw if fail)
-                if (cursor.TryGotoNext(moveType: MoveType.After,  x => x.MatchNewobj<Explosion.ExplosionLight>())
-                    && cursor.TryGotoPrev(moveType: MoveType.After,  x => x.MatchLdcR4(160)) )
+                if (cursor.TryGotoNext(moveType: MoveType.After, x => x.MatchNewobj<Explosion.ExplosionLight>())
+                    && cursor.TryGotoPrev(moveType: MoveType.After, x => x.MatchLdcR4(160)))
                 {
                     cursor.EmitDelegate((float orig) =>
                     {
@@ -725,8 +725,8 @@ namespace RainMeadow
                 }
 
                 // Change the shockwave explosion range (purely cosmetic, will not throw if fail)
-                if (cursor.TryGotoNext(moveType: MoveType.After,  x => x.MatchNewobj<ShockWave>())
-                    && cursor.TryGotoPrev(moveType: MoveType.After,  x => x.MatchLdcR4(200)) )
+                if (cursor.TryGotoNext(moveType: MoveType.After, x => x.MatchNewobj<ShockWave>())
+                    && cursor.TryGotoPrev(moveType: MoveType.After, x => x.MatchLdcR4(200)))
                 {
                     cursor.EmitDelegate((float orig) =>
                     {
@@ -1295,7 +1295,7 @@ namespace RainMeadow
             {
                 if (
                     self.player.abstractPhysicalObject.GetOnlineObject(out var oe) == true
-                    && ArenaHelpers.GetArenaClientSettings(oe!.owner)?.weaverTail == true
+                    && ArenaHelpers.GetArenaClientSettings(oe.owner)?.weaverTail == true
                 )
                     self.InitializeLongerWatcherTail();
             }
@@ -1312,7 +1312,7 @@ namespace RainMeadow
         {
             if (isArenaMode(out _)
                 && self.player.abstractPhysicalObject.GetOnlineObject(out var oe) == true
-                && ArenaHelpers.GetArenaClientSettings(oe!.owner)?.weaverTail == true
+                && ArenaHelpers.GetArenaClientSettings(oe.owner)?.weaverTail == true
             )
                 self.player.watcherMorph = 0.51f;
 
@@ -1352,7 +1352,7 @@ namespace RainMeadow
             if (
                 isArenaMode(out _)
                 && self.pGraphics.player.abstractPhysicalObject.GetOnlineObject(out var oe)
-                && ArenaHelpers.GetArenaClientSettings(oe!.owner)?.weaverTail == true
+                && ArenaHelpers.GetArenaClientSettings(oe.owner)?.weaverTail == true
             )
             {
                 self.weaverTier = 4;

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -53,18 +53,17 @@ namespace RainMeadow
         public static bool IsLocal(this AbstractPhysicalObject apo) => OnlineManager.lobby is null || (GetOnlineObject(apo)?.isMine ?? true);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject opo)
+        public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject? opo)
         {
-            opo = null!;
-            if (OnlineManager.lobby is null) return true;
-            return OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine;
+            opo = null;
+            return OnlineManager.lobby is null || (OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLocal(this PhysicalObject po) => IsLocal(po.abstractPhysicalObject);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsLocal(this PhysicalObject po, out OnlinePhysicalObject opo) => IsLocal(po.abstractPhysicalObject, out opo);
+        public static bool IsLocal(this PhysicalObject po, out OnlinePhysicalObject? opo) => IsLocal(po.abstractPhysicalObject, out opo);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CanMove(this AbstractPhysicalObject apo, WorldCoordinate? newCoord = null, bool quiet = false)

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -47,7 +47,7 @@ namespace RainMeadow
         public static OnlineCreature? GetOnlineCreature(this AbstractCreature ac) => GetOnlineObject(ac) as OnlineCreature;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool GetOnlineCreature(this AbstractCreature apo, out OnlineCreature oc) => (oc = GetOnlineCreature(apo) ?? default!) is not null;
+        public static bool GetOnlineCreature(this AbstractCreature apo, out OnlineCreature oc) => (oc = GetOnlineCreature(apo) ?? null!) is not null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLocal(this AbstractPhysicalObject apo) => OnlineManager.lobby is null || (GetOnlineObject(apo)?.isMine ?? true);

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -56,7 +56,7 @@ namespace RainMeadow
         public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject opo)
         {
             opo = null!;
-            if (OnlineManager.lobby is null) return false;
+            if (OnlineManager.lobby is null) return true;
             return OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine;
         }
 

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -41,29 +41,30 @@ namespace RainMeadow
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool GetOnlineObject(this AbstractPhysicalObject apo, out OnlinePhysicalObject? opo) => OnlinePhysicalObject.map.TryGetValue(apo, out opo);
+        public static bool GetOnlineObject(this AbstractPhysicalObject apo, out OnlinePhysicalObject opo) => OnlinePhysicalObject.map.TryGetValue(apo, out opo);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static OnlineCreature? GetOnlineCreature(this AbstractCreature ac) => GetOnlineObject(ac) as OnlineCreature;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool GetOnlineCreature(this AbstractCreature apo, out OnlineCreature? oc) => (oc = GetOnlineCreature(apo)) is not null;
+        public static bool GetOnlineCreature(this AbstractCreature apo, out OnlineCreature oc) => (oc = GetOnlineCreature(apo) ?? default!) is not null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLocal(this AbstractPhysicalObject apo) => OnlineManager.lobby is null || (GetOnlineObject(apo)?.isMine ?? true);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject? opo)
+        public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject opo)
         {
-            opo = null;
-            return OnlineManager.lobby is null || (OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine);
+            opo = default!;
+            if (OnlineManager.lobby is null) return false;
+            return OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLocal(this PhysicalObject po) => IsLocal(po.abstractPhysicalObject);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsLocal(this PhysicalObject po, out OnlinePhysicalObject? opo) => IsLocal(po.abstractPhysicalObject, out opo);
+        public static bool IsLocal(this PhysicalObject po, out OnlinePhysicalObject opo) => IsLocal(po.abstractPhysicalObject, out opo);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CanMove(this AbstractPhysicalObject apo, WorldCoordinate? newCoord = null, bool quiet = false)
@@ -531,9 +532,9 @@ namespace RainMeadow
                 TryParallelStitchBind(listList[0], listList[listList.Count - 1], areRows, areColumns);
             }
         }
-        public static bool IsDictionary(this Type type, out Type? dictInterface)
+        public static bool IsDictionary(this Type type, out Type dictInterface)
         {
-            dictInterface = null;
+            dictInterface = default!;
 
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
             {

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -50,18 +50,13 @@ namespace RainMeadow
         public static bool GetOnlineCreature(this AbstractCreature apo, out OnlineCreature oc) => (oc = GetOnlineCreature(apo) ?? default!) is not null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsLocal(this AbstractPhysicalObject apo)
-        {
-            if (OnlineManager.lobby is null) throw new InvalidOperationException("The lobby is null, did you forgeet to check for a valid lobby?");
-            if (GetOnlineObject(apo) is not OnlinePhysicalObject opo) return true;
-            return opo.isMine;
-        }
+        public static bool IsLocal(this AbstractPhysicalObject apo) => OnlineManager.lobby is null || (GetOnlineObject(apo)?.isMine ?? true);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject opo)
         {
             opo = null!;
-            if (OnlineManager.lobby is null) throw new InvalidOperationException("The lobby is null, did you forgeet to check for a valid lobby?");
+            if (OnlineManager.lobby is null) return false;
             return OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine;
         }
 

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -50,13 +50,17 @@ namespace RainMeadow
         public static bool GetOnlineCreature(this AbstractCreature apo, out OnlineCreature oc) => (oc = GetOnlineCreature(apo) ?? default!) is not null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsLocal(this AbstractPhysicalObject apo) => OnlineManager.lobby is null || (GetOnlineObject(apo)?.isMine ?? true);
+        public static bool IsLocal(this AbstractPhysicalObject apo)
+        {
+            if (OnlineManager.lobby is null) throw new InvalidOperationException("The lobby is null, did you forgeet to check for a valid lobby?");
+            if (GetOnlineObject(apo) is not OnlinePhysicalObject opo) return true;
+            return opo.isMine;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject opo)
         {
-            opo = default!;
-            if (OnlineManager.lobby is null) return false;
+            if (OnlineManager.lobby is null) throw new InvalidOperationException("The lobby is null, did you forgeet to check for a valid lobby?");
             return OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine;
         }
 

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -60,6 +60,7 @@ namespace RainMeadow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLocal(this AbstractPhysicalObject apo, out OnlinePhysicalObject opo)
         {
+            opo = null!;
             if (OnlineManager.lobby is null) throw new InvalidOperationException("The lobby is null, did you forgeet to check for a valid lobby?");
             return OnlinePhysicalObject.map.TryGetValue(apo, out opo) && opo.isMine;
         }
@@ -538,7 +539,7 @@ namespace RainMeadow
         }
         public static bool IsDictionary(this Type type, out Type dictInterface)
         {
-            dictInterface = default!;
+            dictInterface = null!;
 
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
             {

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -304,8 +304,8 @@ namespace RainMeadow
 
             if (RoomSession.map.TryGetValue(creature.room.abstractRoom, out var roomSession))
             {
-                if (creature.abstractCreature.GetOnlineCreature(out var oc) &&
-                    item.abstractPhysicalObject.GetOnlineObject(out var opo))
+                if (creature.abstractCreature.GetOnlineCreature(out OnlineCreature oc) &&
+                    item.abstractPhysicalObject.GetOnlineObject(out OnlinePhysicalObject opo))
                 {
                     oc.BroadcastRPCInRoom(roomSession.CreaturePutItemOnGround, opo.id, oc.id);
                 }

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -90,7 +90,7 @@ namespace RainMeadow
                 if (roomSession != null && roomSession.isOwner)
                 {
                     orig(self, pos, branchingChance, size, effectRadius, killRadius, delayFrames);
-                    foreach(var player in roomSession.participants)
+                    foreach (var player in roomSession.participants)
                     {
                         if (player.isMe) continue;
                         player.InvokeRPC(RPCs.LightingMakerStrike, roomSession, pos, branchingChance, size, effectRadius, killRadius, delayFrames);
@@ -111,14 +111,14 @@ namespace RainMeadow
                     if (!cs.isThinking) cs.isThinking = true;
                     self.LookAtPoint(self.player.mainBodyChunk.pos + Vector2.up * 25f, 100);
                     self.player.Blink(10);
-                    if ((self.player.abstractCreature.world.game.GetStorySession is not StoryGameSession storyGame 
+                    if ((self.player.abstractCreature.world.game.GetStorySession is not StoryGameSession storyGame
                         || storyGame.saveState.deathPersistentSaveData.theMark)
                         && self.player.abstractCreature.world.game.ActiveRippleLayer == self.player.abstractCreature.rippleLayer)
                     {
                         self.markAlpha = Custom.LerpAndTick(
-                            self.lastMarkAlpha, 
-                            Mathf.Clamp01(1f - UnityEngine.Random.value * Mathf.InverseLerp(80f, 30f, self.player.touchedNoInputCounter)), 
-                            0.1f, 
+                            self.lastMarkAlpha,
+                            Mathf.Clamp01(1f - UnityEngine.Random.value * Mathf.InverseLerp(80f, 30f, self.player.touchedNoInputCounter)),
+                            0.1f,
                             0.033333335f
                         );
                         // RainMeadow.Debug($"Mark at alpha {self.markAlpha}<{self.player.touchedNoInputCounter}>");
@@ -223,12 +223,12 @@ namespace RainMeadow
                 {
                     cursor.MoveAfterLabels();
                     cursor.EmitDelegate(() => OnlineManager.lobby is not null && RPCEvent.currentRPCEvent is not null);
-                    cursor.Emit(OpCodes.Brtrue, label); 
+                    cursor.Emit(OpCodes.Brtrue, label);
                     // If we are in an RPC, move it directly to parrying, even if the weapons are going in the same directions
 
                     cursor.GotoLabel(label, MoveType.Before);
                     cursor.MoveAfterLabels();
-                    cursor.Emit(OpCodes.Ldarg_0);            
+                    cursor.Emit(OpCodes.Ldarg_0);
                     cursor.Emit(OpCodes.Ldarg_1);
                     cursor.EmitDelegate((Weapon w1, Weapon w2) =>
                         {
@@ -243,7 +243,7 @@ namespace RainMeadow
                 {
                     RainMeadow.Error("Could not find IL hook :<");
                 }
-                    
+
             }
             catch (Exception ex)
             {
@@ -257,22 +257,22 @@ namespace RainMeadow
             OnlinePhysicalObject? wep2 = B.abstractPhysicalObject.GetOnlineObject();
             if (wep1 == null || wep2 == null || !(wep1.isMine || wep2.isMine)) return;
             RainMeadow.Debug($"Parry {wep1}, {wep1.owner}, {wep2}, {wep2.owner}");
-            
+
             RealizedWeaponState? realizedstatewep1 = GetAppropriateWeaponState(wep1);
             if (realizedstatewep1 is null)
             {
                 RainMeadow.Error($"Failed to create the appropriate weapon state for obj {wep1}");
                 return;
-            } 
+            }
 
-            
+
             RealizedWeaponState? realizedstatewep2 = GetAppropriateWeaponState(wep2);
             if (realizedstatewep2 is null)
             {
                 RainMeadow.Error($"Failed to create the appropriate weapon state for obj {wep2}");
                 return;
-            } 
-            
+            }
+
 
             if (!wep1.isMine)
             {
@@ -283,7 +283,7 @@ namespace RainMeadow
             {
                 wep2.Lock("parry", wep2.owner.InvokeRPC(RPCs.Weapon_HitAnotherThrownWeapon, wep1, wep2, realizedstatewep1, realizedstatewep2, A.firstChunk.lastPos, B.firstChunk.lastPos, UnityEngine.Random.state));
             }
-            
+
 
             foreach (OnlinePlayer p in wep1.roomSession?.participants ?? [])
             {
@@ -304,11 +304,10 @@ namespace RainMeadow
 
             if (RoomSession.map.TryGetValue(creature.room.abstractRoom, out var roomSession))
             {
-                if (creature.abstractCreature.GetOnlineCreature(out OnlineCreature? oc) &&
-                    item.abstractPhysicalObject.GetOnlineObject(out OnlinePhysicalObject? opo))
+                if (creature.abstractCreature.GetOnlineCreature(out var oc) &&
+                    item.abstractPhysicalObject.GetOnlineObject(out var opo))
                 {
-                    oc?.BroadcastRPCInRoom(roomSession.CreaturePutItemOnGround,
-                        opo.id, oc.id);
+                    oc.BroadcastRPCInRoom(roomSession.CreaturePutItemOnGround, opo.id, oc.id);
                 }
 
             }
@@ -750,7 +749,8 @@ namespace RainMeadow
                     }
 
                     return orig(self, result, eu);
-                } else RainMeadow.Error($"Failed to create the appropriate weapon state for obj {WeaponOnline}");
+                }
+                else RainMeadow.Error($"Failed to create the appropriate weapon state for obj {WeaponOnline}");
             }
             return true;
         }
@@ -1042,7 +1042,7 @@ namespace RainMeadow
                     if (onlineGrabbed != null && !onlineGrabbed.isMine && onlineGrabbed.isTransferable && !onlineGrabbed.isPending) // been leased to someone else
                     {
                         var grabbersOtherThanMe = grasp.grabbed.grabbedBy.Select(x => x.grabber).Where(x => x != self);
-                        if (grabbersOtherThanMe.All(x => x.abstractPhysicalObject.GetOnlineObject(out var opo) && opo != null && opo.isMine))
+                        if (grabbersOtherThanMe.All(x => x.abstractPhysicalObject.GetOnlineObject(out var opo) && opo.isMine))
                             onlineGrabbed.Request();
                     }
                 }

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -299,7 +299,7 @@ namespace RainMeadow
         {
 
             orig(self, item, creature);
-            if (OnlineManager.lobby != null) return;
+            if (OnlineManager.lobby is null) return;
             if (!creature.IsLocal()) return;
 
             if (RoomSession.map.TryGetValue(creature.room.abstractRoom, out var roomSession))

--- a/Game/RainMeadow.PlayerHooks.cs
+++ b/Game/RainMeadow.PlayerHooks.cs
@@ -1940,7 +1940,7 @@ public partial class RainMeadow
             {
                 self.controller = new OnlineController(oe, self); // remote player
             }
-            else if (oe is null)
+            else
             {
                 RainMeadow.Error("player entity not found for " + self + " " + self.abstractCreature);
             }
@@ -2184,7 +2184,7 @@ public partial class RainMeadow
             c.Emit(OpCodes.Ldarg_0);
             c.EmitDelegate((Player self) =>
             {
-                if (OnlineManager.lobby != null && self.abstractPhysicalObject.GetOnlineObject(out var oe))
+                if (OnlineManager.lobby != null && self.abstractPhysicalObject.GetOnlineObject(out _))
                 {
                     // signal not-in-a-room
                     self.objectInStomach.InDen = true;


### PR DESCRIPTION
it's not a first time i question why `out` arguments of these methods are considered nullable if it doesn't matter much, since they're thrown away if they're `null` on `false` returned.
ideally they're supposed to have a prefix `Try`, and not be an overload. but it's besides the point.

so i've asked choc, who wrote these methods. [quote](https://discord.com/channels/1094716194180841602/1155268800669831270/1542605607763447888):
> can i ask why `GetOnlineObject` has a signature of `bool AbstractPhysicalObject.GetOnlineObject(out OnlinePhysicalObject? opo)`, and not `bool AbstractPhysicalObject.TryGetOnlineObject(out OnlinePhysicalObject opo)`?
> this is like.. a flaw in design. "TryGet" methods are always guaranteed to return true on existing out variable, but it's marked as nullable

then i explained my point and he said i'm free to PR, which i'm doing right now.
PLUS i've fixed some unnecessary checks (i hope i didn't break anything, didn't test much), to show it cuts some warnings for free.

there's also some `TryGet` methods outside of Extensions i found, but the PR doesn't touch them.
and lowering the scope is better to me, since i wont be home for a day if this even matters, and generally smaller scope is better to show the point to show the point.


@One-Letter-Shor also commented he's "working on something rn".
i'm mentioning it since i'm curious