### PR TITLE
fix: arena stat offset midquit

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -2262,26 +2262,30 @@ namespace RainMeadow
                         return;
                     }
 
-                    for (int i = 0; i < arena.arenaSittingOnlineOrder.Count; i++)
+                    if (OnlineManager.lobby.isOwner)
                     {
-                        OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByLobbyId(
-                            arena.arenaSittingOnlineOrder[i]
-                        );
-
-                        if (onlinePlayer != null && !onlinePlayer.isMe)
+                        for (int i = 0; i < arena.arenaSittingOnlineOrder.Count; i++)
                         {
-                            if (OnlineManager.lobby.isOwner)
+                            ushort lobbyId = arena.arenaSittingOnlineOrder[i];
+                            if (arena.playersQuitMidRound.Contains(lobbyId))
+                            {
+                                continue; // already left the round; they have no session to end
+                            }
+
+                            OnlinePlayer? onlinePlayer = ArenaHelpers.FindOnlinePlayerByLobbyId(lobbyId);
+
+                            if (onlinePlayer != null && !onlinePlayer.isMe)
                             {
                                 onlinePlayer.InvokeOnceRPC(ArenaRPCs.Arena_EndSessionEarly);
                             }
-                            else
-                            {
-                                onlinePlayer.InvokeOnceRPC(
-                                    ArenaRPCs.Arena_RemovePlayerWhoQuit,
-                                    OnlineManager.mePlayer
-                                );
-                            }
                         }
+                    }
+                    else
+                    {
+                        OnlineManager.lobby.owner.InvokeOnceRPC(
+                            ArenaRPCs.Arena_RemovePlayerWhoQuit,
+                            OnlineManager.mePlayer
+                        );
                     }
 
                     if (OnlineManager.lobby.isOwner)

--- a/Arena/ArenaLobbyData.cs
+++ b/Arena/ArenaLobbyData.cs
@@ -184,6 +184,9 @@ namespace RainMeadow
             [OnlineField(group = "arenaGameplay")]
             public List<ushort> playersLateWaitingInLobby;
 
+            [OnlineField(group = "arenaGameplay")]
+            public List<ushort> playersQuitMidRound;
+
             [OnlineField(nullable = true, group = "arenaGameplay")]
             public Generics.DynamicOrderedPlayerIDs reigningChamps;
 
@@ -282,6 +285,7 @@ namespace RainMeadow
                 );
 
                 playersLateWaitingInLobby = new List<ushort>(arenaOnline.playersLateWaitingInLobbyForNextRound);
+                playersQuitMidRound = new List<ushort>(arenaOnline.playersQuitMidRound);
 
                 playersChoosingSlugs = new Dictionary<string, int>(arenaOnline.playersInLobbyChoosingSlugs);
                 countdownSafetyCatchTimer = arenaOnline.countdownSafetyCatchTimer;
@@ -402,6 +406,7 @@ namespace RainMeadow
                 );
 
                 arenaOnline.playersLateWaitingInLobbyForNextRound = playersLateWaitingInLobby;
+                arenaOnline.playersQuitMidRound = playersQuitMidRound;
 
                 arenaOnline.countdownSafetyCatchTimer = countdownSafetyCatchTimer;
                 arenaOnline.countdownInitiatedHoldFire = countdownInitiatedHoldFire;

--- a/Arena/ArenaLobbyMenu.cs
+++ b/Arena/ArenaLobbyMenu.cs
@@ -550,7 +550,7 @@ namespace RainMeadow
                     if (!arena.playersLateWaitingInLobbyForNextRound.Contains(OnlineManager.mePlayer.inLobbyId)) // lobby's locked up, you don't have permission to rejoin, you haven't asked to be queued
                     {
                         if (arena.arenaSittingOnlineOrder.Contains(OnlineManager.mePlayer.inLobbyId)
-                            && !arena.playersQuitMidRound.Contains(OnlineManager.mePlayer.inLobbyId)) // normal. Quitters stay in the sitting order until NextLevel, so check both.
+                            && !arena.playersQuitMidRound.Contains(OnlineManager.mePlayer.inLobbyId)) 
                         {
                             // noop
                         }

--- a/Arena/ArenaLobbyMenu.cs
+++ b/Arena/ArenaLobbyMenu.cs
@@ -549,7 +549,8 @@ namespace RainMeadow
 
                     if (!arena.playersLateWaitingInLobbyForNextRound.Contains(OnlineManager.mePlayer.inLobbyId)) // lobby's locked up, you don't have permission to rejoin, you haven't asked to be queued
                     {
-                        if (arena.arenaSittingOnlineOrder.Contains(OnlineManager.mePlayer.inLobbyId)) // normal. You should be removed when you quit back to lobby or on next level if you're missing
+                        if (arena.arenaSittingOnlineOrder.Contains(OnlineManager.mePlayer.inLobbyId)
+                            && !arena.playersQuitMidRound.Contains(OnlineManager.mePlayer.inLobbyId)) // normal. Quitters stay in the sitting order until NextLevel, so check both.
                         {
                             // noop
                         }

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -171,14 +171,15 @@ namespace RainMeadow
 
             for (int i = arenaOnline.arenaSittingOnlineOrder.Count - 1; i >= 0; i--)
             {
-                OnlinePlayer? missingPlayer = ArenaHelpers.FindOnlinePlayerByLobbyId(
-                    arenaOnline.arenaSittingOnlineOrder[i]
-                );
-                if (missingPlayer == null)
+                ushort lobbyId = arenaOnline.arenaSittingOnlineOrder[i];
+                if (ArenaHelpers.FindOnlinePlayerByLobbyId(lobbyId) is null
+                    || arenaOnline.playersQuitMidRound.Contains(lobbyId))
                 {
                     arenaOnline.arenaSittingOnlineOrder.RemoveAt(i);
                 }
             }
+
+            arenaOnline.playersQuitMidRound.Clear();
 
             if (RoomSession.map.TryGetValue(abstractRoom, out var roomSession))
             {
@@ -1242,16 +1243,18 @@ namespace RainMeadow
                 .Count(settings =>
                     settings!.playingAs == RainMeadow.Ext_SlugcatStatsName.OnlineOverseerSpectator
                 );
+            int sittingPlayerCount =
+                arenaOnline.arenaSittingOnlineOrder.Count - arenaOnline.playersQuitMidRound.Count;
             if (
                 self.Players.Count + activePlayerCountWithOverseers
-                != arenaOnline.arenaSittingOnlineOrder.Count
+                != sittingPlayerCount
             )
             {
                 RainMeadow.Trace(
-                    $"Arena: Abstract Creature count does not equal registered players in the online Sitting! AC Count: {self.Players.Count} | ArenaSittingOnline Count: {arenaOnline.arenaSittingOnlineOrder.Count}"
+                    $"Arena: Abstract Creature count does not equal registered players in the online Sitting! AC Count: {self.Players.Count} | ArenaSittingOnline Count: {sittingPlayerCount}"
                 );
 
-                var extraPlayers = self.Players.Skip(arenaOnline.arenaSittingOnlineOrder.Count).ToList();
+                var extraPlayers = self.Players.Skip(sittingPlayerCount).ToList();
 
                 self.Players.RemoveAll(p => extraPlayers.Contains(p));
 
@@ -1276,7 +1279,7 @@ namespace RainMeadow
             {
                 arenaOnline.playersEqualToOnlineSitting =
                     self.Players.Count + activePlayerCountWithOverseers
-                    == arenaOnline.arenaSittingOnlineOrder.Count;
+                    == sittingPlayerCount;
             }
 
             if (!self.sessionEnded)

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1236,15 +1236,24 @@ namespace RainMeadow
             }
 
             int activePlayerCountWithOverseers = arenaOnline
-                .arenaSittingOnlineOrder.Select(id => ArenaHelpers.FindOnlinePlayerByLobbyId(id)) // Get the player
+                .arenaSittingOnlineOrder.Where(id => !arenaOnline.playersQuitMidRound.Contains(id)) // Skip mid-round quitters, as sittingPlayerCount does
+                .Select(id => ArenaHelpers.FindOnlinePlayerByLobbyId(id)) // Get the player
                 .Where(player => player != null) // Ensure player exists
                 .Select(player => ArenaHelpers.GetArenaClientSettings(player)) // Get settings
                 .Where(settings => settings != null) // Ensure settings exist
                 .Count(settings =>
                     settings!.playingAs == RainMeadow.Ext_SlugcatStatsName.OnlineOverseerSpectator
                 );
-            int sittingPlayerCount =
-                arenaOnline.arenaSittingOnlineOrder.Count - arenaOnline.playersQuitMidRound.Count;
+            if (arenaOnline.playersQuitMidRound.Count > 0)
+            {
+                self.Players.RemoveAll(ac =>
+                    ac?.GetOnlineCreature()?.owner is OnlinePlayer owner
+                    && arenaOnline.playersQuitMidRound.Contains(owner.inLobbyId)
+                );
+            }
+            int sittingPlayerCount = arenaOnline.arenaSittingOnlineOrder.Count(id =>
+                !arenaOnline.playersQuitMidRound.Contains(id)
+            );
             if (
                 self.Players.Count + activePlayerCountWithOverseers
                 != sittingPlayerCount
@@ -1258,12 +1267,13 @@ namespace RainMeadow
 
                 self.Players.RemoveAll(p => extraPlayers.Contains(p));
 
-                foreach (
-                    var playerAvatar in OnlineManager.lobby.playerAvatars.Select(kv => kv.Value)
-                )
+                foreach (var avatarEntry in OnlineManager.lobby.playerAvatars)
                 {
+                    var playerAvatar = avatarEntry.Value;
                     if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none)
                         continue; // not in game
+                    if (arenaOnline.playersQuitMidRound.Contains(avatarEntry.Key.inLobbyId))
+                        continue; // quit mid-round; their avatar may linger a few frames
                     if (
                         playerAvatar.FindEntity(true) is OnlinePhysicalObject opo
                         && opo.apo is AbstractCreature ac

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -1273,7 +1273,7 @@ namespace RainMeadow
                     if (playerAvatar.type == (byte)OnlineEntity.EntityId.IdType.none)
                         continue; // not in game
                     if (arenaOnline.playersQuitMidRound.Contains(avatarEntry.Key.inLobbyId))
-                        continue; // quit mid-round; their avatar may linger a few frames
+                        continue; // avatar may linger a few frames after quit
                     if (
                         playerAvatar.FindEntity(true) is OnlinePhysicalObject opo
                         && opo.apo is AbstractCreature ac

--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -251,7 +251,7 @@ namespace RainMeadow
                 [
                     .. OnlineManager.players.Where(x =>
                         ArenaHelpers.GetArenaClientSettings(x)?.ready == true && !x.isMe
-                    ),
+                    ).OrderBy(x => x.inLobbyId),
                 ];
 
                 self.players.Clear();
@@ -285,16 +285,22 @@ namespace RainMeadow
                     {
                         if (player != null) // always gotta check in case something happened to them
                         {
-                            if (
-                                !arenaOnline.arenaSittingOnlineOrder.Contains(player.inLobbyId)
-                                && OnlineManager.lobby.isOwner
-                            )
+                            int sittingIndex = arenaOnline.arenaSittingOnlineOrder.IndexOf(
+                                player.inLobbyId
+                            );
+                            if (sittingIndex < 0)
                             {
                                 arenaOnline.arenaSittingOnlineOrder.Add(player.inLobbyId);
+                                sittingIndex = arenaOnline.arenaSittingOnlineOrder.Count - 1;
                             }
-                            ArenaSitting.ArenaPlayer newArenaPlayer = new(
-                                arenaOnline.arenaSittingOnlineOrder.Count - 1
-                            )
+                            if (self.players.Any(p => p.playerNumber == sittingIndex))
+                            {
+                                RainMeadow.Error(
+                                    $"Arena: duplicate player number {sittingIndex} for {player}"
+                                );
+                                continue;
+                            }
+                            ArenaSitting.ArenaPlayer newArenaPlayer = new(sittingIndex)
                             {
                                 playerClass = ArenaHelpers
                                     .GetArenaClientSettings(player)!

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -70,7 +70,7 @@ namespace RainMeadow
                 );
                 return;
             }
-            if (ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arenaOnline, playerNumber)is not OnlinePlayer onlinePlayer)
+            if (ArenaHelpers.FindOnlinePlayerByFakePlayerNumber(arenaOnline, playerNumber) is not OnlinePlayer onlinePlayer)
             {
                 RainMeadow.Warn($"Unable to find online player with player number {playerNumber}.");
                 return;
@@ -266,10 +266,10 @@ namespace RainMeadow
         {
             if (RainMeadow.isArenaMode(out var arena))
             {
-                if (arena.lobby.isOwner
-                    && arena.arenaSittingOnlineOrder.Contains(earlyQuitterOrLatecomer.inLobbyId))
+                if (arena.arenaSittingOnlineOrder.Contains(earlyQuitterOrLatecomer.inLobbyId)
+                    && !arena.playersQuitMidRound.Contains(earlyQuitterOrLatecomer.inLobbyId))
                 {
-                    arena.arenaSittingOnlineOrder.Remove(earlyQuitterOrLatecomer.inLobbyId); // you'll add them in NextLevel
+                    arena.playersQuitMidRound.Add(earlyQuitterOrLatecomer.inLobbyId);
                 }
                 int removedPlayers = arena.ArenaSession?.Players?.RemoveAll(
                     x => x.GetOnlineCreature()?.owner == earlyQuitterOrLatecomer) ?? 0;

--- a/Arena/ArenaRPCs.cs
+++ b/Arena/ArenaRPCs.cs
@@ -266,14 +266,13 @@ namespace RainMeadow
         {
             if (RainMeadow.isArenaMode(out var arena))
             {
-                if (arena.arenaSittingOnlineOrder.Contains(earlyQuitterOrLatecomer.inLobbyId)
+                if (arena.lobby.isOwner
+                    && arena.arenaSittingOnlineOrder.Contains(earlyQuitterOrLatecomer.inLobbyId)
                     && !arena.playersQuitMidRound.Contains(earlyQuitterOrLatecomer.inLobbyId))
                 {
-                    arena.playersQuitMidRound.Add(earlyQuitterOrLatecomer.inLobbyId);
+                    arena.playersQuitMidRound.Add(earlyQuitterOrLatecomer.inLobbyId); // clients receive this via ArenaLobbyData
+                    RainMeadow.Debug($"{earlyQuitterOrLatecomer} quit mid-round");
                 }
-                int removedPlayers = arena.ArenaSession?.Players?.RemoveAll(
-                    x => x.GetOnlineCreature()?.owner == earlyQuitterOrLatecomer) ?? 0;
-                RainMeadow.Debug($"Removed {removedPlayers} players from {earlyQuitterOrLatecomer} who quitted!");
             }
         }
 

--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -466,8 +466,11 @@ namespace RainMeadow
                 });
                 c.Emit(OpCodes.Brtrue, skipVanilla);
 
-                c.GotoNext(i => i.MatchLdfld<VirtualMicrophone>(nameof(VirtualMicrophone.deaf)));
-                c.GotoPrev(i => i.MatchLdarg(0));
+                c.GotoNext(MoveType.Before,
+                    i => i.MatchLdarg(0),
+                    i => i.MatchLdarg(0),
+                    i => i.MatchLdfld<VirtualMicrophone>(nameof(VirtualMicrophone.deaf))
+                    );
                 c.MarkLabel(skipVanilla);
             }
             catch (Exception e)

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -1185,10 +1185,10 @@ namespace RainMeadow
                 RainMeadow.Debug($"{onlinePlayer} left mid-round; recording as a quitter");
             }
 
-            if (ArenaSession is ArenaGameSession arenaSession)
-            {
-                arenaSession.Players.RemoveAll(ac => ac?.GetOnlineCreature()?.owner == onlinePlayer);
-            }
+            if (ArenaSession is not null) 
+             { 
+                 ArenaSession.Players.RemoveAll(ac => ac?.GetOnlineCreature()?.owner == onlinePlayer); 
+             }
 
             base.PlayerLeftLobby(onlinePlayer);
         }

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -1176,6 +1176,20 @@ namespace RainMeadow
             AllKillsByOPlayer.Remove(onlinePlayer);
             RoundKillsByOPlayer.Remove(onlinePlayer);
 
+            if (OnlineManager.lobby.isOwner
+                && isInGame
+                && arenaSittingOnlineOrder.Contains(onlinePlayer.inLobbyId)
+                && !playersQuitMidRound.Contains(onlinePlayer.inLobbyId))
+            {
+                playersQuitMidRound.Add(onlinePlayer.inLobbyId); // clients receive this via ArenaLobbyData
+                RainMeadow.Debug($"{onlinePlayer} left mid-round; recording as a quitter");
+            }
+
+            if (ArenaSession is ArenaGameSession arenaSession)
+            {
+                arenaSession.Players.RemoveAll(ac => ac?.GetOnlineCreature()?.owner == onlinePlayer);
+            }
+
             base.PlayerLeftLobby(onlinePlayer);
         }
 

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -164,6 +164,7 @@ namespace RainMeadow
         public bool shufflePlayList;
         public List<string> playList = [];
         public List<ushort> arenaSittingOnlineOrder = [];
+        public List<ushort> playersQuitMidRound = [];
         public List<ushort> playersLateWaitingInLobbyForNextRound = [];
         public List<int> bannedSlugs = [];
 
@@ -700,14 +701,15 @@ namespace RainMeadow
 
             for (int i = arenaSittingOnlineOrder.Count - 1; i >= 0; i--)
             {
-                OnlinePlayer? missingPlayer = ArenaHelpers.FindOnlinePlayerByLobbyId(
-                    arenaSittingOnlineOrder[i]
-                );
-                if (missingPlayer is null)
+                ushort lobbyId = arenaSittingOnlineOrder[i];
+                if (ArenaHelpers.FindOnlinePlayerByLobbyId(lobbyId) is null
+                    || playersQuitMidRound.Contains(lobbyId))
                 {
                     arenaSittingOnlineOrder.RemoveAt(i);
                 }
             }
+
+            playersQuitMidRound.Clear();
 
             AbstractRoom absRoom = game.world.abstractRooms[0];
             Room room = absRoom.realizedRoom;
@@ -955,6 +957,7 @@ namespace RainMeadow
             }
             currentLevel = 0;
             arenaSittingOnlineOrder.Clear();
+            playersQuitMidRound.Clear();
             playersReadiedUp.list.Clear();
             playersLateWaitingInLobbyForNextRound.Clear();
         }
@@ -981,6 +984,7 @@ namespace RainMeadow
             if (OnlineManager.lobby.isOwner)
             {
                 arenaSittingOnlineOrder.Clear();
+                playersQuitMidRound.Clear();
                 ClearAllLobbyDataStats();
             }
         }

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -764,7 +764,7 @@ namespace RainMeadow
             [
                 .. OnlineManager.players.Where(x =>
                     ArenaHelpers.GetArenaClientSettings(x)?.ready == true && !x.isMe
-                ),
+                ).OrderBy(x => x.inLobbyId),
             ];
             arenaSitting.players.Clear();
             for (int i = 0; i < arenaSittingOnlineOrder.Count; i++)
@@ -798,16 +798,20 @@ namespace RainMeadow
                 {
                     if (player != null) // always gotta check in case something happened to them
                     {
-                        if (
-                            !arenaSittingOnlineOrder.Contains(player.inLobbyId)
-                            && OnlineManager.lobby.isOwner
-                        )
+                        int sittingIndex = arenaSittingOnlineOrder.IndexOf(player.inLobbyId);
+                        if (sittingIndex < 0)
                         {
                             arenaSittingOnlineOrder.Add(player.inLobbyId);
+                            sittingIndex = arenaSittingOnlineOrder.Count - 1;
                         }
-                        ArenaSitting.ArenaPlayer newArenaPlayer = new(
-                            arenaSittingOnlineOrder.Count - 1
-                        )
+                        if (arenaSitting.players.Any(p => p.playerNumber == sittingIndex))
+                        {
+                            RainMeadow.Error(
+                                $"Arena: duplicate player number {sittingIndex} for {player}"
+                            );
+                            continue;
+                        }
+                        ArenaSitting.ArenaPlayer newArenaPlayer = new(sittingIndex)
                         {
                             playerClass = ArenaHelpers.GetArenaClientSettings(player)!.playingAs,
                             hasEnteredGameArea = true,

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -436,6 +436,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
                 Arena.hasPermissionToRejoin
                 && !initiateStartGameAfterCountDown
                 && Arena.arenaClientSettings.ready
+                && !Arena.playersQuitMidRound.Contains(OnlineManager.mePlayer.inLobbyId) // quit this round; wait for the next one
             )
             {
                 initiateStartGameAfterCountDown = true;


### PR DESCRIPTION
Updates mid game quits to:
- block re-entering on same round
- Clients now read from lobby state of quit users
- Avatars are removed during the PlayerQuit RPC


- [x] tested