### PR TITLE
story: fix watcher ripple race condition

### DIFF
--- a/Game/RainMeadow.GameplayHooks.cs
+++ b/Game/RainMeadow.GameplayHooks.cs
@@ -466,8 +466,11 @@ namespace RainMeadow
                 });
                 c.Emit(OpCodes.Brtrue, skipVanilla);
 
-                c.GotoNext(i => i.MatchLdfld<VirtualMicrophone>(nameof(VirtualMicrophone.deaf)));
-                c.GotoPrev(i => i.MatchLdarg(0));
+                c.GotoNext(MoveType.Before,
+                    i => i.MatchLdarg(0),
+                    i => i.MatchLdarg(0),
+                    i => i.MatchLdfld<VirtualMicrophone>(nameof(VirtualMicrophone.deaf))
+                    );
                 c.MarkLabel(skipVanilla);
             }
             catch (Exception e)

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -53,6 +53,8 @@ namespace RainMeadow
         public float maximumRippleLevel;
         public List<int> spinningTopEncounters = new();
 
+        public Dictionary<int, Vector2> hostRippleRaiser = new();
+
         public List<AbstractCreature> pups;
 
         public StoryLobbyData.MenuSaveStateState? menuSaveState;
@@ -82,6 +84,7 @@ namespace RainMeadow
             minimumRippleLevel = 0.0f;
             maximumRippleLevel = 0.0f;
             spinningTopEncounters = new();
+            hostRippleRaiser = new();
             this.ResetOverWorld();
 
         }

--- a/GameModes/StoryGameMode.cs
+++ b/GameModes/StoryGameMode.cs
@@ -52,6 +52,8 @@ namespace RainMeadow
         public float minimumRippleLevel;
         public float maximumRippleLevel;
         public List<int> spinningTopEncounters = new();
+        public uint campaignGeneration = 0;
+        public string? appliedSaveStateString = null;
 
         public Dictionary<int, Vector2> hostRippleRaiser = new();
 
@@ -84,6 +86,7 @@ namespace RainMeadow
             minimumRippleLevel = 0.0f;
             maximumRippleLevel = 0.0f;
             spinningTopEncounters = new();
+            appliedSaveStateString = null;
             hostRippleRaiser = new();
             this.ResetOverWorld();
 

--- a/Story/StoryHelpers.cs
+++ b/Story/StoryHelpers.cs
@@ -37,6 +37,27 @@ namespace RainMeadow
             return added;
         }
 
+
+        public static int ResolveSpinningTopID(Room room)
+        {
+            if (room?.updateList == null) return -1;
+
+            Watcher.SpinningTop? found = null;
+            int count = 0;
+            foreach (var uad in room.updateList)
+            {
+                if (uad is Watcher.SpinningTop spinningTop)
+                {
+                    count++;
+                    found ??= spinningTop;
+                }
+            }
+            if (count > 1) RainMeadow.Error($"multiple SpinningTops found in room {room.abstractRoom?.name}, using the first");
+
+            if (found?.SpecialData is Watcher.SpinningTopData specialData) return specialData.spawnIdentifier;
+            return -1;
+        }
+
         public static void SaveEchoWarp(RainWorldGame game, WarpPoint warpPoint, bool saveRoomWarp = false, bool saveString = false)
         {
             var warpData = warpPoint.overrideData ?? warpPoint.Data;

--- a/Story/StoryHelpers.cs
+++ b/Story/StoryHelpers.cs
@@ -44,7 +44,7 @@ namespace RainMeadow
 
             Watcher.SpinningTop? found = null;
             int count = 0;
-            foreach (var uad in room.updateList)
+            foreach (UpdatableAndDeletable uad in room.updateList)
             {
                 if (uad is Watcher.SpinningTop spinningTop)
                 {

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -430,40 +430,64 @@ namespace RainMeadow
             }
         }
 
-        // Static method, fortunely, means we dont have to worry about keeping track of a spinning top (echo)
+
         public void SpinningTop_RaiseRippleLevel(On.Watcher.SpinningTop.orig_RaiseRippleLevel orig, Room room)
         {
-            orig(room);
-            if (RainMeadow.isStoryMode(out var story))
+            if (!RainMeadow.isStoryMode(out var story)) { orig(room); return; }
+            if (room.game.session is not StoryGameSession storySession)
             {
-                if (room.game.session is not StoryGameSession storySession)
-                {
-                    Error("echo raised ripple level outside of a story session?");
-                    return;
-                }
-                var deathPersistentSaveData = storySession.saveState.deathPersistentSaveData;
-                var vector = new UnityEngine.Vector2(
-                    deathPersistentSaveData.minimumRippleLevel,
-                    deathPersistentSaveData.maximumRippleLevel
-                );
+                Error("echo raised ripple level outside of a story session?");
+                orig(room);
+                return;
+            }
 
-                if (OnlineManager.lobby.isOwner)
-                {
-                    story.rippleLevel = deathPersistentSaveData.rippleLevel;
-                    story.minimumRippleLevel = deathPersistentSaveData.minimumRippleLevel;
-                    story.maximumRippleLevel = deathPersistentSaveData.maximumRippleLevel;
-                }
-                else if (story.rippleLevel < vector.y)
-                {
-                    OnlineManager.lobby.owner.InvokeOnceRPC(StoryRPCs.RaiseRippleLevel, vector);
-                }
+            int spinningTopID = StoryHelpers.ResolveSpinningTopID(room);
+            if (spinningTopID != -1 && story.spinningTopEncounters.Contains(spinningTopID))
+            {
+                Debug($"skipping duplicate ripple raise for spinning top {spinningTopID}");
+                StoryRPCs.ApplyRippleLevelToSaveState(storySession,
+                    new UnityEngine.Vector2(story.minimumRippleLevel, story.maximumRippleLevel));
+                return; // block orig
+            }
 
+            if (spinningTopID != -1)
+            {
+                StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
                 foreach (OnlinePlayer player in OnlineManager.players)
                 {
-                    if (!player.isMe)
-                    {
-                        player.InvokeOnceRPC(StoryRPCs.PlayRaiseRippleLevelAnimation, vector);
-                    }
+                    if (!player.isMe) player.InvokeOnceRPC(StoryRPCs.AddSpinningTopEncounter, spinningTopID);
+                }
+            }
+            else
+            {
+                Error("could not resolve spinning top id for ripple raise; falling back to legacy path");
+            }
+
+            var d = storySession.saveState.deathPersistentSaveData;
+            Debug($"[ripple] pre-orig  me={OnlineManager.mePlayer} owner={OnlineManager.lobby.isOwner} echo={spinningTopID} " +
+                  $"room={room.abstractRoom?.name} ripple={d.rippleLevel} min={d.minimumRippleLevel} max={d.maximumRippleLevel}");
+
+            orig(room);
+
+            Debug($"[ripple] post-orig ripple={d.rippleLevel} min={d.minimumRippleLevel} max={d.maximumRippleLevel}");
+
+            var vector = new UnityEngine.Vector2(d.minimumRippleLevel, d.maximumRippleLevel);
+
+            if (OnlineManager.lobby.isOwner)
+            {
+
+                StoryRPCs.DetermineRippleRaise(story, spinningTopID, vector);
+            }
+            else if (story.maximumRippleLevel < vector.y) // max vs max, not current vs max — see 06
+            {
+                OnlineManager.lobby.owner.InvokeOnceRPC(StoryRPCs.RaiseRippleLevelRequest, spinningTopID, vector);
+            }
+
+            foreach (OnlinePlayer player in OnlineManager.players)
+            {
+                if (!player.isMe)
+                {
+                    player.InvokeOnceRPC(StoryRPCs.PlayRaiseRippleLevelAnimation, spinningTopID, vector);
                 }
             }
         }

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -433,7 +433,7 @@ namespace RainMeadow
 
         public void SpinningTop_RaiseRippleLevel(On.Watcher.SpinningTop.orig_RaiseRippleLevel orig, Room room)
         {
-            if (!RainMeadow.isStoryMode(out var story)) { orig(room); return; }
+            if (!RainMeadow.isStoryMode(out StoryGameMode story)) { orig(room); return; }
             if (room.game.session is not StoryGameSession storySession)
             {
                 Error("echo raised ripple level outside of a story session?");
@@ -463,11 +463,11 @@ namespace RainMeadow
                 Error("could not resolve spinning top id for ripple raise; skipping duplicate-encounter dedupe and echo bookkeeping for this raise");
             }
 
-            var d = storySession.saveState.deathPersistentSaveData;
+            DeathPersistentSaveData d = storySession.saveState.deathPersistentSaveData;
 
             orig(room);
 
-            var vector = new UnityEngine.Vector2(d.minimumRippleLevel, d.maximumRippleLevel);
+            Vector2 vector = new UnityEngine.Vector2(d.minimumRippleLevel, d.maximumRippleLevel);
 
             if (OnlineManager.lobby.isOwner)
             {

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -460,35 +460,22 @@ namespace RainMeadow
             }
             else
             {
-                Error("could not resolve spinning top id for ripple raise; falling back to legacy path");
+                Error("could not resolve spinning top id for ripple raise; skipping duplicate-encounter dedupe and echo bookkeeping for this raise");
             }
 
             var d = storySession.saveState.deathPersistentSaveData;
-            Debug($"[ripple] pre-orig  me={OnlineManager.mePlayer} owner={OnlineManager.lobby.isOwner} echo={spinningTopID} " +
-                  $"room={room.abstractRoom?.name} ripple={d.rippleLevel} min={d.minimumRippleLevel} max={d.maximumRippleLevel}");
 
             orig(room);
-
-            Debug($"[ripple] post-orig ripple={d.rippleLevel} min={d.minimumRippleLevel} max={d.maximumRippleLevel}");
 
             var vector = new UnityEngine.Vector2(d.minimumRippleLevel, d.maximumRippleLevel);
 
             if (OnlineManager.lobby.isOwner)
             {
-
-                StoryRPCs.DetermineRippleRaise(story, spinningTopID, vector);
+                StoryRPCs.DetermineRippleRaise(story, spinningTopID, vector, trustVector: true);
             }
             else if (story.maximumRippleLevel < vector.y) // max vs max, not current vs max — see 06
             {
                 OnlineManager.lobby.owner.InvokeOnceRPC(StoryRPCs.RaiseRippleLevelRequest, spinningTopID, vector);
-            }
-
-            foreach (OnlinePlayer player in OnlineManager.players)
-            {
-                if (!player.isMe)
-                {
-                    player.InvokeOnceRPC(StoryRPCs.PlayRaiseRippleLevelAnimation, spinningTopID, vector);
-                }
             }
         }
 

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -455,7 +455,7 @@ namespace RainMeadow
                 StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
                 foreach (OnlinePlayer player in OnlineManager.players)
                 {
-                    if (!player.isMe) player.InvokeOnceRPC(StoryRPCs.AddSpinningTopEncounter, spinningTopID);
+                    if (!player.isMe) player.InvokeOnceRPC(StoryRPCs.AddSpinningTopEncounter, story.campaignGeneration, spinningTopID);
                 }
             }
             else
@@ -1823,6 +1823,7 @@ namespace RainMeadow
                 var hostSaveState = new SaveState(self.currentSaveState.saveStateNumber, self);
                 hostSaveState.LoadGame(InflateJoarXML(storyGameMode.saveStateString ?? ""), game);
                 self.currentSaveState = ApplyClientSaveState(hostSaveState, self.currentSaveState);
+                storyGameMode.appliedSaveStateString = storyGameMode.saveStateString;
             }
 
             RainMeadow.Debug($"START DENPOS save:{self.currentSaveState.denPosition} last:{storyGameMode.myLastDenPos} lobby:{storyGameMode.defaultDenPos}");

--- a/Story/StoryLobbyData.cs
+++ b/Story/StoryLobbyData.cs
@@ -76,6 +76,8 @@ namespace RainMeadow
             public float maximumRippleLevel;
             [OnlineField]
             public List<int> spinningTopEncounters;
+            [OnlineField]
+            public uint campaignGeneration;
 
             [OnlineField(nullable = true)]
             public MenuSaveStateState? currentMenuSaveState;
@@ -123,6 +125,7 @@ namespace RainMeadow
                 minimumRippleLevel = storyGameMode.minimumRippleLevel;
                 maximumRippleLevel = storyGameMode.maximumRippleLevel;
                 spinningTopEncounters = new(storyGameMode.spinningTopEncounters); // copy, the state outlives this tick
+                campaignGeneration = storyGameMode.campaignGeneration;
 
                 food = (currentGameState?.Players[0].state as PlayerState)?.foodInStomach ?? 0;
                 quarterfood = (currentGameState?.Players[0].state as PlayerState)?.quarterFoodPoints ?? 0;
@@ -153,6 +156,7 @@ namespace RainMeadow
                 story.minimumRippleLevel = minimumRippleLevel;
                 story.maximumRippleLevel = maximumRippleLevel;
                 story.spinningTopEncounters = new(spinningTopEncounters);
+                story.campaignGeneration = campaignGeneration;
 
                 if (currentGameState is not null)
                 {
@@ -200,11 +204,18 @@ namespace RainMeadow
                     {
                         if (!localEncounters.Contains(encounter)) localEncounters.Add(encounter);
                     }
-                    foreach (int encounter in localEncounters)
+                    bool saveSynced = story.appliedSaveStateString != null
+                        && saveStateString != null
+                        && story.appliedSaveStateString == saveStateString;
+
+                    if (saveSynced)
                     {
-                        if (spinningTopEncounters.Contains(encounter)) continue;
-                        if (!story.spinningTopEncounters.Contains(encounter)) story.spinningTopEncounters.Add(encounter);
-                        lobby.owner.InvokeOnceRPC(StoryRPCs.AddSpinningTopEncounter, encounter);
+                        foreach (int encounter in localEncounters)
+                        {
+                            if (spinningTopEncounters.Contains(encounter)) continue;
+                            if (!story.spinningTopEncounters.Contains(encounter)) story.spinningTopEncounters.Add(encounter);
+                            lobby.owner.InvokeOnceRPC(StoryRPCs.AddSpinningTopEncounter, story.campaignGeneration, encounter);
+                        }
                     }
 
                     storySession.saveState.deathPersistentSaveData.reinforcedKarma = reinforcedKarma;

--- a/Story/StoryOnlineMenu.cs
+++ b/Story/StoryOnlineMenu.cs
@@ -272,6 +272,13 @@ namespace RainMeadow
             {
                 manager.rainWorld.progression.WipeSaveState(storyGameMode.currentCampaign);
                 manager.menuSetup.startGameCondition = ProcessManager.MenuSetup.StoryGameInitCondition.New;
+
+                if (OnlineManager.lobby.isOwner)
+                {
+                    storyGameMode.campaignGeneration++;
+                    storyGameMode.spinningTopEncounters.Clear();
+                    storyGameMode.hostRippleRaiser.Clear();
+                }
             }
 
             else

--- a/Story/StoryRPCs.cs
+++ b/Story/StoryRPCs.cs
@@ -188,8 +188,7 @@ namespace RainMeadow
             game.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.Credits);
         }
 
-        // Host accepts the first (min,max) report for a given echo id
-        public static void DetermineRippleRaise(StoryGameMode story, int spinningTopID, UnityEngine.Vector2 vector)
+        public static void DetermineRippleRaise(StoryGameMode story, int spinningTopID, UnityEngine.Vector2 vector, bool trustVector)
         {
             if (spinningTopID != -1)
             {
@@ -198,6 +197,24 @@ namespace RainMeadow
                     RainMeadow.Debug($"discarding duplicate raise report for echo {spinningTopID} (reported {vector.y}, authoritative {authoritative.y})");
                     return;
                 }
+
+                if (!trustVector)
+                {
+                    if (RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame hostGame
+                        && hostGame.session is StoryGameSession
+                        && hostGame.cameras != null && hostGame.cameras.Length > 0 && hostGame.cameras[0].room != null)
+                    {
+                        vector = Watcher.SpinningTop.NextMinMaxRippleLevel(hostGame.cameras[0].room);
+                    }
+                    else
+                    {
+                        var oneStep = OneStepFromCurrent(story.minimumRippleLevel, story.maximumRippleLevel, story.rippleLevel);
+                        vector = new UnityEngine.Vector2(
+                            UnityEngine.Mathf.Min(vector.x, oneStep.x),
+                            UnityEngine.Mathf.Min(vector.y, oneStep.y));
+                    }
+                }
+
                 story.hostRippleRaiser[spinningTopID] = vector;
                 StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
             }
@@ -208,21 +225,39 @@ namespace RainMeadow
 
             story.minimumRippleLevel = UnityEngine.Mathf.Max(story.minimumRippleLevel, vector.x);
             story.maximumRippleLevel = UnityEngine.Mathf.Max(story.maximumRippleLevel, vector.y);
-            story.rippleLevel = UnityEngine.Mathf.Max(story.rippleLevel, vector.y); 
+            story.rippleLevel = UnityEngine.Mathf.Max(story.rippleLevel, vector.y);
 
             if (RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession storyGameSession)
             {
                 ApplyRippleLevelToSaveState(storyGameSession, vector);
             }
+
+            foreach (OnlinePlayer player in OnlineManager.players)
+            {
+                if (!player.isMe) player.InvokeOnceRPC(PlayRaiseRippleLevelAnimation, spinningTopID, vector);
+            }
         }
 
-        // Client -> host: Send to ripple raise request for determination
-       // Helps prevent race condition
-        [RPCMethod]
-        public static void RaiseRippleLevelRequest(int spinningTopID, UnityEngine.Vector2 vector)
+        private static UnityEngine.Vector2 OneStepFromCurrent(float min, float max, float ripple)
         {
+            if (max == 0f) return new UnityEngine.Vector2(0.25f, 0.25f);
+            if (ripple == 0.25f) return new UnityEngine.Vector2(0.5f, 0.5f);
+            if (ripple == 0.5f) return new UnityEngine.Vector2(1f, 1f);
+            float newMax = UnityEngine.Mathf.Min(5f, max + 0.5f);
+            float newMin = max >= 5f ? UnityEngine.Mathf.Min(5f, min + 0.5f) : UnityEngine.Mathf.Max(1f, newMax - 2f);
+            return new UnityEngine.Vector2(newMin, newMax);
+        }
+
+        [RPCMethod]
+        public static void RaiseRippleLevelRequest(RPCEvent rpc, int spinningTopID, UnityEngine.Vector2 vector)
+        {
+            if (!OnlineManager.lobby.isOwner) return;
+            if (rpc != null && rpc.from == null) return;
             if (!RainMeadow.isStoryMode(out var story)) return;
-            DetermineRippleRaise(story, spinningTopID, vector);
+            vector = new UnityEngine.Vector2(
+                UnityEngine.Mathf.Clamp(vector.x, 0f, 5f),
+                UnityEngine.Mathf.Clamp(vector.y, 0f, 5f));
+            DetermineRippleRaise(story, spinningTopID, vector, trustVector: false);
         }
 
         [RPCMethod]
@@ -231,23 +266,14 @@ namespace RainMeadow
             if (RainMeadow.isStoryMode(out var story) && spinningTopID != -1)
                 StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
 
-            // apply the data even mid-transition, only the HUD part needs a live game.
-            if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession storyGameSession)) return;
-            ApplyRippleLevelToSaveState(storyGameSession, vector);
-
-            if (RainMeadow.isStoryMode(out var story2) && OnlineManager.lobby.isOwner)
-            {
-                story2.rippleLevel = UnityEngine.Mathf.Max(story2.rippleLevel, vector.y);
-                story2.minimumRippleLevel = UnityEngine.Mathf.Max(story2.minimumRippleLevel, vector.x);
-                story2.maximumRippleLevel = UnityEngine.Mathf.Max(story2.maximumRippleLevel, vector.y);
-            }
+            if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession)) return;
 
             var karmaMeter = game.cameras?.FirstOrDefault()?.hud?.karmaMeter;
-            if (karmaMeter == null) return; // no hud yet (loading / mid warp), the data above still landed
+            if (karmaMeter == null) return; // no hud yet (loading / mid warp)
             karmaMeter.UpdateGraphic();
             karmaMeter.forceVisibleCounter = 120; //it's max for a reason(?)
         }
-        private static void ApplyRippleLevelToSaveState(StoryGameSession storyGameSession, UnityEngine.Vector2 vector)
+        internal static void ApplyRippleLevelToSaveState(StoryGameSession storyGameSession, UnityEngine.Vector2 vector)
         {
             var deathPersistentSaveData = storyGameSession.saveState.deathPersistentSaveData;
             deathPersistentSaveData.minimumRippleLevel = UnityEngine.Mathf.Max(deathPersistentSaveData.minimumRippleLevel, vector.x);

--- a/Story/StoryRPCs.cs
+++ b/Story/StoryRPCs.cs
@@ -188,20 +188,27 @@ namespace RainMeadow
             game.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.Credits);
         }
 
-        // Raises ripple level, usually client also tells
-        [RPCMethod]
-        public static void RaiseRippleLevel(UnityEngine.Vector2 vector)
+        // Host accepts the first (min,max) report for a given echo id
+        public static void DetermineRippleRaise(StoryGameMode story, int spinningTopID, UnityEngine.Vector2 vector)
         {
+            if (spinningTopID != -1)
+            {
+                if (story.hostRippleRaiser.TryGetValue(spinningTopID, out var authoritative))
+                {
+                    RainMeadow.Debug($"discarding duplicate raise report for echo {spinningTopID} (reported {vector.y}, authoritative {authoritative.y})");
+                    return;
+                }
+                story.hostRippleRaiser[spinningTopID] = vector;
+                StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
+            }
 
-            if (!RainMeadow.isStoryMode(out var story)) return;
-            if (story.rippleLevel >= vector.y) return;
+            if (story.maximumRippleLevel >= vector.y) return; // max vs max
 
-            RainMeadow.Debug($"Raising Ripple Level from: {story.rippleLevel} to {vector.y}");
+            RainMeadow.Debug($"Raising Ripple Level from: {story.maximumRippleLevel} to {vector.y} (echo {spinningTopID})");
 
-
-            story.rippleLevel = vector.y;
             story.minimumRippleLevel = UnityEngine.Mathf.Max(story.minimumRippleLevel, vector.x);
             story.maximumRippleLevel = UnityEngine.Mathf.Max(story.maximumRippleLevel, vector.y);
+            story.rippleLevel = UnityEngine.Mathf.Max(story.rippleLevel, vector.y); 
 
             if (RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession storyGameSession)
             {
@@ -209,18 +216,30 @@ namespace RainMeadow
             }
         }
 
+        // Client -> host: Send to ripple raise request for determination
+       // Helps prevent race condition
         [RPCMethod]
-        public static void PlayRaiseRippleLevelAnimation(UnityEngine.Vector2 vector)
+        public static void RaiseRippleLevelRequest(int spinningTopID, UnityEngine.Vector2 vector)
         {
+            if (!RainMeadow.isStoryMode(out var story)) return;
+            DetermineRippleRaise(story, spinningTopID, vector);
+        }
+
+        [RPCMethod]
+        public static void PlayRaiseRippleLevelAnimation(int spinningTopID, UnityEngine.Vector2 vector)
+        {
+            if (RainMeadow.isStoryMode(out var story) && spinningTopID != -1)
+                StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
+
             // apply the data even mid-transition, only the HUD part needs a live game.
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession storyGameSession)) return;
             ApplyRippleLevelToSaveState(storyGameSession, vector);
 
-            if (RainMeadow.isStoryMode(out var story) && OnlineManager.lobby.isOwner)
+            if (RainMeadow.isStoryMode(out var story2) && OnlineManager.lobby.isOwner)
             {
-                story.rippleLevel = UnityEngine.Mathf.Max(story.rippleLevel, vector.y);
-                story.minimumRippleLevel = UnityEngine.Mathf.Max(story.minimumRippleLevel, vector.x);
-                story.maximumRippleLevel = UnityEngine.Mathf.Max(story.maximumRippleLevel, vector.y);
+                story2.rippleLevel = UnityEngine.Mathf.Max(story2.rippleLevel, vector.y);
+                story2.minimumRippleLevel = UnityEngine.Mathf.Max(story2.minimumRippleLevel, vector.x);
+                story2.maximumRippleLevel = UnityEngine.Mathf.Max(story2.maximumRippleLevel, vector.y);
             }
 
             var karmaMeter = game.cameras?.FirstOrDefault()?.hud?.karmaMeter;

--- a/Story/StoryRPCs.cs
+++ b/Story/StoryRPCs.cs
@@ -192,7 +192,7 @@ namespace RainMeadow
         {
             if (spinningTopID != -1)
             {
-                if (story.hostRippleRaiser.TryGetValue(spinningTopID, out var authoritative))
+                if (story.hostRippleRaiser.TryGetValue(spinningTopID, out UnityEngine.Vector2 authoritative))
                 {
                     RainMeadow.Debug($"discarding duplicate raise report for echo {spinningTopID} (reported {vector.y}, authoritative {authoritative.y})");
                     return;
@@ -208,7 +208,7 @@ namespace RainMeadow
                     }
                     else
                     {
-                        var oneStep = OneStepFromCurrent(story.minimumRippleLevel, story.maximumRippleLevel, story.rippleLevel);
+                        UnityEngine.Vector2 oneStep = OneStepFromCurrent(story.minimumRippleLevel, story.maximumRippleLevel, story.rippleLevel);
                         vector = new UnityEngine.Vector2(
                             UnityEngine.Mathf.Min(vector.x, oneStep.x),
                             UnityEngine.Mathf.Min(vector.y, oneStep.y));
@@ -252,8 +252,7 @@ namespace RainMeadow
         public static void RaiseRippleLevelRequest(RPCEvent rpc, int spinningTopID, UnityEngine.Vector2 vector)
         {
             if (!OnlineManager.lobby.isOwner) return;
-            if (rpc != null && rpc.from == null) return;
-            if (!RainMeadow.isStoryMode(out var story)) return;
+            if (!RainMeadow.isStoryMode(out StoryGameMode story)) return;
             vector = new UnityEngine.Vector2(
                 UnityEngine.Mathf.Clamp(vector.x, 0f, 5f),
                 UnityEngine.Mathf.Clamp(vector.y, 0f, 5f));
@@ -263,7 +262,7 @@ namespace RainMeadow
         [RPCMethod]
         public static void PlayRaiseRippleLevelAnimation(int spinningTopID, UnityEngine.Vector2 vector)
         {
-            if (RainMeadow.isStoryMode(out var story) && spinningTopID != -1)
+            if (RainMeadow.isStoryMode(out StoryGameMode story) && spinningTopID != -1)
                 StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
 
             if (!(RWCustom.Custom.rainWorld.processManager.currentMainLoop is RainWorldGame game && game.session is StoryGameSession)) return;

--- a/Story/StoryRPCs.cs
+++ b/Story/StoryRPCs.cs
@@ -281,9 +281,14 @@ namespace RainMeadow
         }
 
         [RPCMethod]
-        public static void AddSpinningTopEncounter(int spinningTopID)
+        public static void AddSpinningTopEncounter(uint generation, int spinningTopID)
         {
             if (!RainMeadow.isStoryMode(out var story)) return;
+            if (generation != story.campaignGeneration)
+            {
+                RainMeadow.Debug($"dropping spinning top encounter {spinningTopID} from campaign generation {generation}, current is {story.campaignGeneration}");
+                return;
+            }
             StoryHelpers.RecordSpinningTopEncounter(story, spinningTopID);
         }
 


### PR DESCRIPTION
Introduced that one during my last attempted fix

Basically, we have to track the ripples we've met. But clients save file might be different and try to update ours. So we protect it by a campaign generation uint that increments each time we touch the save, that way clients aren't allowed to notify us until they've synced up with the standard save slot data. 

- [x] Test

