### PR TITLE
Fix story gate transition readiness and premature closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release 1.16.0
 
+## Story
+- Fixed gates starting region transitions before all players are ready and closing the middle door before all players have crossed
+
 ## Arena
 - Fixed infinite tinnitus again
 

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -2100,11 +2100,12 @@ namespace RainMeadow
                 {
                     if (isStoryMode(out var story))
                     {
-                        var wasReadyForTransition = story.storyClientData.readyForTransition;
+                        if (story.readyForTransition >= StoryGameMode.ReadyForTransition.Opening)
+                        {
+                            story.storyClientData.readyForTransition = true;
+                            return true;
+                        }
                         story.storyClientData.readyForTransition = false;
-                        return story.readyForTransition == StoryGameMode.ReadyForTransition.Opening
-                            || (story.readyForTransition == StoryGameMode.ReadyForTransition.Crossed && wasReadyForTransition);
-
                     }
                     return false;
                 });

--- a/Story/StoryHooks.cs
+++ b/Story/StoryHooks.cs
@@ -2100,8 +2100,10 @@ namespace RainMeadow
                 {
                     if (isStoryMode(out var story))
                     {
+                        var wasReadyForTransition = story.storyClientData.readyForTransition;
                         story.storyClientData.readyForTransition = false;
-                        return story.readyForTransition >= StoryGameMode.ReadyForTransition.Opening;
+                        return story.readyForTransition == StoryGameMode.ReadyForTransition.Opening
+                            || (story.readyForTransition == StoryGameMode.ReadyForTransition.Crossed && wasReadyForTransition);
 
                     }
                     return false;
@@ -2117,7 +2119,7 @@ namespace RainMeadow
                     if (isStoryMode(out var story))
                     {
                         story.storyClientData.readyForTransition = true;
-
+                        return false;
                     }
                     return true;
 


### PR DESCRIPTION
Story gates can initiate a region switch before the host approves the group, or close the middle door immediately after loading while players are still on the entrance side.

Return from the gate update after advertising local readiness until the shared transition state permits opening. Keep the local readiness flag set when beginning the transition so the host continues waiting for players to pass through. The existing AllPlayersThroughToOtherSide hook clears each flag when that player's local crossing check succeeds.

- A local harness applies the source IL hook to a reduced gate update and uses the source crossing hook and host completion block. It checks waiting for approval, keeping the middle open before crossing, waiting for the slower player, closing after both cross, delayed clients, and offline initiation.
- A two-player test with both players using the patched build reports successful crossing. The inspected client log contains two completed VS to SI world loads in separate attempts and later shelter discovery in SI, without the previous region-request failure loop.
- Host console and exception logs show VS and SI loading, with no gate exception recorded.