### PR TITLE
Optimize registering RPCs and OnlineStates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   - Optimized registering RPCs (~28x as fast) and online states (~2x as fast)
   - Total Rain Meadow load time ~20% faster
 
+### Modders
+- Removed `OnlineState.RegisterState`
+- RPCMethods and OnlineStates now only loaded from the main mod assemblies (the ones that BepInEx detects as mods, i.e. with the class inheriting BaseUnityPlugin) instead of every loaded assembly
+
 ## Chat
 
 ### Modders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## General
 - Improved startup time
-  - Optimized registering RPCs (~28x as fast) and online states (~2x as fast)
+  - Optimized registering RPCs (up to ~2700% faster) and online states (~100% faster)
   - Total Rain Meadow load time ~20% faster
 
 ### Modders
 - Removed `OnlineState.RegisterState`
-- RPCMethods and OnlineStates now only loaded from the main mod assemblies (the ones that BepInEx detects as mods, i.e. with the class inheriting BaseUnityPlugin) instead of every loaded assembly
 
 ## Chat
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release 1.16.0
 
+## General
+- Improved startup time
+  - Optimized registering RPCs (~28x as fast) and online states (~2x as fast)
+  - Total Rain Meadow load time ~20% faster
+
 ## Chat
 
 ### Modders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## General
 - Improved startup time
-  - Optimized registering RPCs (up to ~2700% faster) and online states (~100% faster)
-  - Total Rain Meadow load time ~20% faster
+  - Optimized registering RPCs (up to ~2700% faster) and online states (up to ~100% faster)
+  - Total Rain Meadow load time up to ~20% faster
 
 ### Modders
 - Removed `OnlineState.RegisterState`

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -338,6 +338,12 @@ namespace RainMeadow
             return new Color(Mathf.Clamp(valuecolor.r, 1f / 255f, 1f), Mathf.Clamp(valuecolor.g, 1f / 255f, 1f), Mathf.Clamp(valuecolor.b, 1f / 255f, 1f));
         }
 
+        public static IEnumerable<Assembly> FindReferencingAssemblies(this Assembly assembly)
+        {
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .Where(asm => asm.GetReferencedAssemblies().Any(name => name.Name == assembly.GetName().Name));
+        }
+
         public static Type[] GetTypesSafely(this Assembly assembly)
         {
             try

--- a/Online/RPCManager.cs
+++ b/Online/RPCManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Mono.Cecil;
+using BepInEx.Bootstrap;
 
 namespace RainMeadow
 {
@@ -78,8 +78,10 @@ namespace RainMeadow
         {
             index = 1; // zero is an easy to catch mistake
 
+            Assembly selfAssembly = Assembly.GetExecutingAssembly();
+
             // our own RPCs first
-            foreach (var type in Assembly.GetExecutingAssembly().GetTypesSafely().ToList())
+            foreach (var type in selfAssembly.GetTypesSafely())
             {
                 try
                 {
@@ -94,12 +96,12 @@ namespace RainMeadow
             // intentionally thrown on failure
 
             // other RPCs
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().ToList())
+            foreach (var assembly in Chainloader.PluginInfos.Select(info => info.Value.Instance.GetType().Assembly))
             {
-                if (assembly == Assembly.GetExecutingAssembly()) continue;
+                if (assembly == selfAssembly) continue;
                 try
                 {
-                    foreach (var type in assembly.GetTypesSafely().ToList())
+                    foreach (var type in assembly.GetTypesSafely())
                     {
                         try
                         {
@@ -134,14 +136,18 @@ namespace RainMeadow
 
         public static void RegisterRPCs(Type targetType)
         {
-            if (targetType.IsGenericTypeDefinition || targetType.IsInterface) return;
-            var methods = targetType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly).Where(m => m.GetCustomAttribute<RPCMethodAttribute>() != null);
-            if (!methods.Any()) return;
+            if (targetType.IsGenericTypeDefinition || targetType.IsInterface)
+                return;
 
+            var methods = targetType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
             foreach (var method in methods)
             {
+                RPCMethodAttribute rpcMethodAttribute = method.GetCustomAttribute<RPCMethodAttribute>();
+                if (rpcMethodAttribute is null)
+                    continue;
+
                 var isStatic = method.IsStatic;
-                var isSoft = method.GetCustomAttribute<RPCMethodAttribute>() is SoftRPCMethodAttribute;
+                var isSoft = rpcMethodAttribute is SoftRPCMethodAttribute;
                 // get args
                 RainMeadow.Debug($"New RPC: {targetType}-{method.Name}");
                 var args = method.GetParameters();

--- a/Online/RPCManager.cs
+++ b/Online/RPCManager.cs
@@ -78,31 +78,20 @@ namespace RainMeadow
         {
             index = 1; // zero is an easy to catch mistake
 
-            foreach (Assembly assembly in assemblies)
+            foreach (Type type in assemblies.SelectMany(assembly => assembly.GetTypesSafely()))
             {
                 try
                 {
-                    foreach (var type in assembly.GetTypesSafely())
-                    {
-                        try
-                        {
-                            RegisterRPCs(type);
-                        }
-                        catch (Exception e)
-                        {
-                            if (assembly == Assembly.GetExecutingAssembly())
-                            {
-                                RainMeadow.Error("Error registering RPCs for builtin type: " + type.FullName);
-                                throw; // intentionally thrown on failure
-                            }
-                            RainMeadow.Error(assembly.FullName + ":" + type.FullName);
-                            RainMeadow.Error(e);
-                        }
-                    }
+                    RegisterRPCs(type);
                 }
                 catch (Exception e)
                 {
-                    if (assembly == Assembly.GetExecutingAssembly()) throw; // intentionally thrown on failure
+                    if (type.Assembly == Assembly.GetExecutingAssembly())
+                    {
+                        RainMeadow.Error("Error registering RPCs for builtin type: " + type.FullName);
+                        throw; // intentionally thrown on failure
+                    }
+                    RainMeadow.Error(type.Assembly.FullName + ":" + type.FullName);
                     RainMeadow.Error(e);
                 }
             }

--- a/Online/RPCManager.cs
+++ b/Online/RPCManager.cs
@@ -74,31 +74,12 @@ namespace RainMeadow
             public Guid key;
         }
 
-        public static void SetupRPCs()
+        public static void SetupRPCs(IEnumerable<Assembly> assemblies)
         {
             index = 1; // zero is an easy to catch mistake
 
-            Assembly selfAssembly = Assembly.GetExecutingAssembly();
-
-            // our own RPCs first
-            foreach (var type in selfAssembly.GetTypesSafely())
+            foreach (Assembly assembly in assemblies)
             {
-                try
-                {
-                    RegisterRPCs(type);
-                }
-                catch (Exception e)
-                {
-                    RainMeadow.Error("Error registering RPCs for builtin type: " + type.FullName);
-                    throw e;
-                }
-            }
-            // intentionally thrown on failure
-
-            // other RPCs
-            foreach (var assembly in Chainloader.PluginInfos.Select(info => info.Value.Instance.GetType().Assembly))
-            {
-                if (assembly == selfAssembly) continue;
                 try
                 {
                     foreach (var type in assembly.GetTypesSafely())
@@ -109,6 +90,11 @@ namespace RainMeadow
                         }
                         catch (Exception e)
                         {
+                            if (assembly == Assembly.GetExecutingAssembly())
+                            {
+                                RainMeadow.Error("Error registering RPCs for builtin type: " + type.FullName);
+                                throw; // intentionally thrown on failure
+                            }
                             RainMeadow.Error(assembly.FullName + ":" + type.FullName);
                             RainMeadow.Error(e);
                         }
@@ -116,6 +102,7 @@ namespace RainMeadow
                 }
                 catch (Exception e)
                 {
+                    if (assembly == Assembly.GetExecutingAssembly()) throw; // intentionally thrown on failure
                     RainMeadow.Error(e);
                 }
             }

--- a/Online/State/OnlineState.cs
+++ b/Online/State/OnlineState.cs
@@ -51,13 +51,11 @@ namespace RainMeadow
         private static Dictionary<StateType, StateHandler> handlersByEnum = new Dictionary<StateType, StateHandler>();
         private static Dictionary<Type, StateHandler> handlersByType = new Dictionary<Type, StateHandler>();
 
-        internal static void InitializeBuiltinTypes()
+        internal static void InitializeBuiltinTypes(IEnumerable<Assembly> assemblies)
         {
             _ = StateType.Unknown; // runs static init
-            Assembly selfAssembly = Assembly.GetExecutingAssembly();
-            foreach (var assembly in Chainloader.PluginInfos.Select(info => info.Value.Instance.GetType().Assembly))
+            foreach (Assembly assembly in assemblies)
             {
-                bool isMain = assembly == selfAssembly;
                 bool hasState = false; // wether this assembly tried to register any onlinestates
                 try
                 {
@@ -74,14 +72,14 @@ namespace RainMeadow
                         catch (Exception e)
                         {
                             RainMeadow.Error($"{assembly.FullName}:{type.FullName}");
-                            if (isMain || hasState) throw;
+                            if (hasState || assembly == Assembly.GetExecutingAssembly()) throw;
                             RainMeadow.Error(e);
                         }
                     }
                 }
                 catch (Exception e)
                 {
-                    if (isMain || hasState) throw;
+                    if (hasState || assembly == Assembly.GetExecutingAssembly()) throw;
                     RainMeadow.Error(e);
                 }
             }

--- a/Online/State/OnlineState.cs
+++ b/Online/State/OnlineState.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using BepInEx.Bootstrap;
 using UnityEngine;
 
 namespace RainMeadow
@@ -50,42 +51,37 @@ namespace RainMeadow
         private static Dictionary<StateType, StateHandler> handlersByEnum = new Dictionary<StateType, StateHandler>();
         private static Dictionary<Type, StateHandler> handlersByType = new Dictionary<Type, StateHandler>();
 
-        public static void RegisterState(Type type)
-        {
-            if (!type.IsAbstract && typeof(OnlineState).IsAssignableFrom(type))
-            {
-                StateType stateType = new StateType(type.FullName, true);
-                handlersByEnum[stateType] = handlersByType[type] = new StateHandler(stateType, type);
-            }
-        }
-
         internal static void InitializeBuiltinTypes()
         {
             _ = StateType.Unknown; // runs static init
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().ToList())
+            Assembly selfAssembly = Assembly.GetExecutingAssembly();
+            foreach (var assembly in Chainloader.PluginInfos.Select(info => info.Value.Instance.GetType().Assembly))
             {
-                bool isMain = assembly == Assembly.GetExecutingAssembly();
+                bool isMain = assembly == selfAssembly;
                 bool hasState = false; // wether this assembly tried to register any onlinestates
                 try
                 {
-                    foreach (var type in assembly.GetTypesSafely().ToList())
+                    foreach (var type in assembly.GetTypesSafely())
                     {
                         try
                         {
-                            hasState |= typeof(OnlineState).IsAssignableFrom(type);
-                            OnlineState.RegisterState(type);
+                            if (type.IsAbstract || !typeof(OnlineState).IsAssignableFrom(type))
+                                continue;
+                            hasState = true;
+                            StateType stateType = new StateType(type.FullName, true);
+                            handlersByEnum[stateType] = handlersByType[type] = new StateHandler(stateType, type);
                         }
                         catch (Exception e)
                         {
-                            RainMeadow.Error(assembly.FullName + ":" + type.FullName);
-                            if (isMain || hasState) throw e;
+                            RainMeadow.Error($"{assembly.FullName}:{type.FullName}");
+                            if (isMain || hasState) throw;
                             RainMeadow.Error(e);
                         }
                     }
                 }
                 catch (Exception e)
                 {
-                    if (isMain || hasState) throw e;
+                    if (isMain || hasState) throw;
                     RainMeadow.Error(e);
                 }
             }

--- a/Online/State/OnlineState.cs
+++ b/Online/State/OnlineState.cs
@@ -65,7 +65,11 @@ namespace RainMeadow
                 }
                 catch (Exception)
                 {
-                    RainMeadow.Error($"{type.Assembly.FullName}:{type.FullName}");
+                    RainMeadow.Error(
+                        type.Assembly == Assembly.GetExecutingAssembly() ?
+                            $"Error registering OnlineState for builtin type: {type.FullName}" :
+                            $"{type.Assembly.FullName}:{type.FullName}"
+                    );
                     throw;
                 }
             }

--- a/Online/State/OnlineState.cs
+++ b/Online/State/OnlineState.cs
@@ -54,33 +54,19 @@ namespace RainMeadow
         internal static void InitializeBuiltinTypes(IEnumerable<Assembly> assemblies)
         {
             _ = StateType.Unknown; // runs static init
-            foreach (Assembly assembly in assemblies)
+            foreach (Type type in assemblies.SelectMany(assembly => assembly.GetTypesSafely()))
             {
-                bool hasState = false; // wether this assembly tried to register any onlinestates
+                if (type.IsAbstract || !typeof(OnlineState).IsAssignableFrom(type))
+                    continue;
                 try
                 {
-                    foreach (var type in assembly.GetTypesSafely())
-                    {
-                        try
-                        {
-                            if (type.IsAbstract || !typeof(OnlineState).IsAssignableFrom(type))
-                                continue;
-                            hasState = true;
-                            StateType stateType = new StateType(type.FullName, true);
-                            handlersByEnum[stateType] = handlersByType[type] = new StateHandler(stateType, type);
-                        }
-                        catch (Exception e)
-                        {
-                            RainMeadow.Error($"{assembly.FullName}:{type.FullName}");
-                            if (hasState || assembly == Assembly.GetExecutingAssembly()) throw;
-                            RainMeadow.Error(e);
-                        }
-                    }
+                    StateType stateType = new(type.FullName!, true);
+                    handlersByEnum[stateType] = handlersByType[type] = new StateHandler(stateType, type);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    if (hasState || assembly == Assembly.GetExecutingAssembly()) throw;
-                    RainMeadow.Error(e);
+                    RainMeadow.Error($"{type.Assembly.FullName}:{type.FullName}");
+                    throw;
                 }
             }
         }

--- a/RainMeadow.cs
+++ b/RainMeadow.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using RainMeadow.Game;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -190,10 +191,15 @@ namespace RainMeadow
 
                 StartCoroutine(CheckForUpdates());
 
+                List<Assembly> referencingAssembliesWithSelf = Assembly.GetExecutingAssembly()
+                    .FindReferencingAssemblies()
+                    .Prepend(Assembly.GetExecutingAssembly()) // our own first
+                    .ToList();
+
                 UsernameGenerator.Timestamp = DateTime.Now.Ticks;
 
                 var sw = Stopwatch.StartNew();
-                OnlineState.InitializeBuiltinTypes();
+                OnlineState.InitializeBuiltinTypes(referencingAssembliesWithSelf);
                 sw.Stop();
                 RainMeadow.Debug($"OnlineState.InitializeBuiltinTypes: {sw.Elapsed}");
 
@@ -208,7 +214,7 @@ namespace RainMeadow
                 RainMeadow.Debug($"MeadowProgression.InitializeBuiltinTypes: {sw.Elapsed}");
 
                 sw = Stopwatch.StartNew();
-                RPCManager.SetupRPCs();
+                RPCManager.SetupRPCs(referencingAssembliesWithSelf);
                 sw.Stop();
                 RainMeadow.Debug($"RPCManager.SetupRPCs: {sw.Elapsed}");
 


### PR DESCRIPTION
significantly speeds up these two stages of startup by checking only assemblies referencing Rain Meadow for registering those automatically instead of every single loaded assembly, making them take up about 25% less time of RM's OnModsInit

also reduces GetExecutingAssembly calls, removes redundant GetCustomAttribute and ToList calls and removes redundant try blocks

before | after
--- | ---
<img width="801" height="446" alt="image" src="https://github.com/user-attachments/assets/9923eb1a-f93e-40f9-96c9-24e12e64f433" /> | <img width="817" height="489" alt="image" src="https://github.com/user-attachments/assets/ba025deb-8406-4b8d-b23c-63cc0d986a54" />

(look at SetupRPCs and InitializeBuiltinTypes)

also removes OnlineState.RegisterState so technically breaks api/abi but nobody should be using this anyway
