### PR TITLE
feat: add textfile support for whitelisting mods

### DIFF
--- a/Game/MeadowRemixOptions.cs
+++ b/Game/MeadowRemixOptions.cs
@@ -467,6 +467,7 @@ public class RainMeadowOptions : OptionInterface
 
             OpSimpleButton editSyncRequiredModsButton;
             OpSimpleButton editBannedModsButton;
+            OpSimpleButton editWhitelistModsButton;
 
             OpLabel devOptions;
 
@@ -478,9 +479,10 @@ public class RainMeadowOptions : OptionInterface
                 new OpLabel(440f, 535f, Translate("Nightsky Skin")),
 
 
-                new OpLabel(10f, 490f, RWCustom.Custom.ReplaceLineDelimeters(Translate("Control which mods are permitted on clients by editing the files below.<LINE>Instructions included within."))),
+                new OpLabel(10f, 490f, RWCustom.Custom.ReplaceLineDelimeters(Translate("Control which mods are permitted on clients by editing the files below.<LINE>Instructions included within. A non-empty whitelist replaces the other two lists."))),
                 editSyncRequiredModsButton = new OpSimpleButton(new Vector2(10f, 450f), new Vector2(150f, 30f), Translate("Edit High-Impact Mods")),
                 editBannedModsButton = new OpSimpleButton(new Vector2(185f, 450f), new Vector2(150f, 30f), Translate("Edit Banned Mods")),
+                editWhitelistModsButton = new OpSimpleButton(new Vector2(360f, 450f), new Vector2(150f, 30f), Translate("Edit Whitelist")),
 
 
                 new OpLabel(10, 420, Translate("Playtesting Gift")),
@@ -574,6 +576,18 @@ public class RainMeadowOptions : OptionInterface
                 {
                     RainMeadowModManager.GetBannedMods();
                     System.Diagnostics.Process.Start(AssetManager.ResolveFilePath(RainMeadowModManager.BannedOnlineModsFileName));
+                }
+                catch (Exception e)
+                {
+                    RainMeadow.Error(e);
+                }
+            };
+            editWhitelistModsButton.OnClick += _ =>
+            {
+                try
+                {
+                    RainMeadowModManager.GetWhitelistedMods();
+                    System.Diagnostics.Process.Start(AssetManager.ResolveFilePath(RainMeadowModManager.WhitelistedModsFileName));
                 }
                 catch (Exception e)
                 {

--- a/Menu/LobbyInfo.cs
+++ b/Menu/LobbyInfo.cs
@@ -9,7 +9,8 @@ public abstract class LobbyInfo(
     int? maxPlayerCount,
     string highImpactMods = "",
     string bannedMods = "",
-    string activeTimeline = ""
+    string activeTimeline = "",
+    bool whitelistMode = false
 )
 {
     public string name = name,
@@ -20,7 +21,8 @@ public abstract class LobbyInfo(
     public int playerCount = playerCount,
         maxPlayerCount = maxPlayerCount ?? 0;
     public bool hasPassword = hasPassword,
-        pinned;
+        pinned,
+        whitelistMode = whitelistMode;
 
     public abstract string GetLobbyJoinCode(string? password = null);
 }

--- a/Menu/Menus/LobbySelectMenu.cs
+++ b/Menu/Menus/LobbySelectMenu.cs
@@ -247,7 +247,8 @@ public class LobbySelectMenu : SmartMenu
             lobbyInfo.bannedMods.Split('\n'),
             () => RequestJoinLobby(lobbyInfo, password),
             false,
-            lobbyInfo.GetLobbyJoinCode(password)
+            lobbyInfo.GetLobbyJoinCode(password),
+            lobbyInfo.whitelistMode
         );
     }
 

--- a/ModManager/RainMeadowModManager.cs
+++ b/ModManager/RainMeadowModManager.cs
@@ -14,6 +14,7 @@ namespace RainMeadow
         // TODO: possibly rename these
         public static string SyncRequiredModsFileName => "meadow-highimpactmods.txt";
         public static string BannedOnlineModsFileName => "meadow-bannedmods.txt";
+        public static string WhitelistedModsFileName => "meadow-whitelistmods.txt";
 
         public static string SyncRequiredModsExplanationComment =>
             """
@@ -33,6 +34,17 @@ namespace RainMeadow
 
             """;
 
+        public static string WhitelistedModsExplanationComment =>
+            """
+            // Whitelist. While ANY line below is uncommented, this file replaces both
+            // meadow-highimpactmods.txt and meadow-bannedmods.txt entirely.
+            // Clients joining your lobby must run exactly the mods listed here that you also
+            // have enabled, and must disable every other mod they have enabled.
+            // Uncomment a line by removing its leading '//'. Leave every line commented to
+            // disable whitelist mode and go back to the high-impact / banned lists.
+
+            """;
+
         /// <summary>
         /// Prefix that indicates the following characters should be ignored in one of the user defined files.
         /// </summary>
@@ -45,11 +57,22 @@ namespace RainMeadow
                 };
         public static string[] GetRequiredMods()
         {
+            var whitelistedMods = GetWhitelistedMods();
             var modInfo = RainMeadowModInfoManager.MergedModInfo;
+            var generatedSyncRequiredMods = modInfo.SyncRequiredMods.Except(modInfo.SyncRequiredModsOverride).ToList();
 
-            var requiredMods = modInfo.SyncRequiredMods.Except(modInfo.SyncRequiredModsOverride).ToList();
-
-            requiredMods = UpdateFromOrWriteToFile(SyncRequiredModsFileName, requiredMods, SyncRequiredModsExplanationComment);
+            List<string> requiredMods;
+            if (whitelistedMods.Count > 0)
+            {
+                // Whitelist mode: meadow-highimpactmods.txt is ignored, but mods that were
+                // auto-detected as sync-required (e.g. region/level modifiers) still apply,
+                // since skipping them risks a client crash rather than a mismatched mod list.
+                requiredMods = whitelistedMods.Union(generatedSyncRequiredMods).ToList();
+            }
+            else
+            {
+                requiredMods = UpdateFromOrWriteToFile(SyncRequiredModsFileName, generatedSyncRequiredMods, SyncRequiredModsExplanationComment);
+            }
 
             //add dependencies
             foreach (var mod in ModManager.ActiveMods)
@@ -90,6 +113,13 @@ namespace RainMeadow
       
         public static string[] GetBannedMods()
         {
+            if (IsWhitelistActive())
+            {
+                // Whitelist mode ignores meadow-bannedmods.txt; CheckMods derives the disable
+                // list from the required list instead.
+                return [];
+            }
+
             var modInfo = RainMeadowModInfoManager.MergedModInfo;
 
             var syncRequiredMods = modInfo.SyncRequiredMods.Except(modInfo.SyncRequiredModsOverride).ToList();
@@ -106,6 +136,70 @@ namespace RainMeadow
         }
 
         /// <summary>
+        /// Returns the list of mod IDs uncommented in meadow-whitelistmods.txt, creating the file
+        /// (seeded with the currently active mods, all commented out) if it doesn't exist yet.
+        /// </summary>
+        public static List<string> GetWhitelistedMods()
+        {
+            var path = Path.Combine(Custom.RootFolderDirectory(), WhitelistedModsFileName);
+
+            if (!File.Exists(path))
+            {
+                var seedLines = ModIdsToIdAndName(ModManager.ActiveMods.Select(mod => mod.id).ToList())
+                    .Select(line => CommentPrefix + line)
+                    .ToList();
+                seedLines.Insert(0, WhitelistedModsExplanationComment);
+
+                try
+                {
+                    File.WriteAllLines(path, seedLines);
+                }
+                catch (Exception e)
+                {
+                    RainMeadow.Error(e);
+                }
+
+                return [];
+            }
+
+            var whitelistedMods = new List<string>();
+
+            try
+            {
+                foreach (var line in File.ReadAllLines(path))
+                {
+                    if (!TryParseModListLine(line, out var modId, out var isDisabledLine))
+                    {
+                        continue;
+                    }
+
+                    if (isDisabledLine || modId == "")
+                    {
+                        continue;
+                    }
+
+                    whitelistedMods.Add(modId);
+                }
+            }
+            catch (Exception e)
+            {
+                RainMeadow.Error(e);
+                return [];
+            }
+
+            return whitelistedMods.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Whether meadow-whitelistmods.txt has any uncommented entries. When true, the
+        /// high-impact and banned mod lists are ignored and clients must match the whitelist exactly.
+        /// </summary>
+        public static bool IsWhitelistActive()
+        {
+            return GetWhitelistedMods().Count > 0;
+        }
+
+        /// <summary>
         /// Checks the user's mod list with the lobby, and makes his alter his mod list if necessary.
         /// </summary>
         /// <param name="requiredMods">Mods that the user MUST have in order to join the lobby</param>
@@ -113,8 +207,9 @@ namespace RainMeadow
         /// <param name="onFinish">The action to be taken once the mods are successfully applied.</param>
         /// <param name="ignoreReorder">Whether the lobby should accept users with the same mods but in a different order</param>
         /// <param name="restartCode">The code that the restarter will use to attempt to rejoin the lobby after a restart.</param>
+        /// <param name="whitelistMode">Whether the host's lobby is whitelist mode; if true, the user must disable every active mod that isn't in <paramref name="requiredMods"/>, and <paramref name="bannedMods"/> is ignored.</param>
         /// <returns>True if the mods were successfully applied (or didn't need to be applied) AND the game does not require a restart.</returns>
-        internal static void CheckMods(string[] requiredMods, string[] bannedMods, Action? onFinish, bool ignoreReorder = false, string restartCode = "")
+        internal static void CheckMods(string[] requiredMods, string[] bannedMods, Action? onFinish, bool ignoreReorder = false, string restartCode = "", bool whitelistMode = false)
         {
             try
             {
@@ -122,7 +217,9 @@ namespace RainMeadow
                 RainMeadow.Debug($"banned:   [ {string.Join(", ", bannedMods)} ]");
                 var active = ModManager.ActiveMods.Select(mod => mod.id).ToList();
                 bool reorder = true; //or change mods whatsoever
-                var disable = GetRequiredMods().Union(bannedMods).Except(requiredMods).Intersect(active).ToList();
+                var disable = whitelistMode
+                    ? active.Except(requiredMods).ToList()
+                    : GetRequiredMods().Union(bannedMods).Except(requiredMods).Intersect(active).ToList();
                 var enable = requiredMods.Except(active).ToList();
 
                 //clear phony entries to the mod list
@@ -328,28 +425,10 @@ namespace RainMeadow
             // Trim non-leading comments (leading comments will be used to exclude mods)
             foreach (var line in existingLines)
             {
-                if (string.IsNullOrWhiteSpace(line))
+                if (!TryParseModListLine(line, out var trimmedLine, out var isDisabledLine))
                 {
                     linesToWrite.Add(line);
                     continue;
-                }
-
-                var trimmedLine = line.Trim();
-                var isDisabledLine = false;
-
-                // Leading comment disables the whole line
-                if (trimmedLine.StartsWith(CommentPrefix))
-                {
-                    trimmedLine = trimmedLine.TrimStart(CommentPrefix);
-                    isDisabledLine = true;
-                }
-
-                var commentStartIndex = trimmedLine.IndexOf(CommentPrefix, StringComparison.InvariantCulture);
-
-                // Trim any additional (non-leading) comments
-                if (commentStartIndex != -1)
-                {
-                    trimmedLine = string.Concat(trimmedLine.TakeFromTo(0, commentStartIndex)).Trim();
                 }
 
                 // Discard duplicate active lines
@@ -384,6 +463,45 @@ namespace RainMeadow
         private static List<string> ModIdsToIdAndName(List<string> modIds)
         {
             return modIds.Select(x => IsModInstalled(x) ? x + " // " + ModIdToName(x) : x).ToList();
+        }
+
+        /// <summary>
+        /// Parses a single line from one of the user defined mod list files, stripping whitespace,
+        /// a disabling leading comment prefix, and any trailing (e.g. mod name) comment.
+        /// </summary>
+        /// <param name="line">The raw line to parse.</param>
+        /// <param name="modId">The parsed mod id, or "" if <paramref name="line"/> was blank.</param>
+        /// <param name="isDisabledLine">Whether the line had a leading comment prefix (i.e. it's excluded).</param>
+        /// <returns>False if the line was blank and should be left as-is; true otherwise.</returns>
+        private static bool TryParseModListLine(string line, out string modId, out bool isDisabledLine)
+        {
+            modId = "";
+            isDisabledLine = false;
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return false;
+            }
+
+            var trimmedLine = line.Trim();
+
+            // Leading comment disables the whole line
+            if (trimmedLine.StartsWith(CommentPrefix))
+            {
+                trimmedLine = trimmedLine.TrimStart(CommentPrefix);
+                isDisabledLine = true;
+            }
+
+            var commentStartIndex = trimmedLine.IndexOf(CommentPrefix, StringComparison.InvariantCulture);
+
+            // Trim any additional (non-leading) comments
+            if (commentStartIndex != -1)
+            {
+                trimmedLine = string.Concat(trimmedLine.TakeFromTo(0, commentStartIndex)).Trim();
+            }
+
+            modId = trimmedLine;
+            return true;
         }
     }
 }

--- a/ModManager/RainMeadowModManager.cs
+++ b/ModManager/RainMeadowModManager.cs
@@ -479,7 +479,6 @@ namespace RainMeadow
 
             var trimmedLine = line.Trim();
 
-            // Leading comment disables the whole line
             if (trimmedLine.StartsWith(CommentPrefix))
             {
                 trimmedLine = trimmedLine.TrimStart(CommentPrefix);
@@ -488,7 +487,6 @@ namespace RainMeadow
 
             var commentStartIndex = trimmedLine.IndexOf(CommentPrefix, StringComparison.InvariantCulture);
 
-            // Trim any additional  comments
             if (commentStartIndex != -1)
             {
                 trimmedLine = string.Concat(trimmedLine.TakeFromTo(0, commentStartIndex)).Trim();

--- a/ModManager/RainMeadowModManager.cs
+++ b/ModManager/RainMeadowModManager.cs
@@ -36,10 +36,8 @@ namespace RainMeadow
 
         public static string WhitelistedModsExplanationComment =>
             """
-            // Whitelist. While ANY line below is uncommented, this file replaces both
+            // Whitelist. When any line is uncommented, this file replaces both
             // meadow-highimpactmods.txt and meadow-bannedmods.txt entirely.
-            // Clients joining your lobby must run exactly the mods listed here that you also
-            // have enabled, and must disable every other mod they have enabled.
             // Uncomment a line by removing its leading '//'. Leave every line commented to
             // disable whitelist mode and go back to the high-impact / banned lists.
 
@@ -64,9 +62,6 @@ namespace RainMeadow
             List<string> requiredMods;
             if (whitelistedMods.Count > 0)
             {
-                // Whitelist mode: meadow-highimpactmods.txt is ignored, but mods that were
-                // auto-detected as sync-required (e.g. region/level modifiers) still apply,
-                // since skipping them risks a client crash rather than a mismatched mod list.
                 requiredMods = whitelistedMods.Union(generatedSyncRequiredMods).ToList();
             }
             else
@@ -115,8 +110,8 @@ namespace RainMeadow
         {
             if (IsWhitelistActive())
             {
-                // Whitelist mode ignores meadow-bannedmods.txt; CheckMods derives the disable
-                // list from the required list instead.
+                // Whitelist mode ignores meadow-bannedmods.txt and CheckMods gets the disable
+                // list from the required list instead
                 return [];
             }
 
@@ -136,8 +131,8 @@ namespace RainMeadow
         }
 
         /// <summary>
-        /// Returns the list of mod IDs uncommented in meadow-whitelistmods.txt, creating the file
-        /// (seeded with the currently active mods, all commented out) if it doesn't exist yet.
+        /// Returns the list of mod IDs uncommented in meadow-whitelistmods.txt and creates the file
+        /// with all currently active mods all commented out if it doesn't exist yet.
         /// </summary>
         public static List<string> GetWhitelistedMods()
         {
@@ -191,8 +186,8 @@ namespace RainMeadow
         }
 
         /// <summary>
-        /// Whether meadow-whitelistmods.txt has any uncommented entries. When true, the
-        /// high-impact and banned mod lists are ignored and clients must match the whitelist exactly.
+        /// Whether meadow-whitelistmods.txt has any uncommented entries. If true then the
+        /// high impact and banned mod lists are ignored and clients must match the whitelist exactly.
         /// </summary>
         public static bool IsWhitelistActive()
         {
@@ -207,7 +202,7 @@ namespace RainMeadow
         /// <param name="onFinish">The action to be taken once the mods are successfully applied.</param>
         /// <param name="ignoreReorder">Whether the lobby should accept users with the same mods but in a different order</param>
         /// <param name="restartCode">The code that the restarter will use to attempt to rejoin the lobby after a restart.</param>
-        /// <param name="whitelistMode">Whether the host's lobby is whitelist mode; if true, the user must disable every active mod that isn't in <paramref name="requiredMods"/>, and <paramref name="bannedMods"/> is ignored.</param>
+        /// <param name="whitelistMode">Whether the host's lobby is whitelist mode <paramref name="requiredMods"/>, and <paramref name="bannedMods"/> is ignored.</param>
         /// <returns>True if the mods were successfully applied (or didn't need to be applied) AND the game does not require a restart.</returns>
         internal static void CheckMods(string[] requiredMods, string[] bannedMods, Action? onFinish, bool ignoreReorder = false, string restartCode = "", bool whitelistMode = false)
         {
@@ -466,13 +461,12 @@ namespace RainMeadow
         }
 
         /// <summary>
-        /// Parses a single line from one of the user defined mod list files, stripping whitespace,
-        /// a disabling leading comment prefix, and any trailing (e.g. mod name) comment.
+        /// Parses a single line from one of the user defined mod list files
         /// </summary>
-        /// <param name="line">The raw line to parse.</param>
-        /// <param name="modId">The parsed mod id, or "" if <paramref name="line"/> was blank.</param>
-        /// <param name="isDisabledLine">Whether the line had a leading comment prefix (i.e. it's excluded).</param>
-        /// <returns>False if the line was blank and should be left as-is; true otherwise.</returns>
+        /// <param name="line">The raw line to parse</param>
+        /// <param name="modId">The parsed mod id or "" if <paramref name="line"/> was blank</param>
+        /// <param name="isDisabledLine">Whether the line had a leading comment prefix</param>
+        /// <returns>False if the line was blank and should be left alone</returns>
         private static bool TryParseModListLine(string line, out string modId, out bool isDisabledLine)
         {
             modId = "";
@@ -494,7 +488,7 @@ namespace RainMeadow
 
             var commentStartIndex = trimmedLine.IndexOf(CommentPrefix, StringComparison.InvariantCulture);
 
-            // Trim any additional (non-leading) comments
+            // Trim any additional  comments
             if (commentStartIndex != -1)
             {
                 trimmedLine = string.Concat(trimmedLine.TakeFromTo(0, commentStartIndex)).Trim();

--- a/Online/Matchmaking/LANMatchmakingManager.cs
+++ b/Online/Matchmaking/LANMatchmakingManager.cs
@@ -17,8 +17,8 @@ namespace RainMeadow {
     public class LANMatchmakingManager : MatchmakingManager {
         public class LANLobbyInfo : LobbyInfo {
             public IPEndPoint endPoint;
-            public LANLobbyInfo(IPEndPoint endPoint, string name, string mode, int playerCount, bool hasPassword, int maxPlayerCount, string highImpactMods = "", string bannedMods = "", string activeTimeline = "") : 
-                base(name, mode, playerCount, hasPassword, maxPlayerCount, highImpactMods, bannedMods, activeTimeline) {
+            public LANLobbyInfo(IPEndPoint endPoint, string name, string mode, int playerCount, bool hasPassword, int maxPlayerCount, string highImpactMods = "", string bannedMods = "", string activeTimeline = "", bool whitelistMode = false) :
+                base(name, mode, playerCount, hasPassword, maxPlayerCount, highImpactMods, bannedMods, activeTimeline, whitelistMode) {
                 this.endPoint = endPoint;
             }
             public override string GetLobbyJoinCode(string? password = null)
@@ -166,7 +166,8 @@ namespace RainMeadow {
                         OnlineManager.lobby.gameModeType.value, OnlineManager.players.Count,
                         RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetRequiredMods()),
                         RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetBannedMods()),
-                        OnlineManager.lobby.ActiveTimeline
+                        OnlineManager.lobby.ActiveTimeline,
+                        RainMeadowModManager.IsWhitelistActive()
                     );
                     OnlineManager.netIO.SendP2P(other, packet, NetIO.SendType.Unreliable, true);
                 }

--- a/Online/Matchmaking/MatchmakingManager.cs
+++ b/Online/Matchmaking/MatchmakingManager.cs
@@ -48,6 +48,7 @@ namespace RainMeadow
         public static string MODE_KEY = "mode";
         public static string MODS_KEY = "mods";
         public static string BANNED_MODS_KEY = "banned_mods";
+        public static string WHITELIST_KEY = "whitelist";
         public static string PINNED_KEY = "pinned";
         public static string PASSWORD_KEY = "password";
         public static string CAMPAIGN_KEY = "campaign";

--- a/Online/Matchmaking/Packets/InformLobbyPacket.cs
+++ b/Online/Matchmaking/Packets/InformLobbyPacket.cs
@@ -12,9 +12,10 @@ namespace RainMeadow
         public string mods = "";
         public string bannedMods = "";
         public string activeTimeline = "";
+        public bool whitelistMode = false;
 
         public InformLobbyPacket(): base() {}
-        public InformLobbyPacket(int maxplayers, string name, bool passwordprotected, string mode, int currentplayercount, string highImpactMods = "", string bannedMods = "", string activeTimeline = "")
+        public InformLobbyPacket(int maxplayers, string name, bool passwordprotected, string mode, int currentplayercount, string highImpactMods = "", string bannedMods = "", string activeTimeline = "", bool whitelistMode = false)
         {
             this.currentplayercount = currentplayercount;
             this.mode = mode;
@@ -24,6 +25,7 @@ namespace RainMeadow
             this.mods = highImpactMods;
             this.bannedMods = bannedMods;
             this.activeTimeline = activeTimeline;
+            this.whitelistMode = whitelistMode;
         }
 
         public override void Serialize(BinaryWriter writer)
@@ -37,6 +39,7 @@ namespace RainMeadow
             writer.Write(mods);
             writer.Write(bannedMods);
             writer.Write(activeTimeline);
+            writer.Write(whitelistMode);
         }
 
         public override void Deserialize(BinaryReader reader)
@@ -50,6 +53,7 @@ namespace RainMeadow
             mods = reader.ReadString();
             bannedMods = reader.ReadString();
             activeTimeline = reader.ReadString();
+            whitelistMode = reader.ReadBoolean();
         }
 
 
@@ -65,7 +69,7 @@ namespace RainMeadow
 
         public LANMatchmakingManager.LANLobbyInfo MakeLobbyInfo() {
             return new LANMatchmakingManager.LANLobbyInfo(
-                (processingPlayer.id as LANMatchmakingManager.LANPlayerId).endPoint, name, mode, currentplayercount, passwordprotected, maxplayers, mods, bannedMods, activeTimeline); 
+                (processingPlayer.id as LANMatchmakingManager.LANPlayerId).endPoint, name, mode, currentplayercount, passwordprotected, maxplayers, mods, bannedMods, activeTimeline, whitelistMode);
         }
 
     }

--- a/Online/Matchmaking/Packets/JoinLobbyPacket.cs
+++ b/Online/Matchmaking/Packets/JoinLobbyPacket.cs
@@ -3,7 +3,7 @@ namespace RainMeadow
     public class JoinLobbyPacket : InformLobbyPacket
     {
         public JoinLobbyPacket() : base() { }
-        public JoinLobbyPacket(int maxplayers, string name, bool passwordprotected, string mode, int currentplayercount, string highImpactMods = "", string bannedMods = "") : base(maxplayers, name, passwordprotected, mode, currentplayercount, highImpactMods, bannedMods) { }
+        public JoinLobbyPacket(int maxplayers, string name, bool passwordprotected, string mode, int currentplayercount, string highImpactMods = "", string bannedMods = "", bool whitelistMode = false) : base(maxplayers, name, passwordprotected, mode, currentplayercount, highImpactMods, bannedMods, whitelistMode: whitelistMode) { }
         public override Type type => Type.JoinLobby;
 
         public override void Process()

--- a/Online/Matchmaking/Packets/RequestJoinPacket.cs
+++ b/Online/Matchmaking/Packets/RequestJoinPacket.cs
@@ -36,7 +36,8 @@ namespace RainMeadow
                     OnlineManager.lobby.gameModeType.value,
                     OnlineManager.players.Count,
                     RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetRequiredMods()),
-                    RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetBannedMods())
+                    RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetBannedMods()),
+                    RainMeadowModManager.IsWhitelistActive()
                 ), NetIO.SendType.Reliable);
 
             }

--- a/Online/Matchmaking/SteamMatchmakingManager.cs
+++ b/Online/Matchmaking/SteamMatchmakingManager.cs
@@ -10,8 +10,8 @@ namespace RainMeadow
 {
     public class SteamLobbyInfo : LobbyInfo {
         public CSteamID iD;
-        public SteamLobbyInfo(CSteamID id, string name, string mode, int playerCount, bool hasPassword, int? maxPlayerCount, string highImpactMods = "", string bannedMods = "", string activeTimeline = "") : 
-            base(name, mode, playerCount, hasPassword, maxPlayerCount, highImpactMods, bannedMods, activeTimeline) {
+        public SteamLobbyInfo(CSteamID id, string name, string mode, int playerCount, bool hasPassword, int? maxPlayerCount, string highImpactMods = "", string bannedMods = "", string activeTimeline = "", bool whitelistMode = false) :
+            base(name, mode, playerCount, hasPassword, maxPlayerCount, highImpactMods, bannedMods, activeTimeline, whitelistMode) {
             iD = id;
 
 
@@ -137,14 +137,15 @@ namespace RainMeadow
                     {
                         CSteamID id = SteamMatchmaking.GetLobbyByIndex(i);
                         
-                        lobbies[i] = new SteamLobbyInfo(id, 
-                            Utils.GetTranslatedLobbyName(SteamMatchmaking.GetLobbyData(id, NAME_KEY)), 
-                            SteamMatchmaking.GetLobbyData(id, MODE_KEY), SteamMatchmaking.GetNumLobbyMembers(id), 
-                            bool.TryParse(SteamMatchmaking.GetLobbyData(id, PASSWORD_KEY), out var hasPass) && hasPass, 
-                            SteamMatchmaking.GetLobbyMemberLimit(id), 
-                            SteamMatchmaking.GetLobbyData(id, MODS_KEY), 
+                        lobbies[i] = new SteamLobbyInfo(id,
+                            Utils.GetTranslatedLobbyName(SteamMatchmaking.GetLobbyData(id, NAME_KEY)),
+                            SteamMatchmaking.GetLobbyData(id, MODE_KEY), SteamMatchmaking.GetNumLobbyMembers(id),
+                            bool.TryParse(SteamMatchmaking.GetLobbyData(id, PASSWORD_KEY), out var hasPass) && hasPass,
+                            SteamMatchmaking.GetLobbyMemberLimit(id),
+                            SteamMatchmaking.GetLobbyData(id, MODS_KEY),
                             SteamMatchmaking.GetLobbyData(id, BANNED_MODS_KEY),
-                            SteamMatchmaking.GetLobbyData(id, CAMPAIGN_KEY)
+                            SteamMatchmaking.GetLobbyData(id, CAMPAIGN_KEY),
+                            bool.TryParse(SteamMatchmaking.GetLobbyData(id, WHITELIST_KEY), out var isWhitelist) && isWhitelist
                         );
                     }
                 }
@@ -281,6 +282,7 @@ namespace RainMeadow
                     SteamMatchmaking.SetLobbyData(lobbyID, MODE_KEY, creatingWithMode);
                     SteamMatchmaking.SetLobbyData(lobbyID, MODS_KEY, RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetRequiredMods()));
                     SteamMatchmaking.SetLobbyData(lobbyID, BANNED_MODS_KEY, RainMeadowModManager.ModArrayToString(RainMeadowModManager.GetBannedMods()));
+                    SteamMatchmaking.SetLobbyData(lobbyID, WHITELIST_KEY, RainMeadowModManager.IsWhitelistActive() ? "true" : "false");
                     SteamMatchmaking.SetLobbyData(lobbyID, PASSWORD_KEY, lobbyPassword != null ? "true" : "false");
                     SteamMatchmaking.SetLobbyData(lobbyID, PINNED_KEY, creatingPinned? "true" : "false");
                     SteamMatchmaking.SetLobbyMemberLimit(lobbyID, MAX_LOBBY);

--- a/Online/Resource/Lobby.cs
+++ b/Online/Resource/Lobby.cs
@@ -17,6 +17,7 @@ namespace RainMeadow
 
         public string[] requiredmods;
         public string[] bannedmods;
+        public bool whitelistmode;
         public DynamicOrderedPlayerIDs bannedUsers = new();
 
         public bool modsChecked;
@@ -69,6 +70,7 @@ namespace RainMeadow
 
             requiredmods = RainMeadowModManager.GetRequiredMods();
             bannedmods = RainMeadowModManager.GetBannedMods();
+            whitelistmode = RainMeadowModManager.IsWhitelistActive();
 
             this.gameMode = OnlineGameMode.FromType(mode, this);
             this.gameModeType = mode;
@@ -92,6 +94,15 @@ namespace RainMeadow
             {
                 this.password = password;
                 (configurableBools, configurableFloats, configurableInts) = OnlineGameMode.GetHostRemixSettings(this.gameMode);
+
+                if (whitelistmode)
+                {
+                    var unlisted = ModManager.ActiveMods.Select(mod => mod.id).Except(requiredmods).ToList();
+                    if (unlisted.Count > 0)
+                    {
+                        RainMeadow.Error($"Whitelist lobby: host has active mods not on the whitelist, clients will not receive them: [ {string.Join(", ", unlisted)} ]");
+                    }
+                }
             }
             else
             {
@@ -283,6 +294,8 @@ namespace RainMeadow
             public string[] requiredmods;
             [OnlineField]
             public string[] bannedmods;
+            [OnlineField]
+            public bool whitelistmode;
             [OnlineField(nullable = true)]
             public Generics.DynamicOrderedPlayerIDs bannedUsers;
             [OnlineField(nullable = true)]
@@ -307,6 +320,7 @@ namespace RainMeadow
                 inLobbyIds = new(lobby.participants.Select(p => p.inLobbyId).ToList());
                 requiredmods = lobby.requiredmods;
                 bannedmods = lobby.bannedmods;
+                whitelistmode = lobby.whitelistmode;
                 bannedUsers = lobby.bannedUsers;
                 onlineBoolRemixSettings = lobby.configurableBools;
                 onlineFloatRemixSettings = lobby.configurableFloats;
@@ -360,10 +374,11 @@ namespace RainMeadow
                 if (!lobby.modsChecked)
                 {
                     //Made asyncronous so that the game doesn't get totally frozen
-                    Task.Run(() => RainMeadowModManager.CheckMods(requiredmods, bannedmods, null, true));
+                    Task.Run(() => RainMeadowModManager.CheckMods(requiredmods, bannedmods, null, true, whitelistMode: whitelistmode));
 
                     lobby.requiredmods = requiredmods;
                     lobby.bannedmods = bannedmods;
+                    lobby.whitelistmode = whitelistmode;
                     if (ModManager.MMF && lobby.gameMode.nonGameplayRemixSettings != null)
                     {
                         OnlineGameMode.SetClientRemixSettings(onlineBoolRemixSettings, onlineFloatRemixSettings, onlineIntRemixSettings);


### PR DESCRIPTION
Enables users to specify a whitelist of mods, preventing any "client-sided" mods.  Primary use cases are:

1. Users wanting 1-1 parity 
2. Tighter competitive scene


- [x] Playtest